### PR TITLE
회원 닉네임 중복 검증 API 추가 및 테스트 코드 작성

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     ALREADY_LIKE_COMMENT(CONFLICT, "이미 추천을 누른 댓글입니다."),
     ALREADY_LIKE_POST(CONFLICT, "이미 추천을 누른 게시글입니다."),
     ALREADY_CANCEL_LIKE_POST(CONFLICT, "이미 추천 취소를 누른 게시글입니다"),
+    ALREADY_REGISTERED_NICKNAME(CONFLICT, "이미 등록된 닉네임입니다."),
 
     // 500
     REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),

--- a/src/main/java/balancetalk/module/member/application/MemberService.java
+++ b/src/main/java/balancetalk/module/member/application/MemberService.java
@@ -117,10 +117,17 @@ public class MemberService {
         }
     }
 
+    public void verifyNickname(String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new BalanceTalkException(ErrorCode.ALREADY_REGISTERED_NICKNAME);
+        }
+    }
+
     private Member extractMember(HttpServletRequest request) {
         String token = jwtTokenProvider.resolveToken(request);
         String email = jwtTokenProvider.getPayload(token);
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
     }
+
 }

--- a/src/main/java/balancetalk/module/member/domain/Member.java
+++ b/src/main/java/balancetalk/module/member/domain/Member.java
@@ -57,7 +57,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @NotNull
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
-    private Role role = Role.USER;
+    private Role role;
 
     @OneToMany(mappedBy = "member")
     private List<Post> posts = new ArrayList<>();

--- a/src/main/java/balancetalk/module/member/domain/MemberRepository.java
+++ b/src/main/java/balancetalk/module/member/domain/MemberRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String username);
+    boolean existsByNickname(String nickname);
     void deleteByEmail(String email);
 }

--- a/src/main/java/balancetalk/module/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/module/member/presentation/MemberController.java
@@ -83,9 +83,9 @@ public class MemberController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @PostMapping("/nickname/verify")
+    @GetMapping("/duplicate")
     @Operation(summary = "닉네임 중복 검증", description = "중복된 닉네임이 존재하는지 체크한다.")
-    public String verifyNickname(@RequestBody String nickname) {
+    public String verifyNickname(@RequestParam String nickname) {
         memberService.verifyNickname(nickname);
         return "사용 가능한 닉네임 입니다.";
     }

--- a/src/main/java/balancetalk/module/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/module/member/presentation/MemberController.java
@@ -81,4 +81,12 @@ public class MemberController {
         memberService.logout();
         return "로그아웃이 정상적으로 처리되었습니다.";
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/nickname/verify")
+    @Operation(summary = "닉네임 중복 검증", description = "중복된 닉네임이 존재하는지 체크한다.")
+    public String verifyNickname(@RequestBody String nickname) {
+        memberService.verifyNickname(nickname);
+        return "사용 가능한 닉네임 입니다.";
+    }
 }

--- a/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
+++ b/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package balancetalk.module.member.application;
 
 import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.jwt.JwtTokenProvider;
 import balancetalk.global.redis.application.RedisService;
 import balancetalk.module.member.domain.Member;
@@ -22,6 +23,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import java.util.List;
@@ -337,5 +339,31 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.logout())
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessage("로그아웃을 위해서는 인증이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 검증 테스트 - 성공")
+    void nickNameDuplicateVerifyTest_Success() {
+        // given
+        String verifyName = "체크할닉네임";
+        when(memberRepository.existsByNickname(verifyName)).thenReturn(false);
+
+        // when
+        memberService.verifyNickname(verifyName);
+
+        // then
+        assertNotEquals(verifyName, member.getNickname());
+    }
+    @Test
+    @DisplayName("닉네임 중복 검증 테스트 - 실패")
+    void nickNameDuplicateVerifyTest_Fail() {
+        // given
+        String verifyName = "멤버1";
+        when(memberRepository.existsByNickname(verifyName)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyNickname(verifyName))
+                .isInstanceOf(BalanceTalkException.class)
+                .hasMessage(ErrorCode.ALREADY_REGISTERED_NICKNAME.getMessage());
     }
 }

--- a/src/test/java/balancetalk/module/post/application/PostServiceTest.java
+++ b/src/test/java/balancetalk/module/post/application/PostServiceTest.java
@@ -1,80 +1,98 @@
 package balancetalk.module.post.application;
 
+import balancetalk.global.redis.application.RedisService;
+import balancetalk.module.file.domain.File;
+import balancetalk.module.file.domain.FileRepository;
+import balancetalk.module.member.domain.Member;
+import balancetalk.module.member.domain.MemberRepository;
+import balancetalk.module.post.domain.*;
+import balancetalk.module.post.dto.BalanceOptionDto;
+import balancetalk.module.post.dto.PostRequest;
+import balancetalk.module.post.dto.PostResponse;
+import balancetalk.module.post.dto.PostTagDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
 
