### PR TITLE
회원가입 시 프로필 사진 선택 기능 구현 완료

### DIFF
--- a/src/main/java/balancetalk/module/member/domain/Member.java
+++ b/src/main/java/balancetalk/module/member/domain/Member.java
@@ -3,6 +3,7 @@ package balancetalk.module.member.domain;
 import balancetalk.module.bookmark.domain.Bookmark;
 import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.comment.domain.CommentLike;
+import balancetalk.module.file.domain.File;
 import balancetalk.module.notice.domain.Notice;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostLike;
@@ -76,6 +77,10 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     @OneToMany(mappedBy = "reporter")
     private List<Report> reports = new ArrayList<>(); // 신고한 기록
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "file_id")
+    private File profilePhoto;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/balancetalk/module/member/dto/JoinRequest.java
+++ b/src/main/java/balancetalk/module/member/dto/JoinRequest.java
@@ -1,5 +1,6 @@
 package balancetalk.module.member.dto;
 
+import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,14 +30,16 @@ public class JoinRequest {
     @Schema(description = "회원 비밀번호", example = "Test1234test!")
     private String password;
 
-    // TODO: profilePhoto 추가
+    @Schema(description = "회원 프로필 사진", example = "4df23447-2355-45h2-8783-7f6gd2ceb848_프로필사진.jpg")
+    private String profilePhoto;
 
-    public Member toEntity() {
+    public Member toEntity(File profilePhoto) {
         return Member.builder()
                 .nickname(nickname)
                 .email(email)
                 .password(password)
                 .role(Role.USER)
+                .profilePhoto(profilePhoto)
                 .build();
     }
 }

--- a/src/main/java/balancetalk/module/member/dto/MemberResponse.java
+++ b/src/main/java/balancetalk/module/member/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package balancetalk.module.member.dto;
 
+import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Data
 @Builder
@@ -36,10 +38,14 @@ public class MemberResponse {
     private int level;
 
     public static MemberResponse fromEntity(Member member) {
+        String profilePhotoName = Optional.ofNullable(member.getProfilePhoto())
+                .map(File::getStoredName)
+                .orElse(null);
+
         return MemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
-                //.profilePhoto(file.getPath())
+                .profilePhoto(profilePhotoName)
                 .createdAt(member.getCreatedAt())
                 .postsCount(member.getPostCount())
                 .totalPostLike(member.getPostLikes())

--- a/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
+++ b/src/test/java/balancetalk/module/member/application/MemberServiceTest.java
@@ -202,7 +202,7 @@ class MemberServiceTest {
 
         // when
         joinRequest.setNickname(newNickname);
-        member = joinRequest.toEntity();
+        member = joinRequest.toEntity(null);
         memberService.updateNickname(newNickname, request);
 
         // then
@@ -236,7 +236,7 @@ class MemberServiceTest {
 
         // when
         joinRequest.setPassword(newPassword);
-        member = joinRequest.toEntity();
+        member = joinRequest.toEntity(null);
         memberService.updatePassword(newPassword, request);
 
         // then


### PR DESCRIPTION
## 💡 작업 내용
- [x] 회원가입 시 프로필 사진 선택 구현
- [x] 예외 처리 구현
- [x] Postman 테스트

## 💡 자세한 설명
![회원가입 프로필 사진 postman](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/1c536853-ea6a-4a9a-b996-9d06309e5d20)
회원 가입 API 사용 시 profilePhoto 필드에 파일 이름을 입력하면 해당 파일의 id가 회원의 프로필 사진으로 등록이 됩니다. (null 가능)

![회원가입시 프로필 선택 가능](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/8c1e86ae-db33-49df-b254-7071a0e491d7)
DB 상에서의 프로필 사진 확인

![단일 회원 조회 시 프로필사진](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/7994dc45-84d2-4bd4-bbb9-b01f792b62dc)
단일 회원 조회 시에 정상적으로 프로필 사진이 보여집니다.

![profilePhoto가 null이라도 조회 가능](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/8b891d1f-e145-4b91-8c29-7bbcfbe14d70)
프로필 사진이 null 이라도 정상적으로 조회 가능합니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #192 