### PR TITLE
게시글 조회 시 balanceOptionId를 응답하도록 구현 완료

### DIFF
--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
@@ -15,6 +15,9 @@ import org.springframework.lang.Nullable;
 @AllArgsConstructor
 public class BalanceOptionDto {
 
+    @Schema(description = "선택지 id", example = "1")
+    private Long balanceOptionId;
+
     @Schema(description = "선택지 제목", example = "선택지 제목1")
     private String title;
 
@@ -36,6 +39,7 @@ public class BalanceOptionDto {
 
     public static BalanceOptionDto fromEntity(BalanceOption balanceOption) {
         BalanceOptionDtoBuilder builder = BalanceOptionDto.builder()
+                .balanceOptionId(balanceOption.getId())
                 .title(balanceOption.getTitle())
                 .description(balanceOption.getDescription());
         if (balanceOption.getFile() != null) {


### PR DESCRIPTION
## 💡 작업 내용
- [x] `BalanceOptionDto` 에서 `balanceOptionId` 반환 구현
- [x] Postman으로 API 테스트

##![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/f3ea4519-8875-46b3-840e-5435324e0a9f)
게시글 작성 또는 조회 시 응답에서 balanceOptionId 반환 확인 완료했습니다.

응답 시 기존에 존재하던 id(게시글 id) 필드와의 구분을 위해 balanceOptionId 로 네이밍했습니다.
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #194 
