### PR TITLE
인기 게시글 조회 기능 구현

### DIFF
--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -36,7 +36,6 @@ public class PostService {
     private final FileRepository fileRepository;
     private final RedisService redisService;
 
-
     public PostResponse save(final PostRequest request) {
         Member writer = getCurrentMember(memberRepository);
         if (redisService.getValues(writer.getEmail()) == null) {

--- a/src/main/java/balancetalk/module/post/domain/PostRepository.java
+++ b/src/main/java/balancetalk/module/post/domain/PostRepository.java
@@ -1,5 +1,17 @@
 package balancetalk.module.post.domain;
 
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("select p "
+            + "from Post p left join p.likes l "
+            + "where p.deadline > current_timestamp "
+            + "and function('month', p.createdAt) = function('month', current_timestamp) "
+            + "group by p.id "
+            + "order by count(l) desc, p.views desc")
+    List<Post> findBestPosts(Pageable pageable);
 }

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -40,6 +40,13 @@ public class PostController {
         return postService.findById(postId, token);
     }
 
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/best")
+    @Operation(summary = "인기 게시글 조회", description = "월별 추천 수가 가장 많은 게시글 5개를 조회한다.")
+    public List<PostResponse> findBestPosts(@RequestHeader(value = "Authorization", required = false) String token) {
+        return postService.findBestPosts(token);
+    }
+
     @ResponseStatus(HttpStatus.CREATED)
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "post-id에 해당하는 게시글을 삭제한다.")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 인기 게시글 조회 기능 구현

## 💡 자세한 설명
작성일 기준 월간 추천 수가 높은 게시글 순으로 상위 최대 5개를 조회하도록 했습니다.
만약 추천 수가 동일하다면 조회수가 더 높은 게시글 순으로 조회합니다.

```java
@Query("select p "
            + "from Post p left join p.likes l "
            + "where p.deadline > current_timestamp "
            + "and function('month', p.createdAt) = function('month', current_timestamp) "
            + "group by p.id "
            + "order by count(l) desc, p.views desc")
List<Post> findBestPosts(Pageable pageable);
```

메서드 이름으로 조회하기에는 쿼리가 복잡해서 쿼리를 직접 작성하는 방식으로 구현했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
