### PR TITLE
로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ dependencies {
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    testImplementation 'junit:junit:4.13.1'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
 	// emailAuth

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
     AUTHENTICATION_ERROR(UNAUTHORIZED, "인증 오류가 발생했습니다."),
     BAD_CREDENTIAL_ERROR(UNAUTHORIZED, "로그인에 실패했습니다."),
+    UNAUTHORIZED_LOGOUT(UNAUTHORIZED, "로그아웃을 위해서는 인증이 필요합니다."),
   
     // 403
     FORBIDDEN_COMMENT_MODIFY(FORBIDDEN, "댓글 수정 권한이 없습니다."), // TODO : Spring Security 적용 후 적용 필요

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     FORBIDDEN_COMMENT_MODIFY(FORBIDDEN, "댓글 수정 권한이 없습니다."), // TODO : Spring Security 적용 후 적용 필요
     FORBIDDEN_COMMENT_DELETE(FORBIDDEN, "댓글 삭제 권한이 없습니다."), // TODO : SecurityContextHolder 사용 예정
     FORBIDDEN_MEMBER_DELETE(FORBIDDEN, "사용자 탈퇴 권한이 없습니다."),
+    NOT_AUTHENTICATED_POST_CREATION(FORBIDDEN, "로그아웃 한 사용자는 게시글을 작성할 수 없습니다"),
 
     // 404
     NOT_FOUND_POST(NOT_FOUND, "존재하지 않는 게시글입니다."),
@@ -50,9 +51,6 @@ public enum ErrorCode {
 
     // 500
     REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),
-
-
-    // 500
     DUPLICATE_EMAIL(INTERNAL_SERVER_ERROR, "이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요"),
     AUTHORIZATION_CODE_MISMATCH(INTERNAL_SERVER_ERROR, "인증 번호가 일치하지 않습니다.");
     private final HttpStatus httpStatus;

--- a/src/main/java/balancetalk/module/member/application/MemberService.java
+++ b/src/main/java/balancetalk/module/member/application/MemberService.java
@@ -111,9 +111,10 @@ public class MemberService {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (principal instanceof UserDetails) {
             String username = ((UserDetails) principal).getUsername();
-            log.info("Before logout={}" , redisService.getValues(username));
+            if (redisService.getValues(username) == null) {
+                throw new BalanceTalkException(ErrorCode.UNAUTHORIZED_LOGOUT);
+            }
             redisService.deleteValues(username);
-            log.info("After logout={}" , redisService.getValues(username));
         }
     }
 

--- a/src/main/java/balancetalk/module/member/application/MemberService.java
+++ b/src/main/java/balancetalk/module/member/application/MemberService.java
@@ -3,6 +3,7 @@ package balancetalk.module.member.application;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.jwt.JwtTokenProvider;
+import balancetalk.global.redis.application.RedisService;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.MemberRepository;
 import balancetalk.module.member.dto.*;
@@ -14,6 +15,8 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +32,7 @@ public class MemberService {
     private final AuthenticationManager authenticationManager;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RedisService redisService;
 
     @Transactional
     public Long join(final JoinDto joinDto) {
@@ -100,6 +104,17 @@ public class MemberService {
             throw new BalanceTalkException(ErrorCode.MISMATCHED_EMAIL_OR_PASSWORD);
         }
         memberRepository.deleteByEmail(member.getEmail());
+    }
+
+    @Transactional
+    public void logout(){
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof UserDetails) {
+            String username = ((UserDetails) principal).getUsername();
+            log.info("Before logout={}" , redisService.getValues(username));
+            redisService.deleteValues(username);
+            log.info("After logout={}" , redisService.getValues(username));
+        }
     }
 
     private Member extractMember(HttpServletRequest request) {

--- a/src/main/java/balancetalk/module/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/module/member/presentation/MemberController.java
@@ -21,6 +21,7 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
+
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/join")
     @Operation(summary = "회원 가입", description = "닉네임, 이메일, 비밀번호를 입력하여 회원 가입을 한다.")
@@ -72,5 +73,13 @@ public class MemberController {
     public String deleteMember(@Valid @RequestBody LoginDto loginDto, HttpServletRequest request) {
         memberService.delete(loginDto, request);
         return "회원 탈퇴가 정상적으로 처리되었습니다.";
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그인 된 회원을 로그 아웃한다.")
+    public String logout() {
+        memberService.logout();
+        return "로그아웃이 정상적으로 처리되었습니다.";
     }
 }

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -3,6 +3,7 @@ package balancetalk.module.post.application;
 import static balancetalk.global.exception.ErrorCode.*;
 
 import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.redis.application.RedisService;
 import balancetalk.module.file.domain.File;
 import balancetalk.module.file.domain.FileRepository;
 import balancetalk.module.member.domain.Member;
@@ -33,9 +34,13 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final PostLikeRepository postLikeRepository;
     private final FileRepository fileRepository;
+    private final RedisService redisService;
 
     public PostResponseDto save(final PostRequestDto postRequestDto) {
         Member member = getMember(postRequestDto);
+        if (redisService.getValues(member.getEmail()) == null) {
+            throw new BalanceTalkException(NOT_AUTHENTICATED_POST_CREATION);
+        }
         List<File> images = getImages(postRequestDto);
         Post post = postRequestDto.toEntity(member, images);
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 로그아웃 상태가 되었을 때 Redis에서 토큰을 삭제하는 기능 구현
- [x] 로그아웃 상태일 때 게시글을 작성하려고 하면 에러를 던지는 기능 추가
- [x] 로그인 상태가 아닌 사용자가 로그아웃을 시도할 떄 에러를 던지는 기능 추가

## 💡 자세한 설명
![스크린샷 2024-02-29 오후 7 26 11](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/82ef0784-9d03-4709-98d1-f99c76a17171)
로그아웃을 하면, 사용자 이메일 값에 value로 해당하는 토큰 값이 삭제됩니다. 

![스크린샷 2024-02-29 오후 7 27 41](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/4739446e-e754-4b82-958e-0150cd2be50d)

로그인 한 상태에서는 성공적으로 게시글이 작성되지만,

![스크린샷 2024-02-29 오후 7 27 10](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/45964822-8875-41b0-9b88-d3513dc9f5ef)

로그아웃을 한 상태라면 `(Redis에 저장된 value가 Null일 때)` 에러를 던지도록 구현했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
로그아웃을 하고, 다시 재 로그인을 할때 만료되지 않는 한 동일한 토큰 값이 다시 주어져야 하는데 매번 재발급을 하고 있어서 추후에 코드 수정이 필요합니다.


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #143 
