### PR TITLE
답글 depth를 1로 제한하는 기능 구현 완료

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     EXPIRED_JWT_TOKEN(BAD_REQUEST, "만료된 토큰 입니다."),
     INVALID_JWT_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "RefreshToken이 존재하지 않습니다."),
+    EXCEED_MAX_DEPTH(BAD_REQUEST, "답글에 답글을 달 수 없습니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),

--- a/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
+++ b/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
@@ -1,12 +1,5 @@
 package balancetalk.module.comment.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.module.comment.domain.Comment;
@@ -14,23 +7,34 @@ import balancetalk.module.comment.domain.CommentLikeRepository;
 import balancetalk.module.comment.domain.CommentRepository;
 import balancetalk.module.comment.dto.CommentCreateRequest;
 import balancetalk.module.comment.dto.CommentResponse;
+import balancetalk.module.comment.dto.ReplyCreateRequest;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.MemberRepository;
-
 import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostRepository;
 import balancetalk.module.vote.domain.Vote;
 import balancetalk.module.vote.domain.VoteRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.ProfileValueSourceConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -53,6 +57,11 @@ class CommentServiceTest {
     @Mock
     private VoteRepository voteRepository;
 
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(commentService, "maxDepth", 1);
+    }
     @Test
     @DisplayName("댓글 생성 성공")
     void createComment_Success() {
@@ -274,5 +283,72 @@ class CommentServiceTest {
         assertThatThrownBy(() -> commentService.likeComment(1L, comment.getId(), member.getId()))
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_LIKE_COMMENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("답글 생성 성공")
+    void createReply_Success() {
+        // given
+        Long postId = 1L;
+        Long commentId = 1L;
+        Long memberId = 1L;
+        ReplyCreateRequest request = new ReplyCreateRequest("답글 내용입니다.", memberId, commentId);
+
+        Member member = Member.builder().id(memberId).build();
+        Comment parentComment = Comment.builder().id(commentId).post(Post.builder().id(postId).build()).build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(parentComment));
+        when(postRepository.findById(postId)).thenReturn(Optional.of(parentComment.getPost()));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Comment response = commentService.createReply(postId, memberId, request);
+
+        // then
+        assertThat(response.getContent()).isEqualTo(request.getContent());
+        assertThat(response.getMember()).isEqualTo(member);
+        assertThat(response.getParent()).isEqualTo(parentComment);
+        verify(commentRepository).save(any(Comment.class));
+    }
+
+    @Test
+    @DisplayName("답글에 대한 답글 생성 시도 시 예외 발생")
+    void createReplyToReply_Failure_DepthLimitExceeded() {
+        // given
+        Long postId = 1L;
+        Long parentCommentId = 1L;
+        Long memberId = 1L;
+        ReplyCreateRequest request = new ReplyCreateRequest("답글의 답글 내용입니다.", memberId, parentCommentId);
+
+
+
+        Member member = Member.builder().id(memberId).build();
+        Post post = Post.builder().id(postId).build();
+        Comment parentComment = Comment.builder().id(parentCommentId).post(post).build();
+        Comment replyComment = Comment.builder().id(2L).parent(parentComment).post(post).build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(commentRepository.findById(parentCommentId)).thenReturn(Optional.of(replyComment)); // 주의: 여기서 parentCommentId로 replyComment를 반환
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+
+        // when & then
+        assertThatThrownBy(() -> commentService.createReply(postId, parentCommentId, request))
+                .isInstanceOf(BalanceTalkException.class)
+                .hasMessageContaining(ErrorCode.EXCEED_MAX_DEPTH.getMessage());
+    }
+    @Test
+    @DisplayName("잘못된 postId로 답글 생성 시도 시 예외 발생")
+    void createReplyWithWrongPostId_Failure() {
+        // given
+        Long wrongPostId = 2L;
+        Long memberId = 1L;
+        Long commentId = 1L;
+        ReplyCreateRequest request = new ReplyCreateRequest("답글 내용입니다.", memberId, commentId);
+
+        when(postRepository.findById(wrongPostId)).thenReturn(Optional.empty());
+
+        // when, then
+        assertThrows(BalanceTalkException.class, () -> commentService.createReply(wrongPostId, commentId, request));
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 답글 depth를 1로 제한
- [x] 예외 처리 구현
- [x] 테스트 코드 작성

## 💡 자세한 설명
- 답글 깊이 제한 로직 추가: `CommentService` 내 `createReply` 메서드에서 답글 생성 전, 답글의 깊이를 검증하는 `validateDepth` 메서드를 호출합니다. 이를 통해 답글의 깊이가 설정된 최대 깊이(`maxDepth`)를 초과하는 경우`BalanceTalkException` 을 발생시킵니다. 추후 답글에도 답글을 달 수 있게 하거나 웹 페이지에서 최대 depth 변경시, maxDepth 값만 바꿔 주면 답글에도 답글 작성이 가능합니다.

![depth2](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/3d8fd333-6c69-431b-aa86-2de89156704c)
![depth2-2](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/9414de7c-8dd9-4c38-abe4-b635ccb1db99)
위 사진은 application.yml의 depth를 2로 설정했을 때, 예외 처리 예시입니다.

- 테스트 코드 작성: `답글 생성 성공`, `답글에 대한 답글 생성 시도 시 예외 발생`, `잘못된 postId로 답글 생성 시도 시 예외 발생` 에 대한 테스트 코드를 작성하고 통과를 완료했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #139 