-//@ExtendWith(MockitoExtension.class)
-//class PostServiceTest {
-//
-//    @Mock
-//    MemberRepository memberRepository;
-//
-//    @Mock
-//    PostRepository postRepository;
-//
-//    @Mock
-//    PostLikeRepository postLikeRepository;
-//
-//    @InjectMocks
-//    PostService postService;
-//
-//    @Test
-//    @DisplayName("게시글 작성 테스트")
-//    void createPost_success() {
-//        // given
-//        Member member = Member.builder()
-//                .id(1L)
-//                .build();
-//
-//        FileResponse fileDto = FileResponse.builder()
-//                .uploadName("파일1")
-//                .path("../")
-//                .type(FileType.JPEG)
-//                .size(236L)
-//                .build();
-//
-//        List<PostTagDto> postTagDto = List.of(
-//                PostTagDto.builder()
-//                        .tagName("태그1")
-//                        .build(),
-//                PostTagDto.builder()
-//                        .tagName("태그2")
-//                        .build());
-//
-//        List<BalanceOptionDto> balanceOptionDto = List.of(
-//                BalanceOptionDto.builder()
-//                        .title("제목1")
-//                        .description("섦명 내용")
-//                        .file(fileDto)
-//                        .build(),
-//                BalanceOptionDto.builder()
-//                        .title("제목1")
-//                        .description("섦명 내용")
-//                        .file(fileDto)
-//                        .build());
-//
-//        PostRequestDto postRequestDto = PostRequestDto.builder()
-//                .memberId(member.getId())
-//                .title("게시글 생성 테스트")
-//                .balanceOptions(balanceOptionDto)
-//                .tags(postTagDto)
-//                .build();
-//
-//        Post post = postRequestDto.toEntity(member);
-//
-//
-//        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-//        // 생성된 post 객체를 반환하게 설정
-//        when(postRepository.save(any())).thenReturn(post);
-//
-//        // when
-//        Post result = postService.save(postRequestDto);
-//
-//        // then
-//        assertThat(result.getMember().getId()).isEqualTo(member.getId());
-//
-//    }
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    PostRepository postRepository;
+
+    @Mock
+    PostLikeRepository postLikeRepository;
+
+    @Mock
+    FileRepository fileRepository;
+
+    @Mock
+    RedisService redisService;
+
+    @InjectMocks
+    PostService postService;
+
+    private String accessToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0MTIzNDVAbmF2ZXIuY29tIiwiaWF0IjoxNzA5NDc1NTE4LCJleHAiOjE3MDk1MTg3MTh9.ZZXuN4OWM2HZjWOx7Pupl5NkRtjvd4qnK_txGdRy7G5_GdKgnyF3JfiUsenQgxsi1Y_-7C0dA85xabot2m1cag";
+
+    Member member = Member.builder()
+            .id(1L)
+            .email("member@gmail.com")
+            .build();
+
+    File file = File.builder()
+            .storedName("e90a6177-89a1-45b3-91d3-cb39e9bec407_미어캣.jpg")
+            .build();
+    BalanceOption balanceOption = BalanceOption.builder()
+            .title("option1")
+            .description("description1")
+            .file(file)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        // SecurityContext에 인증된 사용자 설정
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+
+    }
+
+    @Test
+    @DisplayName("게시글 작성 성공")
+    void postSaveSuccess() {
+        // given
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+        when(redisService.getValues(member.getEmail())).thenReturn(accessToken);
+
+        List<File> images = new ArrayList<>();
+        images.add(file);
+
+
+
+    }
 //
 //    @Test
 //    @DisplayName("모든 게시글 조회")
@@ -250,4 +268,4 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 //                .isInstanceOf(BalanceTalkException.class)
 //                .hasMessageContaining(ALREADY_LIKE_POST.getMessage());
 //    }
-//}
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 닉네임 검증 기능 구현
- [x] 단위 테스트 추가
- [x] Api 명세서에 추가

## 💡 자세한 설명
회원 닉네임 중복을 체크해주는 기능을 구현하고, 단위 테스트를 추가했습니다.

## 📗 참고 자료 (선택)

![스크린샷 2024-03-09 오전 1 40 34](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/b891bbc6-0631-48a8-9ca2-f58eedac04c7)

![스크린샷 2024-03-09 오전 1 37 18](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/89b8358f-d41a-4513-925a-2e3fd376cfbc)

String 데이터를 하나만 보낼 때는 `JSON`에서 `Text`로 바꿔서 보내야 합니다. 만약에 db에 `멤버` 라는 값이 들어 있을 때, 중복 검사를 하기 위해서 JSON 형태로 `"멤버"` 값을 보내주면 따옴표 때문에 인식을 하지 못하는 문제가 발생합니다.

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #177 
