### PR TITLE
게시글, 댓글 신고 기능 구현

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     FORBIDDEN_MEMBER_DELETE(FORBIDDEN, "사용자 탈퇴 권한이 없습니다."),
     FORBIDDEN_BOOKMARK_DELETE(FORBIDDEN, "북마크 삭제 권한이 없습니다."),
     FORBIDDEN_POST_CREATE(FORBIDDEN, "글쓰기 권한이 없습니다."),
+    FORBIDDEN_OWN_REPORT(FORBIDDEN, "자신의 게시글 또는 댓글을 신고할 수 없습니다."),
 
     // 404
     NOT_FOUND_POST(NOT_FOUND, "존재하지 않는 게시글입니다."),

--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -99,7 +99,7 @@ public class JwtTokenProvider {
         try {
             return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
         } catch (final IllegalArgumentException | MalformedJwtException e) {
-            throw new IllegalArgumentException("Token이 null이거나 Token 파싱 오류");
+            throw new IllegalArgumentException("토큰 값이 존재하지 않습니다.");
         } catch (final SignatureException e) {
             throw new IllegalArgumentException("토큰의 시크릿 키가 일치하지 않습니다.");
         } catch (final ExpiredJwtException e) {

--- a/src/main/java/balancetalk/module/authmail/dto/EmailRequest.java
+++ b/src/main/java/balancetalk/module/authmail/dto/EmailRequest.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class EmailRequest {
 
     @Email

--- a/src/main/java/balancetalk/module/authmail/dto/EmailVerification.java
+++ b/src/main/java/balancetalk/module/authmail/dto/EmailVerification.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class EmailVerification {
 
     @Email

--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -14,6 +14,9 @@ import balancetalk.module.member.domain.MemberRepository;
 import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostRepository;
+import balancetalk.module.report.domain.Report;
+import balancetalk.module.report.domain.ReportRepository;
+import balancetalk.module.report.dto.ReportRequest;
 import balancetalk.module.vote.domain.Vote;
 import balancetalk.module.vote.domain.VoteRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +39,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final ReportRepository reportRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final VoteRepository voteRepository;
 
@@ -181,5 +185,24 @@ public class CommentService {
         Member member = getCurrentMember(memberRepository);
 
         commentLikeRepository.deleteByMemberAndComment(member, comment);
+    }
+
+    public void reportComment(Long postId, Long commentId, ReportRequest reportRequest) {
+        Comment comment = validateCommentId(commentId);
+        Member member = getCurrentMember(memberRepository);
+        if (comment.getMember().equals(member)) {
+            throw new BalanceTalkException(FORBIDDEN_OWN_REPORT);
+        }
+
+        if (!comment.getPost().getId().equals(postId)) {
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
+        }
+        Report report = Report.builder()
+                .content(reportRequest.getDescription())
+                .reporter(member)
+                .comment(comment)
+                .category(reportRequest.getCategory())
+                .build();
+        reportRepository.save(report);
     }
 }

--- a/src/main/java/balancetalk/module/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/module/comment/domain/Comment.java
@@ -52,6 +52,12 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "comment")
     private List<Report> reports = new ArrayList<>();
 
+    public long reportedCount() {
+        if (reports == null) {
+            return 0;
+        }
+        return reports.size();
+    }
     public void updateContent(String content) {
         this.content = content;
     }

--- a/src/main/java/balancetalk/module/comment/dto/CommentRequest.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentRequest.java
@@ -7,9 +7,11 @@ import balancetalk.module.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class CommentRequest {
 
     @Schema(description = "댓글 내용", example = "댓글 내용...")

--- a/src/main/java/balancetalk/module/comment/dto/CommentRequest.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentRequest.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class CommentRequest {
 
     @Schema(description = "댓글 내용", example = "댓글 내용...")

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -31,6 +31,9 @@ public class CommentResponse {
     @Schema(description = "댓글 추천 수", example = "24")
     private int likeCount;
 
+    @Schema(description = "댓글 신고 수", example = "3")
+    private long reportedCount;
+
     @Schema(description = "댓글 생성 날짜")
     private LocalDateTime createdAt;
 
@@ -45,6 +48,7 @@ public class CommentResponse {
                 .postId(comment.getPost().getId())
                 .selectedOptionId(balanceOptionId)
                 .likeCount(comment.getLikes().size())
+                .reportedCount(comment.reportedCount())
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())
                 .build();

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/posts/{postId}/comments") // posts/1/comments/4
+@RequestMapping("/posts/{postId}/comments")
 @RequiredArgsConstructor
 @Tag(name = "comment", description = "댓글 API")
 public class CommentController {

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -4,6 +4,7 @@ import balancetalk.module.comment.application.CommentService;
 import balancetalk.module.comment.dto.CommentRequest;
 import balancetalk.module.comment.dto.CommentResponse;
 import balancetalk.module.comment.dto.ReplyCreateRequest;
+import balancetalk.module.report.dto.ReportRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +55,7 @@ public class CommentController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{commentId}/replies")
     @Operation(summary = "답글 작성", description = "comment-id에 해당하는 댓글에 답글을 작성한다.")
-    public String createComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody ReplyCreateRequest request) {
+    public String createComment(@PathVariable Long commentId, @PathVariable Long postId, @RequestBody ReplyCreateRequest request) {
         commentService.createReply(postId, commentId, request);
         return "답글이 정상적으로 작성되었습니다.";
     }
@@ -62,7 +63,7 @@ public class CommentController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{commentId}/likes")
     @Operation(summary = "댓글 추천", description = "comment-id에 해당하는 댓글에 추천을 누른다.")
-    public String likeComment(@PathVariable Long postId, @PathVariable Long commentId) {
+    public String likeComment(@PathVariable Long commentId, @PathVariable Long postId) {
         commentService.likeComment(postId, commentId);
         return "요청이 정상적으로 처리되었습니다.";
     }
@@ -72,5 +73,13 @@ public class CommentController {
     @Operation(summary = "댓글 추천 취소", description = "comment-id에 해당하는 댓글에 누른 추천을 취소한다.")
     public void cancelLikeComment(@PathVariable Long commentId) {
         commentService.cancelLikeComment(commentId);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/{commentId}/report")
+    @Operation(summary = "댓글 신고", description = "comment-id에 해당하는 댓글을 신고 처리한다.")
+    public String reportComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody ReportRequest reportRequest) {
+        commentService.reportComment(postId, commentId, reportRequest);
+        return "신고가 성공적으로 접수되었습니다.";
     }
 }

--- a/src/main/java/balancetalk/module/file/dto/FileResponse.java
+++ b/src/main/java/balancetalk/module/file/dto/FileResponse.java
@@ -7,7 +7,6 @@ import lombok.*;
 
 @Data
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class FileResponse {
     @Schema(description = "파일 id", example = "1")

--- a/src/main/java/balancetalk/module/member/domain/Member.java
+++ b/src/main/java/balancetalk/module/member/domain/Member.java
@@ -132,6 +132,11 @@ public class Member extends BaseTimeEntity implements UserDetails {
                 .map(List::size).orElse(0);
     }
 
+    public int getReportsCount() {
+        return Optional.ofNullable(reports)
+                .map(List::size).orElse(0);
+    }
+
     public boolean hasVoted(Post post) {
         return votes.stream()
                 .anyMatch(vote -> vote.getBalanceOption().getPost().equals(post));

--- a/src/main/java/balancetalk/module/member/dto/JoinRequest.java
+++ b/src/main/java/balancetalk/module/member/dto/JoinRequest.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class JoinRequest {
 

--- a/src/main/java/balancetalk/module/member/dto/LoginRequest.java
+++ b/src/main/java/balancetalk/module/member/dto/LoginRequest.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequest {
 

--- a/src/main/java/balancetalk/module/member/dto/LoginResponse.java
+++ b/src/main/java/balancetalk/module/member/dto/LoginResponse.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class LoginResponse {
 

--- a/src/main/java/balancetalk/module/member/dto/MemberResponse.java
+++ b/src/main/java/balancetalk/module/member/dto/MemberResponse.java
@@ -29,6 +29,9 @@ public class MemberResponse {
     @Schema(description = "작성한 게시글 수", example = "11")
     private int postsCount;
 
+    @Schema(description = "신고한 횟수" , example = "3")
+    private int reportsCount;
+
     @Schema(description = "작성한 게시글의 받은 추천 수", example = "119")
     private int totalPostLike;
 
@@ -42,6 +45,7 @@ public class MemberResponse {
                 //.profilePhoto(file.getPath())
                 .createdAt(member.getCreatedAt())
                 .postsCount(member.getPostCount())
+                .reportsCount(member.getReportsCount())
                 .totalPostLike(member.getPostLikes())
                 .build();
     }

--- a/src/main/java/balancetalk/module/member/dto/MemberResponse.java
+++ b/src/main/java/balancetalk/module/member/dto/MemberResponse.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class MemberResponse {
 

--- a/src/main/java/balancetalk/module/member/dto/TokenDto.java
+++ b/src/main/java/balancetalk/module/member/dto/TokenDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class TokenDto {
 

--- a/src/main/java/balancetalk/module/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/module/member/presentation/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{memberId}")
     @Operation(summary = "단일 회원 조회", description = "memberId와 일치하는 회원 정보를 조회한다.")
-    public MemberResponse findMemberInfo(@PathVariable("memberId") Long memberId) {
+    public MemberResponse findMemberInfo(@PathVariable Long memberId) {
         return memberService.findById(memberId);
     }
 

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -83,6 +83,13 @@ public class Post extends BaseTimeEntity {
         }
         return likes.size();
     }
+
+    public long reportedCount() {
+        if (reports == null) {
+            return 0;
+        }
+        return reports.size();
+    }
     
     @PrePersist
     public void init() {

--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
@@ -11,7 +11,6 @@ import org.springframework.lang.Nullable;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class BalanceOptionDto {
 

--- a/src/main/java/balancetalk/module/post/dto/PostRequest.java
+++ b/src/main/java/balancetalk/module/post/dto/PostRequest.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class PostRequest {
 

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -29,6 +29,9 @@ public class PostResponse {
     @Schema(description = "게시글 추천수", example = "15")
     private long likesCount;
 
+    @Schema(description = "신고 횟수" , example = "3")
+    private long reportedCount;
+
     @Schema(description = "추천 여부", example = "true")
     private boolean myLike;
 
@@ -57,6 +60,7 @@ public class PostResponse {
                 .views(post.getViews())
                 .likesCount(post.likesCount())
                 .myLike(member.hasLiked(post))
+                .reportedCount(post.reportedCount())
                 .myBookmark(member.hasBookmarked(post))
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))

--- a/src/main/java/balancetalk/module/post/dto/PostTagDto.java
+++ b/src/main/java/balancetalk/module/post/dto/PostTagDto.java
@@ -7,7 +7,6 @@ import lombok.*;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class PostTagDto {
 

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -29,22 +29,21 @@ public class PostController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     @Operation(summary = "모든 게시글 조회", description = "해당 회원이 쓴 모든 글을 조회한다.")
-    public List<PostResponse> findAllPosts(@RequestParam("member-id") Long memberId) {
+    public List<PostResponse> findAllPosts(@RequestParam Long memberId) {
         return postService.findAll(memberId);
     }
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "post-id에 해당하는 게시글을 조회한다.")
-    public PostResponse findPost(@PathVariable("postId") Long postId,
-                                 @RequestParam("member-id") Long memberId) {
+    public PostResponse findPost(@PathVariable Long postId, @RequestParam Long memberId) {
         return postService.findById(postId, memberId);
     }
 
     @ResponseStatus(HttpStatus.CREATED)
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "post-id에 해당하는 게시글을 삭제한다.")
-    public String deletePost(@PathVariable("postId") Long postId) {
+    public String deletePost(@PathVariable Long postId) {
         postService.deleteById(postId);
         return "요청이 정상적으로 처리되었습니다.";
     }
@@ -52,7 +51,7 @@ public class PostController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}/likes")
     @Operation(summary = "게시글 추천", description = "post-id에 해당하는 게시글에 추천을 누른다.")
-    public String likePost(@PathVariable("postId") Long postId) {
+    public String likePost(@PathVariable Long postId) {
         postService.likePost(postId);
         return "요청이 정상적으로 처리되었습니다.";
     }
@@ -60,7 +59,7 @@ public class PostController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{postId}/likes")
     @Operation(summary = "게시글 추천 취소", description = "post-id에 해당하는 게시글에 누른 추천을 취소한다.")
-    public String cancelLikePost(@PathVariable("postId") Long postId) {
+    public String cancelLikePost(@PathVariable Long postId) {
         postService.cancelLikePost(postId);
         return "요청이 정상적으로 처리되었습니다.";
     }
@@ -68,7 +67,7 @@ public class PostController {
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/{postId}/report")
     @Operation(summary = "게시글 신고", description = "post-id에 해당하는 게시글을 신고 처리한다.")
-    public String reportPost(@PathVariable("postId") Long postId, @RequestBody ReportRequest request) {
+    public String reportPost(@PathVariable Long postId, @RequestBody ReportRequest request) {
         postService.reportPost(postId, request);
         return "신고가 성공적으로 접수되었습니다.";
     }

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -3,6 +3,7 @@ package balancetalk.module.post.presentation;
 import balancetalk.module.post.application.PostService;
 import balancetalk.module.post.dto.PostRequest;
 import balancetalk.module.post.dto.PostResponse;
+import balancetalk.module.report.dto.ReportRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class PostController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}/likes")
     @Operation(summary = "게시글 추천", description = "post-id에 해당하는 게시글에 추천을 누른다.")
-    public String likePost(@PathVariable Long postId) {
+    public String likePost(@PathVariable("postId") Long postId) {
         postService.likePost(postId);
         return "요청이 정상적으로 처리되었습니다.";
     }
@@ -59,8 +60,16 @@ public class PostController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{postId}/likes")
     @Operation(summary = "게시글 추천 취소", description = "post-id에 해당하는 게시글에 누른 추천을 취소한다.")
-    public String cancelLikePost(@PathVariable Long postId) {
+    public String cancelLikePost(@PathVariable("postId") Long postId) {
         postService.cancelLikePost(postId);
         return "요청이 정상적으로 처리되었습니다.";
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/{postId}/report")
+    @Operation(summary = "게시글 신고", description = "post-id에 해당하는 게시글을 신고 처리한다.")
+    public String reportPost(@PathVariable("postId") Long postId, @RequestBody ReportRequest request) {
+        postService.reportPost(postId, request);
+        return "신고가 성공적으로 접수되었습니다.";
     }
 }

--- a/src/main/java/balancetalk/module/report/domain/Report.java
+++ b/src/main/java/balancetalk/module/report/domain/Report.java
@@ -15,11 +15,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
+@Builder
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Report extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/balancetalk/module/report/domain/ReportRepository.java
+++ b/src/main/java/balancetalk/module/report/domain/ReportRepository.java
@@ -1,0 +1,6 @@
+package balancetalk.module.report.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/balancetalk/module/report/dto/ReportRequest.java
+++ b/src/main/java/balancetalk/module/report/dto/ReportRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class ReportRequest {
 
     @Schema(description = "신고 이유", example = "정치 게시글 / 분란성 댓글")
@@ -18,4 +17,5 @@ public class ReportRequest {
 
     @Schema(description = "신고 설명", example = "게시글 / 댓글 신고한 이유")
     private String description;
+
 }

--- a/src/main/java/balancetalk/module/report/dto/ReportRequest.java
+++ b/src/main/java/balancetalk/module/report/dto/ReportRequest.java
@@ -1,0 +1,21 @@
+package balancetalk.module.report.dto;
+
+import balancetalk.module.report.domain.ReportCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportRequest {
+
+    @Schema(description = "신고 이유", example = "정치 게시글 / 분란성 댓글")
+    private ReportCategory category;
+
+    @Schema(description = "신고 설명", example = "게시글 / 댓글 신고한 이유")
+    private String description;
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 신고 기능 구현
- [x] 댓글 신고 기능 구현
- [x] 모든 dto 파일에서 기본 생성자 제거
- [x] 모든 컨트롤러에서 @PathVariable`(id)` 값 제거

## 💡 자세한 설명
게시글과 댓글을 신고 했을 때 reportedCount가 증가하도록 구현하였습니다.

그리고 자기 자신의 댓글이나 게시글을 신고할수 없게끔 
![스크린샷 2024-03-08 오전 1 37 24](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/127d9869-35ee-41bb-8f7c-3387a8dc16c8)
위 에러를 추가하였습니다.



### 게시글이 신고된 경우

![스크린샷 2024-03-08 오전 1 39 47](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/9fe87ee0-2def-4c5a-ae6f-a12242b8af9b)

`reportedCount` 값이 1 증가합니다.


### 댓글이 신고된 경우

![스크린샷 2024-03-08 오전 1 41 11](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/6f8328b3-95d8-4f0f-b366-6bc289307e2a)


마찬가지로 `ReportedCount` 값이 증가합니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

게시글이나 댓글이 신고되었을 때, 작성자의 `reportCount` 가 누적되어야 하지만, 현재는 신고한 사람의 신고한 횟수가 증가합니다. 

![스크린샷 2024-03-08 오전 1 43 10](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/66208e09-fdc3-44ff-80a1-f561d4cf8d96)

`id=2` 인 유저가 신고를 2회 함 -> `id=1`인 신고 당한 유저의 `reportedCount` 를 증가시켜야 합니다. 

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #165  
