### PR TITLE
게시글 응답 DTO에 투표 여부 추가

### DIFF
--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
             postTag.addPost(post);
         }
 
-        return PostResponse.fromEntity(postRepository.save(post), false, false);
+        return PostResponse.fromEntity(postRepository.save(post), false, false, false);
     }
 
     private List<File> getImages(PostRequest postRequestDto) {
@@ -68,12 +68,15 @@ public class PostService {
         List<Post> posts = postRepository.findAll();
         if (token == null) {
             return posts.stream()
-                    .map(post -> PostResponse.fromEntity(post, false, false))
+                    .map(post -> PostResponse.fromEntity(post, false, false, false))
                     .collect(Collectors.toList());
         }
         Member member = getCurrentMember(memberRepository);
         return posts.stream()
-                .map(post -> PostResponse.fromEntity(post, member.hasLiked(post), member.hasBookmarked(post)))
+                .map(post -> PostResponse.fromEntity(post,
+                        member.hasLiked(post),
+                        member.hasBookmarked(post),
+                        member.hasVoted(post)))
                 .collect(Collectors.toList());
     }
 
@@ -82,13 +85,13 @@ public class PostService {
         Post post = getCurrentPost(postId);
         if (token == null) {
             post.increaseViews();
-            return PostResponse.fromEntity(post, false, false);
+            return PostResponse.fromEntity(post, false, false, false);
         }
         Member member = getCurrentMember(memberRepository);
         if (member.getRole() == Role.USER) {
              post.increaseViews();
         }
-        return PostResponse.fromEntity(post, member.hasLiked(post), member.hasBookmarked(post));
+        return PostResponse.fromEntity(post, member.hasLiked(post), member.hasBookmarked(post), member.hasVoted(post));
     }
 
     @Transactional

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -36,6 +36,9 @@ public class PostResponse {
     @Schema(description = "북마크 여부", example = "false")
     private boolean myBookmark;
 
+    @Schema(description = "투표 여부", example = "true")
+    private boolean myVote;
+
     @Schema(description = "게시글 카테고리", example = "CASUAL")
     private PostCategory category;
 
@@ -51,7 +54,7 @@ public class PostResponse {
     private String createdBy;
 
     // todo: ProfilePhoto 추가
-    public static PostResponse fromEntity(Post post, boolean myLike, boolean myBookmark) {
+    public static PostResponse fromEntity(Post post, boolean myLike, boolean myBookmark, boolean myVote) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -60,6 +63,7 @@ public class PostResponse {
                 .likesCount(post.likesCount())
                 .myLike(myLike)
                 .myBookmark(myBookmark)
+                .myVote(myVote)
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 응답 DTO에 투표 여부 추가

## 💡 자세한 설명
프론트엔드에서 요청하여 게시글 응답 DTO에 투표 여부를 추가했습니다.
회원이 조회한 경우에만 동작하며, 투표한 이력이 있는 게시글일 경우 true를 반환합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #197 
