### PR TITLE
게시글 작성 시 파일 첨부 필수 -> 선택으로 변경 완료

### DIFF
--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -1,28 +1,24 @@
 package balancetalk.module.post.application;
 
-import static balancetalk.global.exception.ErrorCode.*;
-
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.redis.application.RedisService;
 import balancetalk.module.file.domain.File;
 import balancetalk.module.file.domain.FileRepository;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.MemberRepository;
-import balancetalk.module.post.domain.BalanceOption;
-import balancetalk.module.post.domain.Post;
-import balancetalk.module.post.domain.PostLike;
-import balancetalk.module.post.domain.PostLikeRepository;
-import balancetalk.module.post.domain.PostRepository;
-import balancetalk.module.post.domain.PostTag;
+import balancetalk.module.post.domain.*;
 import balancetalk.module.post.dto.BalanceOptionDto;
 import balancetalk.module.post.dto.PostRequest;
 import balancetalk.module.post.dto.PostResponse;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static balancetalk.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -64,6 +60,7 @@ public class PostService {
     private List<File> getImages(PostRequest postRequestDto) {
         List<BalanceOptionDto> balanceOptions = postRequestDto.getBalanceOptions();
         return balanceOptions.stream()
+                .filter(optionDto -> optionDto.getStoredFileName() != null && !optionDto.getStoredFileName().isEmpty())
                 .map(optionDto -> fileRepository.findByStoredName(optionDto.getStoredFileName())
                         .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE)))
                 .toList();

--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
@@ -3,7 +3,11 @@ package balancetalk.module.post.dto;
 import balancetalk.module.file.domain.File;
 import balancetalk.module.post.domain.BalanceOption;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 @Data
 @Builder
@@ -20,19 +24,23 @@ public class BalanceOptionDto {
     @Schema(description = "DB에 저장되는 이미지 이름", example = "4df23447-2355-45h2-8783-7f6gd2ceb848_고양이.jpg")
     private String storedFileName;
 
-    public BalanceOption toEntity(File image) {
-        return BalanceOption.builder()
+    public BalanceOption toEntity(@Nullable File image) {
+        BalanceOption.BalanceOptionBuilder builder = BalanceOption.builder()
                 .title(title)
-                .description(description)
-                .file(image)
-                .build();
+                .description(description);
+        if (image != null) {
+            builder.file(image);
+        }
+        return builder.build();
     }
 
     public static BalanceOptionDto fromEntity(BalanceOption balanceOption) {
-        return BalanceOptionDto.builder()
+        BalanceOptionDtoBuilder builder = BalanceOptionDto.builder()
                 .title(balanceOption.getTitle())
-                .description(balanceOption.getDescription())
-                .storedFileName(balanceOption.getFile().getStoredName())
-                .build();
+                .description(balanceOption.getDescription());
+        if (balanceOption.getFile() != null) {
+            builder.storedFileName(balanceOption.getFile().getStoredName());
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/balancetalk/module/post/dto/PostRequest.java
+++ b/src/main/java/balancetalk/module/post/dto/PostRequest.java
@@ -8,10 +8,15 @@ import balancetalk.module.post.domain.PostCategory;
 import balancetalk.module.post.domain.PostTag;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.stream.IntStream;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Data
@@ -51,9 +56,19 @@ public class PostRequest {
     }
 
     private List<BalanceOption> getBalanceOptions(List<File> images) {
-        return IntStream.range(0, balanceOptions.size())
-                .mapToObj(i -> balanceOptions.get(i).toEntity(images.get(i)))
-                .collect(Collectors.toList());
+        if (images.isEmpty()) {
+            return balanceOptions.stream()
+                    .map(balanceOptionDto -> balanceOptionDto.toEntity(null))
+                    .collect(Collectors.toList());
+        } else {
+            Map<String, File> fileNameToFileMap = images.stream()
+                    .collect(Collectors.toMap(File::getStoredName, Function.identity()));
+
+            return balanceOptions.stream()
+                    .map(balanceOptionDto -> balanceOptionDto.toEntity(fileNameToFileMap.getOrDefault(balanceOptionDto.getStoredFileName(),
+                            null)))
+                    .collect(Collectors.toList());
+        }
     }
 
     private List<PostTag> getPostTags() {


### PR DESCRIPTION
## 💡 작업 내용
- [ ] BalanceOptionDto에서 File이 `NULL` 일 경우의 로직 추가
- [ ] PostRequest에서 images가 `NULL`일 경우와 그렇지 않은 경우의 로직 추가
- [ ] PostService에서 getStoredFileName() 이 `NULL` 일 경우의 로직 추가

## 💡 자세한 설명
PostRequest 클래스의 getBalanceOptions 메서드를 아래와 같이 수정했습니다.
```java
private List<BalanceOption> getBalanceOptions(List<File> images) {
        if (images.isEmpty()) {
            return balanceOptions.stream()
                    .map(balanceOptionDto -> balanceOptionDto.toEntity(null))
                    .collect(Collectors.toList());
        } else {
            Map<String, File> fileNameToFileMap = images.stream()
                    .collect(Collectors.toMap(File::getStoredName, Function.identity()));

            return balanceOptions.stream()
                    .map(balanceOptionDto -> balanceOptionDto.toEntity(fileNameToFileMap.getOrDefault(balanceOptionDto.getStoredFileName(),
                            null)))
                    .collect(Collectors.toList());
        }
    }
```

`images` 리스트(업로드된 이미지 파일 객체의 리스트)를 스트림으로 변환한 다음, 각 `File` 객체의 저장된 이름(`getStoredName()`)을 키로, File 객체 자체를 값으로 하는 맵(`Map<String, File>`)을 생성합니다. Collectors.toMap 컬렉터로 각 요소를 맵의 엔트리로 변환해줍니다.  여기서 Function.identity()는 현재 요소(File 객체)를 그대로 반환하게 해 줍니다.

그 다음 `balanceOptions` 리스트를 스트림으로 변환하고, 각 `BalanceOptionDto`를 `BalanceOption` 엔터티로 변환합니다. 변환 과정에서, `BalanceOptionDto`의 `storedFileName`을 사용하여 `filenameToFileMap` 에서 해당 이미지 파일 객체를 검색합니다. `Map.getOrDefault` 메서드를 사용하여, `storedFileName` 에 해당하는 파일 객체가 맵에 있으면 그 객체를 반환하고, 없으면 `null` 을 반환합니다. 이렇게 검색된 파일 객체(또는 `null`)는 `toEntity` 메서드에 인자로 전달되어, 이미지 파일이 있는 경우 해당 파일 정보가 `BalanceOption` 엔터티에 포함됩니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
