### PR TITLE
댓글 기능 사용 시 해당 댓글이 URL의 게시글 id와 매칭 여부 검증 로직 추가 완료

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -33,8 +33,8 @@ public enum ErrorCode {
     UNAUTHORIZED_LOGOUT(UNAUTHORIZED, "로그아웃을 위해서는 인증이 필요합니다."),
 
     // 403
-    FORBIDDEN_COMMENT_MODIFY(FORBIDDEN, "해당 댓글은 수정 권한이 없습니다."), // TODO : Spring Security 적용 후 적용 필요
-    FORBIDDEN_COMMENT_DELETE(FORBIDDEN, "해당 댓글은 삭제 권한이 없습니다."), // TODO : SecurityContextHolder 사용 예정
+    FORBIDDEN_COMMENT_MODIFY(FORBIDDEN, "해당 댓글은 수정 권한이 없습니다."),
+    FORBIDDEN_COMMENT_DELETE(FORBIDDEN, "해당 댓글은 삭제 권한이 없습니다."),
     FORBIDDEN_MEMBER_DELETE(FORBIDDEN, "사용자 탈퇴 권한이 없습니다."),
     FORBIDDEN_BOOKMARK_DELETE(FORBIDDEN, "북마크 삭제 권한이 없습니다."),
     FORBIDDEN_POST_CREATE(FORBIDDEN, "글쓰기 권한이 없습니다."),
@@ -50,6 +50,7 @@ public enum ErrorCode {
     NOT_SUPPORTED_FILE_TYPE(NOT_FOUND, "지원하지 않는 파일 형식입니다."),
     NOT_FOUND_FILE(NOT_FOUND, "존재하지 않는 파일입니다."),
     NOT_FOUND_PARENT_COMMENT(NOT_FOUND, "존재하지 않는 원 댓글입니다."),
+    NOT_FOUND_COMMENT_AT_THAT_POST(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
 
     // 409
     ALREADY_VOTE(CONFLICT, "이미 투표한 게시글입니다."),

--- a/src/main/java/balancetalk/module/bookmark/application/BookmarkService.java
+++ b/src/main/java/balancetalk/module/bookmark/application/BookmarkService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static balancetalk.global.exception.ErrorCode.*;
+import static balancetalk.global.utils.SecurityUtils.getCurrentMember;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,7 @@ public class BookmarkService {
 
     @Transactional
     public Bookmark createBookmark(Long postId) {
-        Member member = getCurrentMember();
+        Member member = getCurrentMember(memberRepository);
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_POST));
         if (member.hasBookmarked(post)) {
@@ -45,7 +46,7 @@ public class BookmarkService {
 
     @Transactional(readOnly = true)
     public List<BookmarkResponse> findAllByMember() {
-        Member member = getCurrentMember();
+        Member member = getCurrentMember(memberRepository);
         List<Bookmark> bookmarks = bookmarkRepository.findByMember(member);
 
         return bookmarks.stream()
@@ -55,7 +56,7 @@ public class BookmarkService {
 
     @Transactional
     public void deleteByPostId(Long postId) {
-        Member member = getCurrentMember();
+        Member member = getCurrentMember(memberRepository);
         Bookmark bookmark = bookmarkRepository.findByMemberAndPostId(member, postId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_BOOKMARK));
 
@@ -64,13 +65,5 @@ public class BookmarkService {
         }
 
         bookmarkRepository.delete(bookmark);
-    }
-
-    private Member getCurrentMember() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String email = authentication.getName();
-
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/balancetalk/module/bookmark/application/BookmarkService.java
+++ b/src/main/java/balancetalk/module/bookmark/application/BookmarkService.java
@@ -9,8 +9,6 @@ import balancetalk.module.member.domain.MemberRepository;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -1,7 +1,5 @@
 package balancetalk.module.comment.application;
 
-import static balancetalk.global.exception.ErrorCode.*;
-
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.module.comment.domain.Comment;

--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -73,23 +73,33 @@ public class CommentService {
         return responses;
     }
 
-    public Comment updateComment(Long commentId, String content) {
+    public Comment updateComment(Long commentId, Long postId, String content) {
         Comment comment = validateCommentId(commentId);
+        validatePostId(postId);
 
         if (!getCurrentMember(memberRepository).equals(comment.getMember())) {
             throw new BalanceTalkException(FORBIDDEN_COMMENT_MODIFY);
+        }
+
+        if (!comment.getPost().getId().equals(postId)) {
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
         }
 
         comment.updateContent(content);
         return comment;
     }
 
-    public void deleteComment(Long commentId) {
-        validateCommentId(commentId);
+    public void deleteComment(Long commentId, Long postId) {
+        Comment comment = validateCommentId(commentId);
         Member commentMember = commentRepository.findById(commentId).get().getMember();
+        validatePostId(postId);
 
         if (!getCurrentMember(memberRepository).equals(commentMember)) {
             throw new BalanceTalkException(FORBIDDEN_COMMENT_DELETE);
+        }
+
+        if (!comment.getPost().getId().equals(postId)) {
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
         }
 
         commentRepository.deleteById(commentId);

--- a/src/main/java/balancetalk/module/comment/domain/CommentLike.java
+++ b/src/main/java/balancetalk/module/comment/domain/CommentLike.java
@@ -1,13 +1,7 @@
 package balancetalk.module.comment.domain;
 
 import balancetalk.module.member.domain.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/balancetalk/module/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/module/comment/domain/CommentRepository.java
@@ -1,7 +1,8 @@
 package balancetalk.module.comment.domain;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long postId);

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -1,11 +1,12 @@
 package balancetalk.module.comment.dto;
 
 import balancetalk.module.comment.domain.Comment;
-import java.time.LocalDateTime;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -37,16 +37,16 @@ public class CommentController {
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{commentId}")
     @Operation(summary = "댓글 수정", description = "comment-id에 해당하는 댓글 내용을 수정한다.")
-    public String updateComment(@PathVariable Long commentId, @RequestBody CommentRequest request) {
-        commentService.updateComment(commentId, request.getContent());
+    public String updateComment(@PathVariable Long commentId, @PathVariable Long postId, @RequestBody CommentRequest request) {
+        commentService.updateComment(commentId, postId, request.getContent());
         return "댓글이 정상적으로 수정되었습니다.";
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{commentId}")
     @Operation(summary = "댓글 삭제", description = "comment-id에 해당하는 댓글을 삭제한다.")
-    public String deleteComment(@PathVariable Long commentId) {
-        commentService.deleteComment(commentId);
+    public String deleteComment(@PathVariable Long commentId, @PathVariable Long postId) {
+        commentService.deleteComment(commentId, postId);
         return "댓글이 정상적으로 삭제되었습니다.";
     }
 

--- a/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
+++ b/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
@@ -136,6 +136,7 @@ class CommentServiceTest {
     void updateComment_Success() {
         // given
         Long commentId = 1L;
+        Long postId = 1L;
         String updatedContent = "업데이트된 댓글 내용";
         Member member = Member.builder().email(authenticatedEmail).votes(List.of()).build();
         Comment existingComment = Comment.builder().id(commentId).member(member).content("기존 댓글 내용").build();
@@ -144,7 +145,7 @@ class CommentServiceTest {
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(existingComment));
 
         // when
-        Comment updatedComment = commentService.updateComment(commentId, updatedContent);
+        Comment updatedComment = commentService.updateComment(commentId, postId, updatedContent);
 
         // then
         assertThat(updatedComment.getContent()).isEqualTo(updatedContent);
@@ -155,6 +156,7 @@ class CommentServiceTest {
     void deleteComment_Success() {
         // given
         Long commentId = 1L;
+        Long postId = 1L;
         Member member = Member.builder().email(authenticatedEmail).votes(List.of()).build();
         Comment existingComment = Comment.builder().id(commentId).member(member).content("기존 댓글 내용").build();
 
@@ -163,7 +165,7 @@ class CommentServiceTest {
         doNothing().when(commentRepository).deleteById(commentId);
 
         // when
-        commentService.deleteComment(commentId);
+        commentService.deleteComment(commentId, postId);
 
         // then
         verify(commentRepository).deleteById(commentId);
@@ -209,6 +211,7 @@ class CommentServiceTest {
     void updateComment_Fail_CommentNotFound() {
         // given
         Long commentId = 1L;
+        Long postId = 1L;
         String updatedContent = "업데이트된 댓글 내용";
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
@@ -216,7 +219,7 @@ class CommentServiceTest {
         // when
 
         // then
-        assertThatThrownBy(() -> commentService.updateComment(commentId, updatedContent))
+        assertThatThrownBy(() -> commentService.updateComment(commentId, postId, updatedContent))
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessageContaining("존재하지 않는 댓글입니다.");
     }
@@ -226,13 +229,14 @@ class CommentServiceTest {
     void deleteComment_Fail_CommentNotFound() {
         // given
         Long commentId = 1L;
+        Long postId = 1L;
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
 
         // when
 
         // then
-        assertThatThrownBy(() -> commentService.deleteComment(commentId))
+        assertThatThrownBy(() -> commentService.deleteComment(commentId, postId))
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessageContaining("존재하지 않는 댓글입니다.");
     }
@@ -297,6 +301,7 @@ class CommentServiceTest {
     void updateComment_Fail_ForbiddenModify() {
         // given
         Long commentId = 1L;
+        Long postId = 1L;
         String updatedContent = "업데이트된 댓글 내용";
         Member commentOwner = Member.builder().email("owner@example.com").build(); // 댓글 소유자
         Comment existingComment = Comment.builder().id(commentId).member(commentOwner).content("기존 댓글 내용").build();
@@ -305,7 +310,7 @@ class CommentServiceTest {
         when(memberRepository.findByEmail(authenticatedEmail)).thenReturn(Optional.of(Member.builder().email(authenticatedEmail).build()));
 
         // when, then
-        assertThatThrownBy(() -> commentService.updateComment(commentId, updatedContent))
+        assertThatThrownBy(() -> commentService.updateComment(commentId, postId, updatedContent))
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessageContaining(ErrorCode.FORBIDDEN_COMMENT_MODIFY.getMessage());
     }
@@ -315,6 +320,7 @@ class CommentServiceTest {
     void deleteComment_Fail_ForbiddenDelete() {
         // given
         Long commentId = 1L;
+        Long postId = 1L;
         Member commentOwner = Member.builder().email("owner@example.com").build(); // 댓글 소유자
         Comment existingComment = Comment.builder().id(commentId).member(commentOwner).content("기존 댓글 내용").build();
 
@@ -322,7 +328,7 @@ class CommentServiceTest {
         when(memberRepository.findByEmail(authenticatedEmail)).thenReturn(Optional.of(Member.builder().email(authenticatedEmail).build()));
 
         // when, then
-        assertThatThrownBy(() -> commentService.deleteComment(commentId))
+        assertThatThrownBy(() -> commentService.deleteComment(commentId, postId))
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessageContaining(ErrorCode.FORBIDDEN_COMMENT_DELETE.getMessage());
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] BookmarkService에서 getCurrentMember() 메서드를 전역 static 메서드로 사용하도록 수정
- [x] 예외 검증 로직 작성
- [x] 에러 코드 추가
- [x] 예외 테스트 코드 작성

## 💡 자세한 설명
댓글 수정, 삭제 메서드에 아래와 같은 로직을 추가함으로서, 해당 댓글이 URL과 일치하는 post에 속하는지 여부를 검사합니다.
```java
if (!comment.getPost().getId().equals(postId)) {
            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
        }
```

이를 위해 컨트롤러에서도 `@PathVariable` 로 `postId` 를 받아오게 수정했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
