### PR TITLE
댓글 조회시 selectedOptionId 반환 기능 구현 완료

### DIFF
--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -93,7 +93,7 @@ public class CommentService {
 
     private BalanceOption validateBalanceOptionId(CommentCreateRequest request, Post post) {
         return post.getOptions().stream()
-                .filter(option -> option.getId().equals(request.getBalanceOptionId()))
+                .filter(option -> option.getId().equals(request.getSelectedOptionId()))
                 .findFirst()
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_BALANCE_OPTION));
     }

--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -38,9 +38,9 @@ public class CommentService {
     public CommentResponse createComment(CommentCreateRequest request, Long postId) {
         Member member = validateMemberId(request);
         Post post = validatePostId(postId);
-        validateBalanceOptionId(request, post);
+        BalanceOption balanceOption = validateBalanceOptionId(request, post);
 
-        Comment comment = request.toEntity(member, post);
+        Comment comment = request.toEntity(member, post, balanceOption);
         comment = commentRepository.save(comment);
         return CommentResponse.fromEntity(comment);
     }

--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -46,6 +46,8 @@ public class CommentService {
         Member member = validateMemberId(request);
         Post post = validatePostId(postId);
         BalanceOption balanceOption = validateBalanceOptionId(request, post);
+        voteRepository.findByMemberIdAndBalanceOption_PostId(request.getMemberId(), postId)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE));
 
         Comment comment = request.toEntity(member, post);
         return commentRepository.save(comment);
@@ -61,7 +63,8 @@ public class CommentService {
         for (Comment comment : comments) {
             Optional<Vote> voteForComment = voteRepository.findByMemberIdAndBalanceOption_PostId(comment.getMember().getId(), postId);
 
-            Long balanceOptionId = voteForComment.map(Vote::getBalanceOption).map(BalanceOption::getId).orElse(null);
+            Long balanceOptionId = voteForComment.map(Vote::getBalanceOption).map(BalanceOption::getId)
+                    .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_BALANCE_OPTION));
             CommentResponse response = CommentResponse.fromEntity(comment, balanceOptionId);
             responses.add(response);
         }

--- a/src/main/java/balancetalk/module/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/module/comment/domain/Comment.java
@@ -3,6 +3,7 @@ package balancetalk.module.comment.domain;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.module.ViewStatus;
 import balancetalk.module.member.domain.Member;
+import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.report.domain.Report;
 import jakarta.persistence.Column;
@@ -53,6 +54,10 @@ public class Comment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "balance_option_id")
+    private BalanceOption balanceOption;
 
     @OneToMany(mappedBy = "comment")
     private List<CommentLike> likes = new ArrayList<>();

--- a/src/main/java/balancetalk/module/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/module/comment/domain/Comment.java
@@ -55,10 +55,6 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "balance_option_id")
-    private BalanceOption balanceOption;
-
     @OneToMany(mappedBy = "comment")
     private List<CommentLike> likes = new ArrayList<>();
 

--- a/src/main/java/balancetalk/module/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentCreateRequest.java
@@ -3,6 +3,7 @@ package balancetalk.module.comment.dto;
 import balancetalk.module.ViewStatus;
 import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.member.domain.Member;
+import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,11 +15,12 @@ public class CommentCreateRequest {
     private Long memberId;
     private Long balanceOptionId;
 
-    public Comment toEntity(Member member, Post post) {
+    public Comment toEntity(Member member, Post post, BalanceOption balanceOption) {
         return Comment.builder()
                 .content(content)
                 .member(member)
                 .post(post)
+                .balanceOption(balanceOption)
                 .viewStatus(ViewStatus.NORMAL)
                 .build();
     }

--- a/src/main/java/balancetalk/module/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentCreateRequest.java
@@ -3,7 +3,6 @@ package balancetalk.module.comment.dto;
 import balancetalk.module.ViewStatus;
 import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.member.domain.Member;
-import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,12 +14,11 @@ public class CommentCreateRequest {
     private Long memberId;
     private Long balanceOptionId;
 
-    public Comment toEntity(Member member, Post post, BalanceOption balanceOption) {
+    public Comment toEntity(Member member, Post post) {
         return Comment.builder()
                 .content(content)
                 .member(member)
                 .post(post)
-                .balanceOption(balanceOption)
                 .viewStatus(ViewStatus.NORMAL)
                 .build();
     }

--- a/src/main/java/balancetalk/module/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentCreateRequest.java
@@ -12,7 +12,7 @@ import lombok.Data;
 public class CommentCreateRequest {
     private String content;
     private Long memberId;
-    private Long balanceOptionId;
+    private Long selectedOptionId;
 
     public Comment toEntity(Member member, Post post) {
         return Comment.builder()

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -19,13 +19,15 @@ public class CommentResponse {
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
 
-    public static CommentResponse fromEntity(Comment comment) {
+    public static CommentResponse fromEntity(Comment comment, Long balanceOptionId) {
+
+
         return CommentResponse.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
                 .memberName(comment.getMember().getNickname())
                 .postId(comment.getPost().getId())
-                .balanceOptionId(comment.getBalanceOption().getId())
+                .balanceOptionId(balanceOptionId)
                 // .likeCount(comment.getLikes().size()) //TODO: likeCount가 NULL이라 Response 어려움
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -14,7 +14,7 @@ public class CommentResponse {
     private String content;
     private String memberName;
     private Long postId;
-    private Long balanceOptionId;
+    private Long selectedOptionId;
     private int likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
@@ -27,7 +27,7 @@ public class CommentResponse {
                 .content(comment.getContent())
                 .memberName(comment.getMember().getNickname())
                 .postId(comment.getPost().getId())
-                .balanceOptionId(balanceOptionId)
+                .selectedOptionId(balanceOptionId)
                 // .likeCount(comment.getLikes().size()) //TODO: likeCount가 NULL이라 Response 어려움
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -14,7 +14,7 @@ public class CommentResponse {
     private String content;
     private String memberName;
     private Long postId;
-    // TODO : selectedOptionId 추가, 엔티티 연관 필요
+    private Long balanceOptionId;
     private int likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
@@ -25,6 +25,7 @@ public class CommentResponse {
                 .content(comment.getContent())
                 .memberName(comment.getMember().getNickname())
                 .postId(comment.getPost().getId())
+                .balanceOptionId(comment.getBalanceOption().getId())
                 // .likeCount(comment.getLikes().size()) //TODO: likeCount가 NULL이라 Response 어려움
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())

--- a/src/main/java/balancetalk/module/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/module/vote/domain/VoteRepository.java
@@ -2,5 +2,8 @@ package balancetalk.module.vote.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VoteRepository extends JpaRepository<Vote, Long> {
+    Optional<Vote> findByMemberIdAndBalanceOption_PostId(Long memberId, Long postId);
 }

--- a/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
+++ b/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
@@ -61,7 +61,7 @@ class CommentServiceTest {
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        CommentResponse response = commentService.createComment(request, postId);
+        Comment response = commentService.createComment(request, postId);
 
         // then
         assertThat(response.getContent()).isEqualTo(request.getContent());


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 조회시, 해당 되는 selectedOptionId 반환하도록 구현
- [x] 투표한 사람만 댓글 작성할 수 있도록 예외 처리 구현
## 💡 자세한 설명
 Comment<->BalanceOption 연관 관계를 맺어주지 않고, Vote를 활용해서 selectedOptionId를 반환하게 구현했습니다.
또한 투표한 사람만 댓글을 작성할 수 있도록 예외 처리를 구현했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #61
