### PR TITLE
fix: JSON 매핑 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/balancetalk/module/file/domain/File.java
+++ b/src/main/java/balancetalk/module/file/domain/File.java
@@ -32,9 +32,8 @@ public class File {
     @Column(nullable = false, length = 50)
     private String uploadName; // 사용자가 업로드한 파일명
 
-    @NotBlank
     @Size(max = 50)
-    @Column(nullable = false, length = 50, unique = true)
+    @Column(length = 50, unique = true)
     private String storedName; // 서버 내부에서 관리하는 파일명
 
     @NotBlank

--- a/src/main/java/balancetalk/module/file/dto/FileDto.java
+++ b/src/main/java/balancetalk/module/file/dto/FileDto.java
@@ -8,17 +8,17 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class FileDto {
-    private String uploadName; // 사용자가 업로드한 파일명
-    private String path;
-    private FileType type;
-    private Long size; // 바이트 단위로 파일 크기 저장
+    private String imgName; // 사용자가 업로드한 파일명
+    private String imgPath;
+    private FileType imgType;
+    private Long imgSize; // 바이트 단위로 파일 크기 저장
 
     public File toEntity() {
-        return File.builder()
-                .uploadName(uploadName)
-                .path(path)
-                .type(type)
-                .size(size)
+        return balancetalk.module.file.domain.File.builder()
+                .uploadName(imgName)
+                .path(imgPath)
+                .type(imgType)
+                .size(imgSize)
                 .build();
     }
 }

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -1,8 +1,10 @@
 package balancetalk.module.post.application;
 
+import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostRepository;
 import balancetalk.module.post.dto.PostRequestDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,10 @@ public class PostService {
     @Transactional
     public void save(final PostRequestDto postRequestDto) {
         Post postEntity = postRequestDto.toEntity();
+        List<BalanceOption> options = postEntity.getOptions();
+        for (BalanceOption option : options) {
+            option.addPost(postEntity);
+        }
         postRepository.save(postEntity);
     }
 }

--- a/src/main/java/balancetalk/module/post/domain/BalanceOption.java
+++ b/src/main/java/balancetalk/module/post/domain/BalanceOption.java
@@ -2,6 +2,7 @@ package balancetalk.module.post.domain;
 
 import balancetalk.module.file.domain.File;
 import balancetalk.module.vote.domain.Vote;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -40,7 +41,7 @@ public class BalanceOption {
     @Column(nullable = false, length = 100)
     private String description;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "file_id")
     private File file;
 
@@ -56,5 +57,9 @@ public class BalanceOption {
         this.title = title;
         this.description = description;
         this.file = file;
+    }
+
+    public void addPost(Post post) {
+        this.post = post;
     }
 }

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -1,7 +1,6 @@
 package balancetalk.module.post.domain;
 
 import balancetalk.module.comment.domain.Comment;
-import balancetalk.module.post.dto.BalanceOptionDto;
 import balancetalk.module.report.domain.Report;
 import balancetalk.module.ViewStatus;
 import balancetalk.module.member.domain.Member;
@@ -55,7 +54,7 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<BalanceOption> options = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")

--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
@@ -1,5 +1,6 @@
 package balancetalk.module.post.dto;
 
+
 import balancetalk.module.file.dto.FileDto;
 import balancetalk.module.post.domain.BalanceOption;
 import lombok.*;
@@ -11,12 +12,13 @@ import lombok.*;
 public class BalanceOptionDto {
     private String title;
     private String description;
-    private FileDto fileDto;
+    private FileDto file;
+
     public BalanceOption toEntity() {
         return BalanceOption.builder()
                 .title(title)
                 .description(description)
-                .file(fileDto.toEntity())
+                .file(file.toEntity())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 저장 시 발생하는 JSON 매핑 오류 해결

## 💡 자세한 설명
게시글 저장 시 BalanceOptionDto의 필드명이 fileDto인 관계로 JSON 매핑 오류가 발생했습니다.
fileDto 필드명을 요청 json 메시지의 필드명과 동일하게 file로 수정하여 오류를 해결했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
