### PR TITLE
시큐리티 인증 URL 추가 및 에러 처리 추가

### DIFF
--- a/src/main/java/balancetalk/global/config/SecurityConfig.java
+++ b/src/main/java/balancetalk/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import balancetalk.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,6 +25,26 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    private static final String[] PUBLIC_GET = {
+            // h2 database
+            "/h2-console/**",
+            // swagger
+            "/swagger-ui/**", "/v3/api-docs/**",
+            "/members/duplicate",
+            "/posts", "/posts/{postId}", "/posts/{postId}/vote", "/posts/{postId}/comments",
+            "/notices", "/notices/{noticeId}"
+    };
+
+    private static final String[] PUBLIC_POST = {
+            "/members/join", "/members/login",
+            "/email/request", "/email/verify",
+            "/posts/{postId}/vote"
+    };
+
+    private static final String[] PUBLIC_PUT = {
+            "/posts/{postId}/vote"
+    };
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -48,7 +69,9 @@ public class SecurityConfig {
                 // 세션 사용 X (jwt 사용)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/**", "/h2-console/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, PUBLIC_GET).permitAll()
+                        .requestMatchers(HttpMethod.POST, PUBLIC_POST).permitAll()
+                        .requestMatchers(HttpMethod.PUT, PUBLIC_PUT).permitAll()
                         .anyRequest().authenticated()
                 )
                 // jwtFilter 먼저 적용

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -21,13 +21,12 @@ public enum ErrorCode {
     MIME_TYPE_NULL(BAD_REQUEST, "MIME 타입이 null입니다."),
     FILE_UPLOAD_FAILED(BAD_REQUEST, "파일 업로드에 실패했습니다."),
     FILE_SIZE_EXCEEDED(BAD_REQUEST, "파일 크기가 초과되었습니다."),
-    EXPIRED_JWT_TOKEN(BAD_REQUEST, "만료된 토큰 입니다."),
-    INVALID_JWT_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
     EXCEED_MAX_DEPTH(BAD_REQUEST, "답글에 답글을 달 수 없습니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
     PAGE_NUMBER_ZERO(BAD_REQUEST, "페이지 번호는 0보다 커야합니다."),
     PAGE_SIZE_ZERO(BAD_REQUEST, "페이지 사이즈는 0보다 커야합니다."),
     EXCEED_VALIDATION_LENGTH(BAD_REQUEST, "입력값이 제약 조건에 맞지 않습니다."),
+    INVALID_JWT_TOKEN(BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
@@ -35,6 +34,9 @@ public enum ErrorCode {
     BAD_CREDENTIAL_ERROR(UNAUTHORIZED, "로그인에 실패했습니다."),
     UNAUTHORIZED_LOGOUT(UNAUTHORIZED, "로그아웃을 위해서는 인증이 필요합니다."),
     UNAUTHORIZED_CREATE_NOTICE(UNAUTHORIZED, "공지사항 작성 권한이 없습니다."),
+    VERIFY_CODE_MISMATCH(UNAUTHORIZED, "인증 번호가 일치하지 않습니다."),
+    EXPIRED_JWT_TOKEN(UNAUTHORIZED, "만료된 토큰 입니다."),
+
 
     // 403
     FORBIDDEN_POST_DELETE(FORBIDDEN, "해당 게시글은 삭제 권한이 없습니다."),
@@ -64,11 +66,10 @@ public enum ErrorCode {
     ALREADY_LIKE_POST(CONFLICT, "이미 추천을 누른 게시글입니다."),
     ALREADY_CANCEL_LIKE_POST(CONFLICT, "이미 추천 취소를 누른 게시글입니다"),
     ALREADY_REGISTERED_NICKNAME(CONFLICT, "이미 등록된 닉네임입니다."),
+    ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요"),
 
     // 500
-    REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),
-    DUPLICATE_EMAIL(INTERNAL_SERVER_ERROR, "이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요"),
-    AUTHORIZATION_CODE_MISMATCH(INTERNAL_SERVER_ERROR, "인증 번호가 일치하지 않습니다.");
+    REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -70,8 +70,8 @@ public enum ErrorCode {
     ALREADY_CANCEL_LIKE_POST(CONFLICT, "이미 추천 취소를 누른 게시글입니다"),
     ALREADY_REGISTERED_NICKNAME(CONFLICT, "이미 등록된 닉네임입니다."),
     ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요."),
-    NO_CHANGE_NICKNAME(CONFLICT, "변경하려는 닉네임이 현재와 동일합니다. 다른 닉네임을 입력해주세요."),
-    NO_CHANGE_PASSWORD(CONFLICT, "변경하려는 비밀번호가 현재와 동일합니다. 다른 비밀번호를 입력해주세요."),
+    SAME_NICKNAME(CONFLICT, "변경하려는 닉네임이 현재와 동일합니다. 다른 닉네임을 입력해주세요."),
+    SAME_PASSWORD(CONFLICT, "변경하려는 비밀번호가 현재와 동일합니다. 다른 비밀번호를 입력해주세요."),
 
 
     // 500

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
     AUTHENTICATION_ERROR(UNAUTHORIZED, "인증 오류가 발생했습니다."),
     BAD_CREDENTIAL_ERROR(UNAUTHORIZED, "로그인에 실패했습니다."),
-    UNAUTHORIZED_LOGOUT(UNAUTHORIZED, "로그아웃을 위해서는 인증이 필요합니다."),
+    LOGIN_REQUIRED(UNAUTHORIZED, "로그인 하시길 바랍니다."),
     UNAUTHORIZED_CREATE_NOTICE(UNAUTHORIZED, "공지사항 작성 권한이 없습니다."),
     VERIFY_CODE_MISMATCH(UNAUTHORIZED, "인증 번호가 일치하지 않습니다."),
     EXPIRED_JWT_TOKEN(UNAUTHORIZED, "만료된 토큰 입니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
     AUTHENTICATION_ERROR(UNAUTHORIZED, "인증 오류가 발생했습니다."),
     BAD_CREDENTIAL_ERROR(UNAUTHORIZED, "로그인에 실패했습니다."),
-    LOGIN_REQUIRED(UNAUTHORIZED, "로그인 하시길 바랍니다."),
+    AUTHENTICATION_REQUIRED(UNAUTHORIZED, "인증이 필요합니다."),
     UNAUTHORIZED_CREATE_NOTICE(UNAUTHORIZED, "공지사항 작성 권한이 없습니다."),
     VERIFY_CODE_MISMATCH(UNAUTHORIZED, "인증 번호가 일치하지 않습니다."),
     EXPIRED_JWT_TOKEN(UNAUTHORIZED, "만료된 토큰 입니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -66,7 +66,10 @@ public enum ErrorCode {
     ALREADY_LIKE_POST(CONFLICT, "이미 추천을 누른 게시글입니다."),
     ALREADY_CANCEL_LIKE_POST(CONFLICT, "이미 추천 취소를 누른 게시글입니다"),
     ALREADY_REGISTERED_NICKNAME(CONFLICT, "이미 등록된 닉네임입니다."),
-    ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요"),
+    ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요."),
+    NO_CHANGE_NICKNAME(CONFLICT, "변경하려는 닉네임이 현재와 동일합니다. 다른 닉네임을 입력해주세요."),
+    NO_CHANGE_PASSWORD(CONFLICT, "변경하려는 비밀번호가 현재와 동일합니다. 다른 비밀번호를 입력해주세요."),
+
 
     // 500
     REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다.");

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     PAGE_NUMBER_ZERO(BAD_REQUEST, "페이지 번호는 0보다 커야합니다."),
     PAGE_SIZE_ZERO(BAD_REQUEST, "페이지 사이즈는 0보다 커야합니다."),
     EXCEED_VALIDATION_LENGTH(BAD_REQUEST, "입력값이 제약 조건에 맞지 않습니다."),
-    INVALID_JWT_TOKEN(BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
+    EMPTY_JWT_TOKEN(BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
+
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
@@ -36,6 +37,7 @@ public enum ErrorCode {
     UNAUTHORIZED_CREATE_NOTICE(UNAUTHORIZED, "공지사항 작성 권한이 없습니다."),
     VERIFY_CODE_MISMATCH(UNAUTHORIZED, "인증 번호가 일치하지 않습니다."),
     EXPIRED_JWT_TOKEN(UNAUTHORIZED, "만료된 토큰 입니다."),
+    INVALID_JWT_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다"),
 
 
     // 403
@@ -59,6 +61,7 @@ public enum ErrorCode {
     NOT_FOUND_PARENT_COMMENT(NOT_FOUND, "존재하지 않는 원 댓글입니다."),
     NOT_FOUND_COMMENT_AT_THAT_POST(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
     NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
+
 
     // 409
     ALREADY_VOTE(CONFLICT, "이미 투표한 게시글입니다."),

--- a/src/main/java/balancetalk/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/balancetalk/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package balancetalk.global.jwt;
 
+import balancetalk.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,11 +10,24 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("application/json");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> jsonMessage = new HashMap<>();
+
+        jsonMessage.put("httpStatus", "UNAUTHORIZED");
+        jsonMessage.put("message", ErrorCode.AUTHENTICATION_REQUIRED.getMessage());
+        String result = objectMapper.writeValueAsString(jsonMessage);
+
+        response.getWriter().write(result);
     }
 }

--- a/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,5 @@
 package balancetalk.global.jwt;
 
-import balancetalk.global.exception.BalanceTalkException;
-import balancetalk.global.exception.ErrorCode;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -10,11 +7,11 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
 import java.io.IOException;
+
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {

--- a/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             SecurityContextHolder.clearContext();
             throw new BalanceTalkException(ErrorCode.REDIS_CONNECTION_FAIL);
         } catch (ExpiredJwtException e) {
-            log.error(e.getMessage());
             throw new BalanceTalkException(ErrorCode.EXPIRED_JWT_TOKEN);
         }
         chain.doFilter(request, response);

--- a/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
@@ -24,17 +24,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
-
         try {
             if (token != null && jwtTokenProvider.validateToken(token)) {
                 Authentication auth = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
-        } catch (RedisConnectionFailureException e) {
-            SecurityContextHolder.clearContext();
-            throw new BalanceTalkException(ErrorCode.REDIS_CONNECTION_FAIL);
-        } catch (ExpiredJwtException e) {
-            throw new BalanceTalkException(ErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (Exception e) {
+            request.setAttribute("exception" , e.getMessage());
         }
         chain.doFilter(request, response);
     }

--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -78,52 +78,35 @@ public class JwtTokenProvider {
         UserDetails userDetails = userDetailsService.loadUserByUsername(userPrincipal);
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-
     }
 
-    // http 헤더로부터 bearer 토큰 가져옴
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7); // 실제 토큰만 추출
+            return bearerToken.substring(7);
         }
         return null;
     }
 
-
     public String getPayload(String token) {
-        return tokenToJws(token).getBody().getSubject();
+        validateToken(token);
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody().getSubject();
     }
 
-    private Jws<Claims> tokenToJws(final String token) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
-        } catch (final IllegalArgumentException | MalformedJwtException e) {
-            throw new IllegalArgumentException("Token이 null이거나 Token 파싱 오류");
-        } catch (final SignatureException e) {
-            throw new IllegalArgumentException("토큰의 시크릿 키가 일치하지 않습니다.");
-        } catch (final ExpiredJwtException e) {
-            throw new IllegalArgumentException("만료된 토큰 입니다.");
-        }
-    }
-
-    // 토큰 유효성, 만료일자 확인
     public boolean validateToken(String token) {
         try {
             Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException e) {
-            log.error(e.getMessage());
-            throw new IllegalArgumentException("토큰 만료");
-        } catch (JwtException e) {
-            log.error(e.getMessage());
-            throw new IllegalArgumentException("유효하지 않은 JWT");
+            throw new BalanceTalkException(ErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (IllegalArgumentException | MalformedJwtException e) {
+            throw new BalanceTalkException(ErrorCode.INVALID_JWT_TOKEN);
         }
     }
 
     private void validateAuthentication(Authentication authentication) {
         if (authentication == null) {
-            throw new IllegalArgumentException("유저 정보가 존재하지 않습니다.");
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER);
         }
     }
 

--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.redis.application.RedisService;
 import balancetalk.module.member.dto.TokenDto;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -100,6 +101,8 @@ public class JwtTokenProvider {
         } catch (ExpiredJwtException e) {
             throw new BalanceTalkException(ErrorCode.EXPIRED_JWT_TOKEN);
         } catch (IllegalArgumentException | MalformedJwtException e) {
+            throw new BalanceTalkException(ErrorCode.EMPTY_JWT_TOKEN);
+        } catch (SignatureException e) {
             throw new BalanceTalkException(ErrorCode.INVALID_JWT_TOKEN);
         }
     }

--- a/src/main/java/balancetalk/global/jwt/JwtUtils.java
+++ b/src/main/java/balancetalk/global/jwt/JwtUtils.java
@@ -1,6 +1,0 @@
-package balancetalk.global.jwt;
-
-public class JwtUtils {
-
-    // TODO: static으로 메서드 선언 & member 조회 까지
-}

--- a/src/main/java/balancetalk/module/authmail/application/MailService.java
+++ b/src/main/java/balancetalk/module/authmail/application/MailService.java
@@ -68,13 +68,13 @@ public class MailService {
         String redisValue = redisService.getValues(request.getEmail());
         Optional.ofNullable(redisValue)
                 .filter(code -> code.equals(request.getVerificationCode()))
-                .orElseThrow(() -> new BalanceTalkException(ErrorCode.AUTHORIZATION_CODE_MISMATCH));
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.VERIFY_CODE_MISMATCH));
     }
 
     private void validateEmail(String email) {
         Optional<Member> member = memberRepository.findByEmail(email);
         if (member.isPresent()) {
-            throw new BalanceTalkException(ErrorCode.DUPLICATE_EMAIL);
+            throw new BalanceTalkException(ErrorCode.ALREADY_REGISTERED_EMAIL);
         }
     }
 }

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -29,7 +29,7 @@ public class CommentResponse {
     private Long selectedOptionId;
 
     @Schema(description = "댓글 추천 수", example = "24")
-    private int likeCount;
+    private int likesCount;
 
     @Schema(description = "댓글 생성 날짜")
     private LocalDateTime createdAt;
@@ -44,7 +44,7 @@ public class CommentResponse {
                 .memberName(comment.getMember().getNickname())
                 .postId(comment.getPost().getId())
                 .selectedOptionId(balanceOptionId)
-                .likeCount(comment.getLikes().size())
+                .likesCount(comment.getLikes().size())
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())
                 .build();

--- a/src/main/java/balancetalk/module/member/application/MemberService.java
+++ b/src/main/java/balancetalk/module/member/application/MemberService.java
@@ -78,7 +78,6 @@ public class MemberService {
 
     @Transactional
     public void updateNickname(final String newNickname, HttpServletRequest request) {
-        isUserLoggedIn();
         Member member = extractMember(request);
         if (member.getNickname().equals(newNickname)) {
             throw new BalanceTalkException(ErrorCode.NO_CHANGE_NICKNAME);
@@ -88,7 +87,6 @@ public class MemberService {
 
     @Transactional
     public void updatePassword(final String newPassword, HttpServletRequest request) {
-        isUserLoggedIn();
         Member member = extractMember(request);
         if (passwordEncoder.matches(newPassword, member.getPassword())){
             throw new BalanceTalkException(ErrorCode.NO_CHANGE_PASSWORD);
@@ -98,7 +96,6 @@ public class MemberService {
 
     @Transactional
     public void delete(final LoginRequest loginRequest, HttpServletRequest request) {
-        isUserLoggedIn();
         Member member = extractMember(request);
         if (!member.getEmail().equals(loginRequest.getEmail())) {
             throw new BalanceTalkException(ErrorCode.FORBIDDEN_MEMBER_DELETE);
@@ -112,7 +109,8 @@ public class MemberService {
 
     @Transactional
     public void logout(){
-        String username = isUserLoggedIn();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
         redisService.deleteValues(username);
     }
 
@@ -120,15 +118,6 @@ public class MemberService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new BalanceTalkException(ErrorCode.ALREADY_REGISTERED_NICKNAME);
         }
-    }
-
-    private String isUserLoggedIn() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String username = authentication.getName();
-        if (redisService.getValues(username) == null) {
-            throw new BalanceTalkException(ErrorCode.LOGIN_REQUIRED);
-        }
-        return username;
     }
 
     private Member extractMember(HttpServletRequest request) {

--- a/src/main/java/balancetalk/module/member/application/MemberService.java
+++ b/src/main/java/balancetalk/module/member/application/MemberService.java
@@ -80,7 +80,7 @@ public class MemberService {
     public void updateNickname(final String newNickname, HttpServletRequest request) {
         Member member = extractMember(request);
         if (member.getNickname().equals(newNickname)) {
-            throw new BalanceTalkException(ErrorCode.NO_CHANGE_NICKNAME);
+            throw new BalanceTalkException(ErrorCode.SAME_NICKNAME);
         }
         member.updateNickname(newNickname);
     }
@@ -89,7 +89,7 @@ public class MemberService {
     public void updatePassword(final String newPassword, HttpServletRequest request) {
         Member member = extractMember(request);
         if (passwordEncoder.matches(newPassword, member.getPassword())){
-            throw new BalanceTalkException(ErrorCode.NO_CHANGE_PASSWORD);
+            throw new BalanceTalkException(ErrorCode.SAME_PASSWORD);
         }
         member.updatePassword(passwordEncoder.encode(newPassword));
     }

--- a/src/main/java/balancetalk/module/member/application/MemberService.java
+++ b/src/main/java/balancetalk/module/member/application/MemberService.java
@@ -73,12 +73,18 @@ public class MemberService {
     @Transactional
     public void updateNickname(final String newNickname, HttpServletRequest request) {
         Member member = extractMember(request);
+        if (member.getNickname().equals(newNickname)) {
+            throw new BalanceTalkException(ErrorCode.NO_CHANGE_NICKNAME);
+        }
         member.updateNickname(newNickname);
     }
 
     @Transactional
     public void updatePassword(final String newPassword, HttpServletRequest request) {
         Member member = extractMember(request);
+        if (passwordEncoder.matches(newPassword, member.getPassword())){
+            throw new BalanceTalkException(ErrorCode.NO_CHANGE_PASSWORD);
+        }
         member.updatePassword(passwordEncoder.encode(newPassword));
     }
 

--- a/src/main/java/balancetalk/module/member/domain/MemberRepository.java
+++ b/src/main/java/balancetalk/module/member/domain/MemberRepository.java
@@ -5,5 +5,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String username);
     boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
     void deleteByEmail(String email);
 }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -39,8 +39,11 @@ public class PostResponse {
     @Schema(description = "게시글 카테고리", example = "CASUAL")
     private PostCategory category;
 
+    @Schema(description = "선택지 옵션 리스트", example = "[{\"title\": \"선택지 제목1\", \"description\": \"선택지 내용1\" , \"storedFileName\": null}," +
+            "{\"title\": \"선택지 제목2\", \"description\": \"선택지 내용2\", \"storedFileName\": null}]")
     private List<BalanceOptionDto> balanceOptions;
 
+    @Schema(description = "태그 리스트", example = "[\"태그1\", \"태그2\", \"태그3\"]")
     private List<PostTagDto> postTags;
 
     @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")

--- a/src/main/java/balancetalk/module/vote/application/VoteService.java
+++ b/src/main/java/balancetalk/module/vote/application/VoteService.java
@@ -1,9 +1,9 @@
 package balancetalk.module.vote.application;
 
 import static balancetalk.global.exception.ErrorCode.*;
+import static balancetalk.global.utils.SecurityUtils.*;
 
 import balancetalk.global.exception.BalanceTalkException;
-import balancetalk.global.utils.SecurityUtils;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.MemberRepository;
 import balancetalk.module.post.domain.BalanceOption;
@@ -59,7 +59,7 @@ public class VoteService {
     }
 
     private Vote voteForMember(VoteRequest voteRequest, Post post, BalanceOption balanceOption) {
-        Member member = SecurityUtils.getCurrentMember(memberRepository);
+        Member member = getCurrentMember(memberRepository);
 
         if (member.hasVoted(post)) {
             throw new BalanceTalkException(ALREADY_VOTE);
@@ -96,7 +96,7 @@ public class VoteService {
             throw new BalanceTalkException(UNMODIFIABLE_VOTE);
         }
         BalanceOption newSelectedOption = getBalanceOption(voteRequest);
-        Member member = SecurityUtils.getCurrentMember(memberRepository);
+        Member member = getCurrentMember(memberRepository);
         Vote participatedVote = getParticipatedVote(post, member);
 
         return participatedVote.changeBalanceOption(newSelectedOption);

--- a/src/test/java/balancetalk/module/authmail/application/MailServiceTest.java
+++ b/src/test/java/balancetalk/module/authmail/application/MailServiceTest.java
@@ -1,6 +1,7 @@
 package balancetalk.module.authmail.application;
 
 import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.redis.application.RedisService;
 import balancetalk.module.authmail.dto.EmailRequest;
 import balancetalk.module.authmail.dto.EmailVerification;
@@ -76,7 +77,7 @@ class MailServiceTest {
         // when, then
         assertThatThrownBy(() -> mailService.verifyCode(request))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("인증 번호가 일치하지 않습니다.");
+                .hasMessage(ErrorCode.VERIFY_CODE_MISMATCH.getMessage());
     }
 
     @Test
@@ -94,6 +95,6 @@ class MailServiceTest {
         // when, then
         assertThatThrownBy(() -> mailService.sendMail(requestDto))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("이미 존재하는 이메일 입니다. 다른 이메일을 입력해주세요");
+                .hasMessage(ErrorCode.ALREADY_REGISTERED_EMAIL.getMessage());
     }
 }

--- a/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
+++ b/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
@@ -341,7 +341,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> memberService.logout())
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage(ErrorCode.LOGIN_REQUIRED.getMessage());
+                .hasMessage(ErrorCode.AUTHENTICATION_REQUIRED.getMessage());
     }
 
     @Test

--- a/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
+++ b/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
@@ -341,7 +341,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> memberService.logout())
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage(ErrorCode.UNAUTHORIZED_LOGOUT.getMessage());
+                .hasMessage(ErrorCode.LOGIN_REQUIRED.getMessage());
     }
 
     @Test

--- a/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
+++ b/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
@@ -137,7 +137,7 @@ class MemberServiceTest {
         loginRequest.setPassword("wrongPassword!");
         assertThatThrownBy(() -> memberService.login(loginRequest))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("이메일 또는 비밀번호가 잘못되었습니다.");
+                .hasMessage(ErrorCode.MISMATCHED_EMAIL_OR_PASSWORD.getMessage());
     }
 
     @Test
@@ -146,7 +146,7 @@ class MemberServiceTest {
         loginRequest.setEmail("wrongEmail@gmail.com");
         assertThatThrownBy(() -> memberService.login(loginRequest))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("이메일 또는 비밀번호가 잘못되었습니다.");
+                .hasMessage(ErrorCode.MISMATCHED_EMAIL_OR_PASSWORD.getMessage());
     }
 
     @Test
@@ -169,7 +169,7 @@ class MemberServiceTest {
         when(memberRepository.findById(2L)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> memberService.findById(2L))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("존재하지 않는 회원입니다.");
+                .hasMessage(ErrorCode.NOT_FOUND_MEMBER.getMessage());
     }
 
     @Test
@@ -221,7 +221,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> memberService.updateNickname(newNickname, request))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("존재하지 않는 회원입니다.");
+                .hasMessage(ErrorCode.NOT_FOUND_MEMBER.getMessage());
     }
 
     @Test
@@ -256,7 +256,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> memberService.updatePassword(newPassword, request))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("존재하지 않는 회원입니다.");
+                .hasMessage(ErrorCode.NOT_FOUND_MEMBER.getMessage());
     }
 
     @Test
@@ -292,7 +292,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> memberService.delete(loginRequest, request))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("사용자 탈퇴 권한이 없습니다.");
+                .hasMessage(ErrorCode.FORBIDDEN_MEMBER_DELETE.getMessage());
     }
 
     @Test
@@ -308,7 +308,7 @@ class MemberServiceTest {
         // when
         assertThatThrownBy(() -> memberService.delete(loginRequest, request))
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("이메일 또는 비밀번호가 잘못되었습니다.");
+                .hasMessage(ErrorCode.MISMATCHED_EMAIL_OR_PASSWORD.getMessage());
     }
 
     @Test
@@ -341,7 +341,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> memberService.logout())
                 .isInstanceOf(BalanceTalkException.class)
-                .hasMessage("로그아웃을 위해서는 인증이 필요합니다.");
+                .hasMessage(ErrorCode.UNAUTHORIZED_LOGOUT.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## 💡 작업 내용
- [x] 예외 처리 테스트에서 메세지를 비교할때 문자열에서 enum 에러 코드로 변경
- [x] 인증이 필요하지 않은 API들을 시큐리티 config에서 관리
- [x] swagger에서 이중 배열로 나타나던 문제 해결
- [x] 시큐리티 미 인증시 클라이언트에 `httpStatus` 와 `message` 전달 

## 💡 자세한 설명
![스크린샷 2024-03-15 오전 1 28 14](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/ecd1c2db-c855-41f6-815b-0ef3d671fcf6)

이전에 `hasMessage` 에서 String 메세지를 입력했는데, enum의 에러 메세지를 가져오는 형태로 수정헀습니다.

![스크린샷 2024-03-15 오전 1 34 50](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/6364b1d7-dde8-4bdc-821c-45b51446fe71)




![스크린샷 2024-03-15 오전 1 30 45](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/cd7bebcc-2d09-446c-8d2e-d74cca104b23)

인증이 필요하지 않은 URL에 대해서만 접근 가능하게 설정하고, 이외의 URL에 대해서는 미인증 시 접근 불가능하게 설정했습니다.




![스크린샷 2024-03-15 오전 1 34 50](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/91831263-5e95-45e7-af32-17244ab517cb)


이전에 토큰이 만료된 경우에 서버쪽에선 에러 메세지가 정상적으로 출력이 되었지만, 클라이언트엔 단순히 500 Internal Server Error라고 표기되어 어떠한 에러인지 알 수 없었습니다.

위 에러는 스프링 시큐리티에서 발생한 에러이기 때문에, 기존에 에러 메세지를 던지던 `@RestControllerAdvice` 에서 처리가 불가능하고, 시큐리티 필터 로직에서 에러를 처리해야 했습니다.


```java
@Component
public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
    @Override
    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
        response.setCharacterEncoding("utf-8");
        response.setContentType("application/json");

        ObjectMapper objectMapper = new ObjectMapper();
        Map<String, Object> jsonMessage = new HashMap<>();

        jsonMessage.put("httpStatus", "UNAUTHORIZED");
        jsonMessage.put("message", ErrorCode.AUTHENTICATION_REQUIRED.getMessage());
        String result = objectMapper.writeValueAsString(jsonMessage);

        response.getWriter().write(result);
    }
}
```

EntryPoint 에서 에러 메세지를 `JSON` 형태로 바꾸어서 보내주고,

``` java
@Bean
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .csrf(csrf -> csrf.disable())
                .cors(cors -> cors.disable())
                .exceptionHandling(exception -> {
                    exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
                    exception.accessDeniedHandler(jwtAccessDeniedHandler);
                })
...
```

필터에서 예외를 handling 하도록 설정했습니다.

![스크린샷 2024-03-15 오전 1 33 30](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/9626b738-69b0-4ccc-9f1c-39530921fea5)

성공적으로 클라이언트에 HttpStatus와 message를 확인할 수 있었습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #184 
