### PR TITLE
댓글 응답에 추천 여부 추가 구현 완료

### DIFF
--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -31,13 +31,16 @@ public class CommentResponse {
     @Schema(description = "댓글 추천 수", example = "24")
     private int likeCount;
 
+    @Schema(description = "추천 여부", example = "true")
+    private boolean myLike;
+
     @Schema(description = "댓글 생성 날짜")
     private LocalDateTime createdAt;
 
     @Schema(description = "댓글 수정 날짜")
     private LocalDateTime lastModifiedAt;
 
-    public static CommentResponse fromEntity(Comment comment, Long balanceOptionId) {
+    public static CommentResponse fromEntity(Comment comment, Long balanceOptionId, boolean myLike) {
         return CommentResponse.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
@@ -45,6 +48,7 @@ public class CommentResponse {
                 .postId(comment.getPost().getId())
                 .selectedOptionId(balanceOptionId)
                 .likeCount(comment.getLikes().size())
+                .myLike(myLike)
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())
                 .build();

--- a/src/main/java/balancetalk/module/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/module/comment/presentation/CommentController.java
@@ -62,8 +62,8 @@ public class CommentController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{commentId}/likes")
     @Operation(summary = "댓글 추천", description = "comment-id에 해당하는 댓글에 추천을 누른다.")
-    public String likeComment(@PathVariable Long postId, @PathVariable Long commentId) {
-        commentService.likeComment(postId, commentId);
+    public String likeComment(@PathVariable Long commentId) {
+        commentService.likeComment(commentId);
         return "요청이 정상적으로 처리되었습니다.";
     }
 

--- a/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
+++ b/src/test/java/balancetalk/module/comment/application/CommentServiceTest.java
@@ -280,7 +280,7 @@ class CommentServiceTest {
         when(memberRepository.findByEmail(authenticatedEmail)).thenReturn(Optional.of(member));
 
         // when
-        Long likedCommentId = commentService.likeComment(1L, comment.getId());
+        Long likedCommentId = commentService.likeComment( comment.getId());
 
         // then
         assertThat(likedCommentId).isEqualTo(comment.getId());
@@ -301,7 +301,7 @@ class CommentServiceTest {
                 .thenThrow(new BalanceTalkException(ErrorCode.ALREADY_LIKE_COMMENT));
 
         // when, then
-        assertThatThrownBy(() -> commentService.likeComment(1L, comment.getId()))
+        assertThatThrownBy(() -> commentService.likeComment(comment.getId()))
                 .isInstanceOf(BalanceTalkException.class)
                 .hasMessageContaining(ErrorCode.ALREADY_LIKE_COMMENT.getMessage());
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 조회 시 추천 여부(myLike) 필드도 함께 응답하도록 수정
- [x] 회원/비회원 구분하여 댓글 조회하도록 로직 수정
- [x] 포스트맨을 통해 API 테스트

## 💡 자세한 설명
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/cd825c37-63b9-42b9-9968-c0ad6ac20c13)
`try-catch` `getCurrentMember()` 사용 시의 문으로 회원과 비회원 상태를 구분했습니다.

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/c82b4574-3764-4628-80d7-9ae875d5c3fb)
댓글에 추천을 한 후 댓글 조회 시, 토큰으로 사용자 확인이 될 경우 `myLike` 는 `true`
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/30e575d4-81b2-44aa-9a20-4aff9082fb79)
비회원으로 댓글 조회 시 `myLike` 는 `false`

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
1. 추후 테스트코드 작성 필요

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #189 
