### PR TITLE
게시글 단건, 전체 조회 API 응답에 누락된 필드 추가 

### DIFF
--- a/src/main/java/balancetalk/module/member/domain/Member.java
+++ b/src/main/java/balancetalk/module/member/domain/Member.java
@@ -144,4 +144,9 @@ public class Member extends BaseTimeEntity implements UserDetails {
         return bookmarks.stream()
                 .anyMatch(bookmark -> bookmark.getPost().equals(post));
     }
+
+    public boolean hasLiked(Post post) {
+        return postLikes.stream()
+                .anyMatch(like -> like.getPost().equals(post));
+    }
 }

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
             postTag.addPost(post);
         }
 
-        return PostResponseDto.fromEntity(postRepository.save(post));
+        return PostResponseDto.fromEntity(postRepository.save(post), member);
     }
 
     private Member getMember(PostRequestDto postRequestDto) {
@@ -65,11 +65,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponseDto> findAll() {
+    public List<PostResponseDto> findAll(Long memberId) {
         // TODO: 검색, 정렬, 마감 기능 추가
         List<Post> posts = postRepository.findAll();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
         return posts.stream()
-                .map(PostResponseDto::fromEntity)
+                .map(post -> PostResponseDto.fromEntity(post, member))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -74,10 +74,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostResponseDto findById(Long postId) {
+    public PostResponseDto findById(Long postId, Long memberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_POST));
-        return PostResponseDto.fromEntity(post);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
+        return PostResponseDto.fromEntity(post, member);
     }
 
     public void deleteById(Long postId) {

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -79,6 +79,9 @@ public class Post extends BaseTimeEntity {
     }
 
     public long likesCount() {
+        if (likes == null) {
+            return 0;
+        }
         return likes.size();
     }
     

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -77,6 +77,10 @@ public class Post extends BaseTimeEntity {
     public boolean isCasual() {
         return this.category == PostCategory.CASUAL;
     }
+
+    public long likesCount() {
+        return likes.size();
+    }
     
     @PrePersist
     public void init() {

--- a/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
@@ -35,7 +35,13 @@ public class PostResponseDto {
 
     private List<PostTagDto> postTags;
 
-    // todo: likeCount, createdBy, ProfilePhoto 추가
+    @Schema(description = "게시글 작성일", example = "2022-02-12")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "게시글 작성자", example = "작성자 닉네임")
+    private String createdBy;
+
+    // todo: ProfilePhoto 추가
     public static PostResponseDto fromEntity(Post post) {
         return PostResponseDto.builder()
                 .id(post.getId())
@@ -46,6 +52,8 @@ public class PostResponseDto {
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
+                .createdAt(post.getCreatedAt())
+                .createdBy(post.getMember().getNickname())
                 .build();
     }
 

--- a/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
@@ -22,8 +22,11 @@ public class PostResponseDto {
     @Schema(description = "투료 종료 기한", example = "2024-03-16 08:27:17.391706\t")
     private LocalDateTime deadline;
 
-    @Schema(description = "게시글 조회 수", example = "126")
-    private Long views;
+    @Schema(description = "게시글 조회수", example = "126")
+    private long views;
+
+    @Schema(description = "게시글 추천수", example = "15")
+    private long likesCount;
 
     @Schema(description = "게시글 카테고리", example = "CASUAL")
     private PostCategory category;
@@ -39,6 +42,7 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .deadline(post.getDeadline())
                 .views(post.getViews())
+                .likesCount(post.likesCount())
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))

--- a/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
@@ -65,7 +65,7 @@ public class PostResponseDto {
                 .createdBy(post.getMember().getNickname())
                 .build();
     }
-    
+
     private static List<PostTagDto> getPostTags(Post post) {
         return post.getPostTags().stream()
                 .map(PostTagDto::fromEntity)

--- a/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponseDto.java
@@ -1,5 +1,6 @@
 package balancetalk.module.post.dto;
 
+import balancetalk.module.member.domain.Member;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -28,6 +29,12 @@ public class PostResponseDto {
     @Schema(description = "게시글 추천수", example = "15")
     private long likesCount;
 
+    @Schema(description = "추천 여부", example = "true")
+    private boolean myLike;
+
+    @Schema(description = "북마크 여부", example = "false")
+    private boolean myBookmark;
+
     @Schema(description = "게시글 카테고리", example = "CASUAL")
     private PostCategory category;
 
@@ -42,13 +49,15 @@ public class PostResponseDto {
     private String createdBy;
 
     // todo: ProfilePhoto 추가
-    public static PostResponseDto fromEntity(Post post) {
+    public static PostResponseDto fromEntity(Post post, Member member) {
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .deadline(post.getDeadline())
                 .views(post.getViews())
                 .likesCount(post.likesCount())
+                .myLike(member.hasLiked(post))
+                .myBookmark(member.hasBookmarked(post))
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
@@ -56,7 +65,7 @@ public class PostResponseDto {
                 .createdBy(post.getMember().getNickname())
                 .build();
     }
-
+    
     private static List<PostTagDto> getPostTags(Post post) {
         return post.getPostTags().stream()
                 .map(PostTagDto::fromEntity)

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -29,15 +29,17 @@ public class PostController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     @Operation(summary = "모든 게시글 조회", description = "해당 회원이 쓴 모든 글을 조회한다.")
-    public List<PostResponseDto> findAllPost() {
-        return postService.findAll();
+    public List<PostResponseDto> findAllPost(@RequestParam("member-id") Long memberId) {
+        return postService.findAll(memberId);
     }
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "post-id에 해당하는 게시글을 조회한다.")
-    public PostResponseDto findSinglePost(@PathVariable("postId") Long postId) {
-        return postService.findById(postId);
+    public PostResponseDto findSinglePost(@PathVariable("postId") Long postId,
+                                          @RequestParam("member-id") Long memberId) {
+
+        return postService.findById(postId, memberId);
     }
 
     @ResponseStatus(HttpStatus.CREATED)


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 작성자 추가
- [x] 게시글 작성일 추가
- [x] 좋아요 여부 추가
- [x] 북마크 여부 추가

## 💡 자세한 설명
API 명세서에는 존재하지만 실제 API 응답에는 누락된 필드를 추가했습니다.
회원 조회는 ID 조회로 임시 구현했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #119 
