### PR TITLE
공지사항 작성 기능 구현 완료

### DIFF
--- a/src/main/java/balancetalk/global/exception/ConstraintExceptionHandler.java
+++ b/src/main/java/balancetalk/global/exception/ConstraintExceptionHandler.java
@@ -1,0 +1,20 @@
+package balancetalk.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@Slf4j
+@RestControllerAdvice
+public class ConstraintExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleNoticeTitleSizeExceededExceptions(MethodArgumentNotValidException e) {
+        ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.EXCEED_VALIDATION_LENGTH);
+        log.error("exception message = {}", e.getMessage());
+
+        return ResponseEntity.status(errorResponse.getHttpStatus()).body(errorResponse);
+    }
+}

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -25,10 +25,9 @@ public enum ErrorCode {
     INVALID_JWT_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
     EXCEED_MAX_DEPTH(BAD_REQUEST, "답글에 답글을 달 수 없습니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
-    EXCEED_TITLE_LENGTH(BAD_REQUEST, "제목은 1자 이상 100자 이하로 입력해주세요."),
-    EXCEED_NOTICE_CONTENT_LENGTH(BAD_REQUEST, "공지사항 내용은 1자 이상 2000자 이하로 입력해주세요."),
     PAGE_NUMBER_ZERO(BAD_REQUEST, "페이지 번호는 0보다 커야합니다."),
     PAGE_SIZE_ZERO(BAD_REQUEST, "페이지 사이즈는 0보다 커야합니다."),
+    EXCEED_VALIDATION_LENGTH(BAD_REQUEST, "입력값이 제약 조건에 맞지 않습니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
     EXCEED_TITLE_LENGTH(BAD_REQUEST, "제목은 1자 이상 100자 이하로 입력해주세요."),
     EXCEED_NOTICE_CONTENT_LENGTH(BAD_REQUEST, "공지사항 내용은 1자 이상 2000자 이하로 입력해주세요."),
+    PAGE_NUMBER_ZERO(BAD_REQUEST, "페이지 번호는 0보다 커야합니다."),
+    PAGE_SIZE_ZERO(BAD_REQUEST, "페이지 사이즈는 0보다 커야합니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
@@ -55,6 +57,7 @@ public enum ErrorCode {
     NOT_FOUND_FILE(NOT_FOUND, "존재하지 않는 파일입니다."),
     NOT_FOUND_PARENT_COMMENT(NOT_FOUND, "존재하지 않는 원 댓글입니다."),
     NOT_FOUND_COMMENT_AT_THAT_POST(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
+    NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
 
     // 409
     ALREADY_VOTE(CONFLICT, "이미 투표한 게시글입니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -25,12 +25,15 @@ public enum ErrorCode {
     INVALID_JWT_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
     EXCEED_MAX_DEPTH(BAD_REQUEST, "답글에 답글을 달 수 없습니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
+    EXCEED_TITLE_LENGTH(BAD_REQUEST, "제목은 1자 이상 100자 이하로 입력해주세요."),
+    EXCEED_NOTICE_CONTENT_LENGTH(BAD_REQUEST, "공지사항 내용은 1자 이상 2000자 이하로 입력해주세요."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
     AUTHENTICATION_ERROR(UNAUTHORIZED, "인증 오류가 발생했습니다."),
     BAD_CREDENTIAL_ERROR(UNAUTHORIZED, "로그인에 실패했습니다."),
     UNAUTHORIZED_LOGOUT(UNAUTHORIZED, "로그아웃을 위해서는 인증이 필요합니다."),
+    UNAUTHORIZED_CREATE_NOTICE(UNAUTHORIZED, "공지사항 작성 권한이 없습니다."),
 
     // 403
     FORBIDDEN_POST_DELETE(FORBIDDEN, "해당 게시글은 삭제 권한이 없습니다."),

--- a/src/main/java/balancetalk/module/file/domain/File.java
+++ b/src/main/java/balancetalk/module/file/domain/File.java
@@ -1,6 +1,6 @@
 package balancetalk.module.file.domain;
 
-import balancetalk.module.Notice;
+import balancetalk.module.notice.domain.Notice;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/balancetalk/module/member/domain/Member.java
+++ b/src/main/java/balancetalk/module/member/domain/Member.java
@@ -3,7 +3,7 @@ package balancetalk.module.member.domain;
 import balancetalk.module.bookmark.domain.Bookmark;
 import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.comment.domain.CommentLike;
-import balancetalk.module.Notice;
+import balancetalk.module.notice.domain.Notice;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostLike;
 import balancetalk.module.report.domain.Report;
@@ -25,7 +25,6 @@ import jakarta.validation.constraints.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Builder

--- a/src/main/java/balancetalk/module/notice/application/NoticeService.java
+++ b/src/main/java/balancetalk/module/notice/application/NoticeService.java
@@ -9,9 +9,13 @@ import balancetalk.module.notice.dto.NoticeRequest;
 import balancetalk.module.notice.dto.NoticeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static balancetalk.global.exception.ErrorCode.NOT_FOUND_NOTICE;
 import static balancetalk.global.exception.ErrorCode.UNAUTHORIZED_CREATE_NOTICE;
 import static balancetalk.global.utils.SecurityUtils.getCurrentMember;
 import static balancetalk.module.member.domain.Role.ADMIN;
@@ -19,12 +23,12 @@ import static balancetalk.module.member.domain.Role.ADMIN;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public NoticeResponse createNotice(final NoticeRequest request) {
         Member member = getCurrentMember(memberRepository);
         if (!member.getRole().equals(ADMIN)) {
@@ -34,5 +38,17 @@ public class NoticeService {
         Notice notice = request.toEntity(member);
 
         return NoticeResponse.fromEntity(noticeRepository.save(notice));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NoticeResponse> findAllNotices(Pageable pageable) {
+        return noticeRepository.findAll(pageable)
+                .map(NoticeResponse::fromEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeResponse findNoticeById(Long id) {
+        return NoticeResponse.fromEntity(noticeRepository.findById(id)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_NOTICE)));
     }
 }

--- a/src/main/java/balancetalk/module/notice/application/NoticeService.java
+++ b/src/main/java/balancetalk/module/notice/application/NoticeService.java
@@ -1,0 +1,38 @@
+package balancetalk.module.notice.application;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.module.member.domain.Member;
+import balancetalk.module.member.domain.MemberRepository;
+import balancetalk.module.notice.domain.Notice;
+import balancetalk.module.notice.domain.NoticeRepository;
+import balancetalk.module.notice.dto.NoticeRequest;
+import balancetalk.module.notice.dto.NoticeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static balancetalk.global.exception.ErrorCode.UNAUTHORIZED_CREATE_NOTICE;
+import static balancetalk.global.utils.SecurityUtils.getCurrentMember;
+import static balancetalk.module.member.domain.Role.ADMIN;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final MemberRepository memberRepository;
+
+    public NoticeResponse createNotice(final NoticeRequest request) {
+        Member member = getCurrentMember(memberRepository);
+        if (!member.getRole().equals(ADMIN)) {
+            throw new BalanceTalkException(UNAUTHORIZED_CREATE_NOTICE);
+        }
+
+        Notice notice = request.toEntity(member);
+
+        return NoticeResponse.fromEntity(noticeRepository.save(notice));
+    }
+}

--- a/src/main/java/balancetalk/module/notice/application/NoticeService.java
+++ b/src/main/java/balancetalk/module/notice/application/NoticeService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/balancetalk/module/notice/domain/Notice.java
+++ b/src/main/java/balancetalk/module/notice/domain/Notice.java
@@ -4,8 +4,6 @@ import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -23,13 +21,9 @@ public class Notice extends BaseTimeEntity {
     @Column(name = "notice_id")
     private Long id;
 
-    @NotBlank
-    @Size(max = 50)
     @Column(nullable = false, length = 50)
     private String title;
 
-    @NotBlank
-    @Size(max = 2000)
     @Column(nullable = false, length = 2000)
     private String content;
 

--- a/src/main/java/balancetalk/module/notice/domain/Notice.java
+++ b/src/main/java/balancetalk/module/notice/domain/Notice.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/balancetalk/module/notice/domain/Notice.java
+++ b/src/main/java/balancetalk/module/notice/domain/Notice.java
@@ -1,4 +1,4 @@
-package balancetalk.module;
+package balancetalk.module.notice.domain;
 
 import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;

--- a/src/main/java/balancetalk/module/notice/domain/Notice.java
+++ b/src/main/java/balancetalk/module/notice/domain/Notice.java
@@ -1,24 +1,19 @@
 package balancetalk.module.notice.domain;
 
+import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;
-import balancetalk.global.common.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notice extends BaseTimeEntity {
 

--- a/src/main/java/balancetalk/module/notice/domain/NoticeRepository.java
+++ b/src/main/java/balancetalk/module/notice/domain/NoticeRepository.java
@@ -1,0 +1,6 @@
+package balancetalk.module.notice.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/balancetalk/module/notice/dto/NoticeRequest.java
+++ b/src/main/java/balancetalk/module/notice/dto/NoticeRequest.java
@@ -1,0 +1,42 @@
+package balancetalk.module.notice.dto;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.module.member.domain.Member;
+import balancetalk.module.notice.domain.Notice;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import static balancetalk.global.exception.ErrorCode.EXCEED_NOTICE_CONTENT_LENGTH;
+import static balancetalk.global.exception.ErrorCode.EXCEED_TITLE_LENGTH;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeRequest {
+
+    @Schema(description = "공지사항 제목", example = "공지사항 제목")
+    private String title;
+
+    @Schema(description = "공지사항 내용", example = "공지사항 내용")
+    private String content;
+
+    public Notice toEntity(Member member) {
+
+        if (title.length() > 100 || title.isEmpty()) {
+            throw new BalanceTalkException(EXCEED_TITLE_LENGTH);
+        }
+
+        if (content.length() > 2000 || content.isEmpty()) {
+            throw new BalanceTalkException(EXCEED_NOTICE_CONTENT_LENGTH);
+        }
+        return Notice.builder()
+                .title(title)
+                .content(content)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/balancetalk/module/notice/dto/NoticeRequest.java
+++ b/src/main/java/balancetalk/module/notice/dto/NoticeRequest.java
@@ -7,14 +7,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import static balancetalk.global.exception.ErrorCode.EXCEED_NOTICE_CONTENT_LENGTH;
 import static balancetalk.global.exception.ErrorCode.EXCEED_TITLE_LENGTH;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class NoticeRequest {
 

--- a/src/main/java/balancetalk/module/notice/dto/NoticeRequest.java
+++ b/src/main/java/balancetalk/module/notice/dto/NoticeRequest.java
@@ -1,36 +1,31 @@
 package balancetalk.module.notice.dto;
 
-import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.notice.domain.Notice;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
-import static balancetalk.global.exception.ErrorCode.EXCEED_NOTICE_CONTENT_LENGTH;
-import static balancetalk.global.exception.ErrorCode.EXCEED_TITLE_LENGTH;
 
 @Data
 @Builder
 @AllArgsConstructor
 public class NoticeRequest {
 
+    @NotBlank
+    @Size(max = 50)
     @Schema(description = "공지사항 제목", example = "공지사항 제목")
     private String title;
 
+    @NotBlank
+    @Size(max = 2000)
     @Schema(description = "공지사항 내용", example = "공지사항 내용")
     private String content;
 
     public Notice toEntity(Member member) {
 
-        if (title.length() > 100 || title.isEmpty()) {
-            throw new BalanceTalkException(EXCEED_TITLE_LENGTH);
-        }
-
-        if (content.length() > 2000 || content.isEmpty()) {
-            throw new BalanceTalkException(EXCEED_NOTICE_CONTENT_LENGTH);
-        }
         return Notice.builder()
                 .title(title)
                 .content(content)

--- a/src/main/java/balancetalk/module/notice/dto/NoticeResponse.java
+++ b/src/main/java/balancetalk/module/notice/dto/NoticeResponse.java
@@ -19,6 +19,9 @@ public class NoticeResponse {
     @Schema(description = "게시글 제목", example = "게시글 제목")
     private String title;
 
+    @Schema(description = "게시글 내용", example = "게시글 내용")
+    private String content;
+
     @Schema(description = "게시글 작성일", example = "2022-02-12")
     private LocalDateTime createdAt;
 
@@ -29,6 +32,7 @@ public class NoticeResponse {
         return NoticeResponse.builder()
                 .id(notice.getId())
                 .title(notice.getTitle())
+                .content(notice.getContent())
                 .createdAt(notice.getCreatedAt())
                 .createdBy(notice.getMember().getNickname())
                 .build();

--- a/src/main/java/balancetalk/module/notice/dto/NoticeResponse.java
+++ b/src/main/java/balancetalk/module/notice/dto/NoticeResponse.java
@@ -37,5 +37,4 @@ public class NoticeResponse {
                 .createdBy(notice.getMember().getNickname())
                 .build();
     }
-
 }

--- a/src/main/java/balancetalk/module/notice/dto/NoticeResponse.java
+++ b/src/main/java/balancetalk/module/notice/dto/NoticeResponse.java
@@ -1,0 +1,37 @@
+package balancetalk.module.notice.dto;
+
+import balancetalk.module.notice.domain.Notice;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class NoticeResponse {
+
+    @Schema(description = "게시글 id", example = "1")
+    private Long id;
+
+    @Schema(description = "게시글 제목", example = "게시글 제목")
+    private String title;
+
+    @Schema(description = "게시글 작성일", example = "2022-02-12")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "게시글 작성자", example = "작성자 닉네임")
+    private String createdBy;
+
+    public static NoticeResponse fromEntity(Notice notice) {
+        return NoticeResponse.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .createdAt(notice.getCreatedAt())
+                .createdBy(notice.getMember().getNickname())
+                .build();
+    }
+
+}

--- a/src/main/java/balancetalk/module/notice/presentation/NoticeController.java
+++ b/src/main/java/balancetalk/module/notice/presentation/NoticeController.java
@@ -1,13 +1,22 @@
 package balancetalk.module.notice.presentation;
 
+import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.module.notice.application.NoticeService;
 import balancetalk.module.notice.dto.NoticeRequest;
 import balancetalk.module.notice.dto.NoticeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import static balancetalk.global.exception.ErrorCode.PAGE_NUMBER_ZERO;
+import static balancetalk.global.exception.ErrorCode.PAGE_SIZE_ZERO;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,7 +29,32 @@ public class NoticeController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     @Operation(summary = "공지사항 생성" , description = "로그인 상태인 관리자가 게시글을 작성한다.")
-    public NoticeResponse createNotice(@RequestBody final NoticeRequest noticeRequest) {
+    public NoticeResponse createNotice(@Valid @RequestBody final NoticeRequest noticeRequest) {
         return noticeService.createNotice(noticeRequest);
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    @Operation(summary = "전체 공지사항 조회" , description = "작성된 모든 공지사항을 페이지네이션을 이용해 조회한다.")
+    public Page<NoticeResponse> findAllNotices(@RequestParam(value = "page", defaultValue = "1") int page,
+                                               @RequestParam(required = false, value = "size", defaultValue = "13") int size) {
+
+        if (page <= 0) {
+            throw new BalanceTalkException(PAGE_NUMBER_ZERO);
+        }
+        if (size <= 0) {
+            throw new BalanceTalkException(PAGE_SIZE_ZERO);
+        }
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return noticeService.findAllNotices(pageable);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{noticeId}")
+    @Operation(summary = "특정 공지사항 조회" , description = "특정 공지사항을 조회한다.")
+    public NoticeResponse findNoticeById(@PathVariable Long noticeId) {
+        return noticeService.findNoticeById(noticeId);
+    }
+
 }

--- a/src/main/java/balancetalk/module/notice/presentation/NoticeController.java
+++ b/src/main/java/balancetalk/module/notice/presentation/NoticeController.java
@@ -1,0 +1,26 @@
+package balancetalk.module.notice.presentation;
+
+import balancetalk.module.notice.application.NoticeService;
+import balancetalk.module.notice.dto.NoticeRequest;
+import balancetalk.module.notice.dto.NoticeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notices")
+@Tag(name = "notice", description = "공지사항 API")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    @Operation(summary = "공지사항 생성" , description = "로그인 상태인 관리자가 게시글을 작성한다.")
+    public NoticeResponse createNotice(@RequestBody final NoticeRequest noticeRequest) {
+        return noticeService.createNotice(noticeRequest);
+    }
+}

--- a/src/main/java/balancetalk/module/notice/presentation/NoticeController.java
+++ b/src/main/java/balancetalk/module/notice/presentation/NoticeController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/test/java/balancetalk/module/notice/application/NoticeServiceTest.java
+++ b/src/test/java/balancetalk/module/notice/application/NoticeServiceTest.java
@@ -1,0 +1,115 @@
+package balancetalk.module.notice.application;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.module.member.domain.Member;
+import balancetalk.module.member.domain.MemberRepository;
+import balancetalk.module.member.domain.Role;
+import balancetalk.module.notice.domain.Notice;
+import balancetalk.module.notice.domain.NoticeRepository;
+import balancetalk.module.notice.dto.NoticeRequest;
+import balancetalk.module.notice.dto.NoticeResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private final String adminEmail = "admin@example.com";
+    private final String nonAdminEmail = "user@example.com";
+    private final Member adminMember = Member.builder().email(adminEmail).role(Role.ADMIN).build();
+    private final Member nonAdminMember = Member.builder().email(nonAdminEmail).role(Role.USER).build();
+
+    @BeforeEach
+    void setUp() {
+        // SecurityContext에 인증된 사용자 설정
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        // 여기에 추가
+        when(authentication.getName()).thenReturn(adminEmail);
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 성공")
+    void createNotice_Success() {
+        // given
+        NoticeRequest noticeRequest = new NoticeRequest("공지사항 제목", "공지사항 내용");
+        when(memberRepository.findByEmail(adminEmail)).thenReturn(Optional.of(adminMember));
+        when(noticeRepository.save(any(Notice.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        NoticeResponse noticeResponse = noticeService.createNotice(noticeRequest);
+
+        // then
+        assertNotNull(noticeResponse);
+        assertEquals(noticeRequest.getTitle(), noticeResponse.getTitle());
+        assertEquals(noticeRequest.getContent(), noticeResponse.getContent());
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 실패 - Role이 Admin이 아닐 경우")
+    void createNotice_UnauthorizedRole_Fail() {
+        // given
+        NoticeRequest noticeRequest = new NoticeRequest("공지사항 제목", "공지사항 내용");
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(nonAdminMember));
+
+        // when
+        // then
+        assertThrows(BalanceTalkException.class, () -> noticeService.createNotice(noticeRequest));
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 실패 - 공지사항 제목 100자 초과 또는 공백일 경우")
+    void createNotice_InvalidTitle_Fail() {
+        // given
+        String longTitle = "t".repeat(101);
+        NoticeRequest longTitleRequest = new NoticeRequest(longTitle, "공지사항 내용");
+        NoticeRequest emptyTitleRequest = new NoticeRequest("", "공지사항 내용");
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(adminMember));
+
+        // when
+        // then
+        assertThrows(BalanceTalkException.class, () -> noticeService.createNotice(longTitleRequest));
+        assertThrows(BalanceTalkException.class, () -> noticeService.createNotice(emptyTitleRequest));
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 실패 - 공지사항 내용 2000자 초과 또는 공백일 경우")
+    void createNotice_InvalidContent_Fail() {
+        // given
+        String longContent = "c".repeat(2001);
+        NoticeRequest longContentRequest = new NoticeRequest("공지사항 제목", longContent);
+        NoticeRequest emptyContentRequest = new NoticeRequest("공지사항 제목", "");
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(adminMember));
+
+        // when
+        // then
+        assertThrows(BalanceTalkException.class, () -> noticeService.createNotice(longContentRequest));
+        assertThrows(BalanceTalkException.class, () -> noticeService.createNotice(emptyContentRequest));
+    }
+
+}

--- a/src/test/java/balancetalk/module/notice/application/NoticeServiceTest.java
+++ b/src/test/java/balancetalk/module/notice/application/NoticeServiceTest.java
@@ -8,6 +8,7 @@ import balancetalk.module.notice.domain.Notice;
 import balancetalk.module.notice.domain.NoticeRepository;
 import balancetalk.module.notice.dto.NoticeRequest;
 import balancetalk.module.notice.dto.NoticeResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,11 @@ class NoticeServiceTest {
 
         // 여기에 추가
         lenient().when(authentication.getName()).thenReturn(adminEmail);
+    }
+
+    @AfterEach
+    void clear() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test

--- a/src/test/java/balancetalk/module/notice/application/NoticeServiceTest.java
+++ b/src/test/java/balancetalk/module/notice/application/NoticeServiceTest.java
@@ -15,10 +15,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,7 +54,7 @@ class NoticeServiceTest {
         SecurityContextHolder.setContext(securityContext);
 
         // 여기에 추가
-        when(authentication.getName()).thenReturn(adminEmail);
+        lenient().when(authentication.getName()).thenReturn(adminEmail);
     }
 
     @Test
@@ -68,6 +72,44 @@ class NoticeServiceTest {
         assertNotNull(noticeResponse);
         assertEquals(noticeRequest.getTitle(), noticeResponse.getTitle());
         assertEquals(noticeRequest.getContent(), noticeResponse.getContent());
+    }
+
+    @Test
+    @DisplayName("전체 공지 조회 성공")
+    void getAllNotices_Success() {
+        // given
+        NoticeRequest noticeRequest = new NoticeRequest("공지사항 제목", "공지사항 내용");
+        Page<Notice> page = new PageImpl<>(Collections.singletonList(noticeRequest.toEntity(adminMember)));
+        when(noticeRepository.findAll(any(PageRequest.class))).thenReturn(page);
+
+        // when
+        Page<NoticeResponse> result = noticeService.findAllNotices(PageRequest.of(0, 10));
+
+        // then
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.getContent().size());
+    }
+
+    @Test
+    @DisplayName("특정 공지 조회 성공")
+    void findNoticeById_Success() {
+        // given
+        Long noticeId = 1L;
+        Notice notice = Notice.builder()
+                .id(noticeId)
+                .title("특정 공지")
+                .content("내용")
+                .member(adminMember)
+                .build();
+        when(noticeRepository.findById(noticeId)).thenReturn(Optional.of(notice));
+
+        // when
+        NoticeResponse result = noticeService.findNoticeById(noticeId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(noticeId, result.getId());
+        assertEquals("특정 공지", result.getTitle());
     }
 
     @Test
@@ -112,4 +154,14 @@ class NoticeServiceTest {
         assertThrows(BalanceTalkException.class, () -> noticeService.createNotice(emptyContentRequest));
     }
 
+    @Test
+    @DisplayName("특정 공지 조회 실패 - 공지사항 존재하지 않음")
+    void findNoticeById_NotFound_Fail() {
+        // given
+        Long invalidNoticeId = 999L;
+        when(noticeRepository.findById(invalidNoticeId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(BalanceTalkException.class, () -> noticeService.findNoticeById(invalidNoticeId));
+    }
 }

--- a/src/test/java/balancetalk/module/notice/presentation/NoticeControllerTest.java
+++ b/src/test/java/balancetalk/module/notice/presentation/NoticeControllerTest.java
@@ -1,0 +1,44 @@
+package balancetalk.module.notice.presentation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class NoticeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("전체 공지사항 조회 실패 - 페이지 번호가 0 또는 음수")
+    void findAllNotices_InvalidPage_Fail() throws Exception {
+        mockMvc.perform(get("/notices")
+                        .param("page", "-1")
+                        .param("size", "13")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    // 페이지 사이즈가 0 또는 음수일 때의 예외 처리 검증
+    @Test
+    @DisplayName("전체 공지사항 조회 실패 - 페이지 사이즈가 0 또는 음수")
+    void findAllNotices_InvalidSize_Fail() throws Exception {
+        mockMvc.perform(get("/notices")
+                        .param("page", "1")
+                        .param("size", "-10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 공지사항 작성 기능 구현
- [x] 예외 처리 구현
    - [x] Role이 Admin이 아닐 경우
    - [x] 공지사항 제목이 100자 초과 또는 공백일 경우
    - [x] 공지사항 내용이 2000자 초과 또는 공백일 경우
- [x] 단위 테스트 작성 및 통과

## 💡 자세한 설명
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/6f4146dd-7d2b-4351-9795-0e7a82777f6e)
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/1f400a14-232c-45d9-930e-c12b3c0a2723)

~~Notice 엔티티에서 제약 조건으로 걸리는 항목들을 NoticeRequest에서 예외 처리하도록 구현했습니다.
엔티티 자체에서 예외가 처리되게 하거나 핸들링하게 되면, PK_id 값을 예외가 발생할 때 마다 건너뛰게 되므로 위와 같이 구현했습니다.~~

조건문으로 처리하던 제약 조건을 DTO에 어노테이션을 추가하고, `ConstraintExceptionHandler` 클래스를 만들어 핸들링하게 수정했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
1. 엔티티 자체에서 예외가 처리되고 있는 다른 기능들에 대한 예외 처리가 필요합니다.
2. 현재 공지사항 작성 시 파일 업로드는 구현하지 않았는데, 추후 구현이 필요합니다. (나머지 공지사항 기능 완성 후 구현 예정)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #170 
