### PR TITLE
게시글 조회 API에 조회수 증가 로직 추가

### DIFF
--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -62,7 +62,7 @@ public class PostService {
                 .toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PostResponse> findAll(String token) {
         // TODO: 검색, 정렬, 마감 기능 추가
         List<Post> posts = postRepository.findAll();

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -9,6 +9,7 @@ import balancetalk.module.file.domain.File;
 import balancetalk.module.file.domain.FileRepository;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.MemberRepository;
+import balancetalk.module.member.domain.Role;
 import balancetalk.module.post.domain.*;
 import balancetalk.module.post.dto.BalanceOptionDto;
 import balancetalk.module.post.dto.PostRequest;
@@ -61,7 +62,7 @@ public class PostService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public List<PostResponse> findAll(String token) {
         // TODO: 검색, 정렬, 마감 기능 추가
         List<Post> posts = postRepository.findAll();
@@ -76,13 +77,17 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public PostResponse findById(Long postId, String token) {
         Post post = getCurrentPost(postId);
         if (token == null) {
+            post.increaseViews();
             return PostResponse.fromEntity(post, false, false);
         }
         Member member = getCurrentMember(memberRepository);
+        if (member.getRole() == Role.USER) {
+             post.increaseViews();
+        }
         return PostResponse.fromEntity(post, member.hasLiked(post), member.hasBookmarked(post));
     }
 

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,12 +33,12 @@ public class PostService {
     private final RedisService redisService;
 
     public PostResponse save(final PostRequest request) {
-        Member member = getMember(request);
-        if (redisService.getValues(member.getEmail()) == null) {
+        Member writer = getCurrentMember(memberRepository);
+        if (redisService.getValues(writer.getEmail()) == null) {
             throw new BalanceTalkException(FORBIDDEN_POST_CREATE);
         }
         List<File> images = getImages(request);
-        Post post = request.toEntity(member, images);
+        Post post = request.toEntity(writer, images);
 
         List<BalanceOption> options = post.getOptions();
         for (BalanceOption option : options) {
@@ -50,12 +49,7 @@ public class PostService {
             postTag.addPost(post);
         }
 
-        return PostResponse.fromEntity(postRepository.save(post), member);
-    }
-
-    private Member getMember(PostRequest postRequestDto) {
-        return memberRepository.findById(postRequestDto.getMemberId())
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
+        return PostResponse.fromEntity(postRepository.save(post), false, false);
     }
 
     private List<File> getImages(PostRequest postRequestDto) {
@@ -68,23 +62,28 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponse> findAll(Long memberId) {
+    public List<PostResponse> findAll(String token) {
         // TODO: 검색, 정렬, 마감 기능 추가
         List<Post> posts = postRepository.findAll();
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
+        if (token == null) {
+            return posts.stream()
+                    .map(post -> PostResponse.fromEntity(post, false, false))
+                    .collect(Collectors.toList());
+        }
+        Member member = getCurrentMember(memberRepository);
         return posts.stream()
-                .map(post -> PostResponse.fromEntity(post, member))
+                .map(post -> PostResponse.fromEntity(post, member.hasLiked(post), member.hasBookmarked(post)))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public PostResponse findById(Long postId, Long memberId) {
+    public PostResponse findById(Long postId, String token) {
         Post post = getCurrentPost(postId);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
-
-        return PostResponse.fromEntity(post, member);
+        if (token == null) {
+            return PostResponse.fromEntity(post, false, false);
+        }
+        Member member = getCurrentMember(memberRepository);
+        return PostResponse.fromEntity(post, member.hasLiked(post), member.hasBookmarked(post));
     }
 
     @Transactional

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -97,4 +97,8 @@ public class Post extends BaseTimeEntity {
     public boolean hasDeadlineExpired() {
         return deadline.isBefore(LocalDateTime.now());
     }
+
+    public void increaseViews() {
+        views++;
+    }
 }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -1,6 +1,5 @@
 package balancetalk.module.post.dto;
 
-import balancetalk.module.member.domain.Member;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -49,15 +48,15 @@ public class PostResponse {
     private String createdBy;
 
     // todo: ProfilePhoto 추가
-    public static PostResponse fromEntity(Post post, Member member) {
+    public static PostResponse fromEntity(Post post, boolean myLike, boolean myBookmark) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .deadline(post.getDeadline())
                 .views(post.getViews())
                 .likesCount(post.likesCount())
-                .myLike(member.hasLiked(post))
-                .myBookmark(member.hasBookmarked(post))
+                .myLike(myLike)
+                .myBookmark(myBookmark)
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -36,7 +36,7 @@ public class PostController {
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "post-id에 해당하는 게시글을 조회한다.")
     public PostResponse findPost(@PathVariable("postId") Long postId,
-                                 @RequestHeader("Authorization") String token) {
+                                 @RequestHeader(value = "Authorization", required = false) String token) {
         return postService.findById(postId, token);
     }
 

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -28,16 +28,16 @@ public class PostController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     @Operation(summary = "모든 게시글 조회", description = "해당 회원이 쓴 모든 글을 조회한다.")
-    public List<PostResponse> findAllPosts(@RequestParam("member-id") Long memberId) {
-        return postService.findAll(memberId);
+    public List<PostResponse> findAllPosts(@RequestHeader(value = "Authorization", required = false) String token) {
+        return postService.findAll(token);
     }
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "post-id에 해당하는 게시글을 조회한다.")
     public PostResponse findPost(@PathVariable("postId") Long postId,
-                                 @RequestParam("member-id") Long memberId) {
-        return postService.findById(postId, memberId);
+                                 @RequestHeader("Authorization") String token) {
+        return postService.findById(postId, token);
     }
 
     @ResponseStatus(HttpStatus.CREATED)


### PR DESCRIPTION
## 💡 작업 내용
- [x] memberId를 통해 회원을 조회하던 기존 로직을 JWT를 사용하는 로직으로 변경
- [x] 게시글 조회 API에 조회수 증가 로직 추가

## 💡 자세한 설명
<img width="757" alt="스크린샷 2024-03-11 오후 2 21 27" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/110653660/1fea7744-0cd3-4fa5-85df-b2756ac13918">

- 기존의 findById 메서드는 `@Transactional(readOnly = true)`로 되어 있었는데, 조회수가 증가하지 않았습니다. 따라서 readOnly 설정을 제거하였습니다.
- 조회하는 사용자가 ADMIN이 아닌 경우에만 조회수가 증가하도록 구현했습니다.
```java
if (member.getRole() == Role.USER) {
    post.increaseViews();
}
```

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #180 
