### PR TITLE
답글 작성 기능 구현 완료

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     NOT_FOUND_DIRECTORY(NOT_FOUND, "존재하지 않는 디렉토리입니다."),
     NOT_SUPPORTED_FILE_TYPE(NOT_FOUND, "지원하지 않는 파일 형식입니다."),
     NOT_FOUND_FILE(NOT_FOUND, "존재하지 않는 파일입니다."),
+    NOT_FOUND_PARENT_COMMENT(NOT_FOUND, "존재하지 않는 원 댓글입니다."),
 
     // 409
     ALREADY_VOTE(CONFLICT, "투표는 한 번만 가능합니다."),

--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -14,17 +14,15 @@ import balancetalk.module.member.domain.MemberRepository;
 import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostRepository;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import balancetalk.module.vote.domain.Vote;
 import balancetalk.module.vote.domain.VoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static balancetalk.global.exception.ErrorCode.*;
 

--- a/src/main/java/balancetalk/module/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/module/comment/domain/Comment.java
@@ -55,6 +55,10 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
     @OneToMany(mappedBy = "comment")
     private List<CommentLike> likes = new ArrayList<>();
 

--- a/src/main/java/balancetalk/module/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/module/comment/domain/Comment.java
@@ -3,29 +3,16 @@ package balancetalk.module.comment.domain;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.module.ViewStatus;
 import balancetalk.module.member.domain.Member;
-import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.report.domain.Report;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Builder

--- a/src/main/java/balancetalk/module/comment/dto/ReplyCreateRequest.java
+++ b/src/main/java/balancetalk/module/comment/dto/ReplyCreateRequest.java
@@ -1,0 +1,33 @@
+package balancetalk.module.comment.dto;
+
+import balancetalk.module.ViewStatus;
+import balancetalk.module.comment.domain.Comment;
+import balancetalk.module.member.domain.Member;
+import balancetalk.module.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ReplyCreateRequest {
+
+    @Schema(description = "답글 내용", example = "답글 내용...")
+    private String content;
+
+    @Schema(description = "회원 id", example = "1")
+    private Long memberId;
+
+    @Schema(description = "댓글 id", example = "1")
+    private Long commentId;
+
+    public Comment toEntity(Member member, Post post, Comment parentComment) {
+        return Comment.builder()
+                .content(content)
+                .member(member)
+                .parent(parentComment)
+                .post(post)
+                .viewStatus(ViewStatus.NORMAL)
+                .build();
+    }
+}

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -1,11 +1,8 @@
 package balancetalk.module.comment.presentation;
 
 import balancetalk.module.comment.application.CommentService;
-import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.comment.dto.CommentCreateRequest;
 import balancetalk.module.comment.dto.CommentResponse;
-import java.util.List;
-
 import balancetalk.module.comment.dto.ReplyCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @Tag(name = "comment", description = "댓글 API")

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -1,10 +1,12 @@
 package balancetalk.module.comment.presentation;
 
 import balancetalk.module.comment.application.CommentService;
+import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.comment.dto.CommentCreateRequest;
 import balancetalk.module.comment.dto.CommentResponse;
 import java.util.List;
 
+import balancetalk.module.comment.dto.ReplyCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +51,14 @@ public class CommentController {
     public String deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);
         return "댓글이 정상적으로 삭제되었습니다.";
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/{commentId}/replies")
+    @Operation(summary = "답글 작성", description = "comment-id에 해당하는 댓글에 답글을 작성한다.")
+    public String createComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody ReplyCreateRequest request) {
+        commentService.createReply(postId, commentId, request);
+        return "답글이 정상적으로 작성되었습니다.";
     }
 
     @PostMapping("/{commentId}/likes")


### PR DESCRIPTION
## 💡 작업 내용
- [x] `Comment` 엔티티에 답글 관계 구현 위한 `parent` 필드 구현
- [x] `ReplyCreateRequest` 구현
- [x] 답글 기능 구현 
- [x] 예외 처리 구현
- - [x] 해당 게시글이 존재하지 않는 경우 예외 처리
- - [x] 해당 원 댓글(부모 댓글)이 존재하지 않는 경우 예외 처리
- - [x] 해당 해왼이 존재하지 않는 경우 예외 처리

## 💡 자세한 설명
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/1cf6698e-3240-44f1-8f30-47564529b773)
Comment 엔티티에 답글 관계를 구현하기 위한 parent 필드를 구현했습니다.
Comment 엔티티를 수정하지 않고 구현할 방법을 생각해봤으나, 추가적인 테이블을 만드는 것 보다는
이 방식이 추가적인 조회 API를 만들지 않아도 되기에 위와 같은 방식으로 구현했습니다.

 
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/17b93ebf-13a3-41ca-b2a9-2e33964d9fce)
노션 API 명세서에는 memberId 는 포함되어 있지 않으나, 프론트쪽에서 필요하다고 생각되어서 Request DTO에 추가했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
1. 불필요한 구현이 있다면 확인해 주시면 감사하겠습니다!
2. Comment 엔티티를 수정하지 않으면서도 더 효율적인 구현 방식이 있었을까요?
3. 빼먹은 예외가 있다면 알려주세요!

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #122 
