### PR TITLE
파일 기능 단위 테스트 코드 작성

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(BAD_REQUEST, "파일 업로드에 실패했습니다."),
     FILE_DOWNLOAD_FAILED(BAD_REQUEST, "파일 다운로드에 실패했습니다."),
     FILE_SIZE_EXCEEDED(BAD_REQUEST, "파일 크기가 초과되었습니다."),
+    FILE_NAME_EXCEEDED(BAD_REQUEST, "파일 이름이 너무 깁니다."),
 
 
     // 401

--- a/src/main/java/balancetalk/global/exception/FileExceptionHandler.java
+++ b/src/main/java/balancetalk/global/exception/FileExceptionHandler.java
@@ -1,5 +1,6 @@
 package balancetalk.global.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +13,13 @@ public class FileExceptionHandler {
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.FILE_SIZE_EXCEEDED);
+        log.error("exception message = {}", e.getMessage());
+        return ResponseEntity.status(errorResponse.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.FILE_NAME_EXCEEDED);
         log.error("exception message = {}", e.getMessage());
         return ResponseEntity.status(errorResponse.getHttpStatus()).body(errorResponse);
     }

--- a/src/test/java/balancetalk/module/file/application/FileServiceTest.java
+++ b/src/test/java/balancetalk/module/file/application/FileServiceTest.java
@@ -1,0 +1,144 @@
+package balancetalk.module.file.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import balancetalk.global.config.FileConfig;
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.module.file.domain.File;
+import balancetalk.module.file.domain.FileRepository;
+import balancetalk.module.file.domain.FileType;
+import jakarta.servlet.ServletContext;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+    @InjectMocks
+    private FileService fileService;
+
+    @Mock
+    private FileRepository fileRepository;
+
+    @Mock
+    private FileConfig fileConfig;
+
+    @Mock
+    private ServletContext servletContext;
+
+
+    private Path tempDirectory;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // 임시 디렉토리 생성
+        tempDirectory = Files.createTempDirectory("testUploads");
+        servletContext = Mockito.mock(ServletContext.class);
+    }
+
+    @Test
+    @DisplayName("파일 업로드 성공")
+    void uploadFile_Success() {
+        // given
+        String originalFileName = "test.jpg";
+        MultipartFile multipartFile = new MockMultipartFile("file", originalFileName, "image/jpeg",
+                "test data".getBytes());
+        String uploadDir = "uploads/";
+        String storedFileName = "uuid_test.jpg";
+        String path = Paths.get(uploadDir, storedFileName).toString();
+
+        when(fileConfig.getLocation()).thenReturn(tempDirectory.toString());
+        when(fileRepository.save(any(File.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        File savedFile = fileService.uploadFile(multipartFile);
+
+        // then
+        assertThat(savedFile.getUploadName()).isEqualTo(originalFileName);
+        String expectedPath = tempDirectory.resolve(savedFile.getStoredName()).toString();
+        assertThat(savedFile.getPath()).isEqualTo(expectedPath);
+        assertThat(savedFile.getType()).isEqualTo(FileType.JPEG);
+    }
+
+    @Test
+    @DisplayName("파일 다운로드 성공")
+    void downloadFile_Success() throws Exception {
+        // given
+        Long fileId = 1L;
+        String fileName = "uuid_download.jpg";
+        Files.createFile(tempDirectory.resolve(fileName)); // 임시 파일 생성
+
+        File file = File.builder()
+                .id(fileId)
+                .uploadName("download.jpg")
+                .storedName(fileName)
+                .path(tempDirectory.resolve(fileName).toString())
+                .type(FileType.JPEG)
+                .size(1024L)
+                .build();
+
+        when(fileRepository.findById(fileId)).thenReturn(Optional.of(file));
+
+        // when
+        ResponseEntity<Resource> response = fileService.downloadFile(fileId);
+
+        // then
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getHeaders().getContentDisposition().toString()).contains(file.getUploadName());
+    }
+
+    @Test
+    @DisplayName("파일 업로드 실패 - 지원되지 않는 파일 타입")
+    void uploadFile_Failure_UnsupportedFileType() {
+        // given
+        MultipartFile multipartFile = new MockMultipartFile("file", "test.unsupported", "application/unsupported", "data".getBytes());
+
+        // when & then
+        when(fileConfig.getLocation()).thenReturn(tempDirectory.toString());
+
+        assertThatThrownBy(() -> fileService.uploadFile(multipartFile))
+                .isInstanceOf(BalanceTalkException.class)
+                .hasMessageContaining("지원하지 않는 파일 형식입니다.");
+    }
+
+    @Test
+    @DisplayName("파일 다운로드 실패 - 파일을 찾을 수 없음")
+    void downloadFile_Failure_FileNotFound() {
+        // given
+        Long fileId = 999L; // 존재하지 않는 파일 ID 가정
+
+        when(fileRepository.findById(fileId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> fileService.downloadFile(fileId))
+                .isInstanceOf(BalanceTalkException.class)
+                .hasMessageContaining("존재하지 않는 파일입니다.");
+    }
+
+    @Test
+    @DisplayName("파일 다운로드 실패 - 디렉토리를 찾을 수 없음")
+    void downloadFile_Failure_DirectoryNotFound() throws Exception {
+        // Resource 객체는 실제 경로에 대한 검증을 할 수 없으므로, 이 부분을 모킹하는 것은 제한적입니다.
+        // 이 경우, 예외를 발생시키기 위해 파일 시스템 상의 실제 상황을 조작하기보다는,
+        // 실제 운영 환경에서의 로그와 모니터링을 통해 검증하는 것이 적절하다고 판단됩니다.
+    }
+}

--- a/src/test/java/balancetalk/module/file/presentation/FileControllerTest.java
+++ b/src/test/java/balancetalk/module/file/presentation/FileControllerTest.java
@@ -1,0 +1,64 @@
+package balancetalk.module.file.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import balancetalk.module.file.application.FileService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class FileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FileService fileService;
+
+    @Test
+    @DisplayName("파일 업로드 실패 - 용량 초과")
+    void uploadFile_Failure_SizeExceeded() throws Exception {
+        // 사이즈 제한 초과 파일 생성
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                new byte[200 * 1024 * 1024]// 200MB 파일
+        );
+
+        // 파일 업로드 요청 시뮬레이션
+        mockMvc.perform(multipart("/files/upload")
+                        .file(file)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("파일 업로드 실패 - 파일 이름 길이 초과")
+    void uploadFile_Failure_FileNameLengthExceeded() throws Exception {
+        // 파일 이름 길이 제한 초과를 시뮬레이션하기 위한 긴 파일 이름
+        String longFileName = "this_is_a_very_long_file_name_that_exceeds_the_maximum_allowed_length_of_fifty_characters.jpg";
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                longFileName,
+                MediaType.IMAGE_JPEG_VALUE,
+                "Hello, World!".getBytes()
+        );
+
+        // 파일 이름 길이 제한을 초과할 경우 예외를 던지도록 설정
+        // 파일 업로드 요청 시뮬레이션
+        mockMvc.perform(multipart("/files/upload").file(file))
+                .andExpect(status().isBadRequest()); // 예외 발생 시 BadRequest (400) 상태 코드를 반환하도록 예상
+    }
+}

--- a/src/test/java/balancetalk/module/file/presentation/FileControllerTest.java
+++ b/src/test/java/balancetalk/module/file/presentation/FileControllerTest.java
@@ -56,7 +56,6 @@ public class FileControllerTest {
                 "Hello, World!".getBytes()
         );
 
-        // 파일 이름 길이 제한을 초과할 경우 예외를 던지도록 설정
         // 파일 업로드 요청 시뮬레이션
         mockMvc.perform(multipart("/files/upload").file(file))
                 .andExpect(status().isBadRequest()); // 예외 발생 시 BadRequest (400) 상태 코드를 반환하도록 예상


### PR DESCRIPTION
## 💡 작업 내용
- [x] 파일 업로드 단위 테스트 코드 작성 및 통과
- [x] 파일 다운로드 단위 테스트 코드 작성 및 통과
- [x] 파일 업로드 시 호환하지 않는 파일 확장자일 경우 단위 테스트 코드 작성 및 통과
- [x] 파일 다운로드시 resource가 존재하지 않거나 읽을 수 없는 경우 단위 테스트 코드 작성 및 통과
- [ ] 파일 업로드 시 용량 초과일 경우 단위 테스트 코드 작성 및 통과
- [ ] 파일 업로드 시 파일 이름 길이 초과일 경우 단위 테스트 코드 작성 및 통과


## 💡 자세한 설명
다른 테스트 코드는 통과했는데, 파일 업로드 시 **파일 용량 초과 예외, 파일 업로드 시 파일 이름 길이 초과 예외**의 경우 테스트를 실패하고 있습니다.

이 두 예외는 따로 정의한 게 아닌, SpringMVC 자체에서 발생시키는 예외를 핸들링하게 했는데요,
놀랍게도 서버를 돌리면서 실제로 Postman으로 요청을 보내면 정상적으로 에러 메시지를 띄우는데, 테스트코드에서는 파일 업로드 제약 조건을 무시하고 업로드 되어 버립니다...
뭐가 문제인지 도저히 모르겠어서 이렇게 남깁니다..
<img width="1018" alt="스크린샷 2024-02-26 오전 1 57 24" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/dbf6a552-46f7-43f2-aa1b-d49a1cbd9550">


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
`FileControllerTest` 에서, 두 테스트 메서드가 제약 조건을 무시하고 업로드에 성공해버리는 이유는 대체 뭘까요..?
## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #113 
