### PR TITLE
게시글 응답 필드(이미지 url) 변경

### DIFF
--- a/src/main/java/balancetalk/module/file/application/FileService.java
+++ b/src/main/java/balancetalk/module/file/application/FileService.java
@@ -21,7 +21,10 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Service
 @RequiredArgsConstructor
-public class FileUploadService {
+public class FileService {
+
+    private static final String UPLOAD_PATH
+            = "https://balance-talk-static-files.s3.ap-northeast-2.amazonaws.com/balance-talk-images/balance-option/";
 
     private final S3Client s3Client;
     private final FileRepository fileRepository;
@@ -31,15 +34,14 @@ public class FileUploadService {
 
     @Transactional
     public FileResponse uploadImage(MultipartFile multipartFile) {
-        String uploadDir = "balance-talk-images/balance-option/";
         String originalName = multipartFile.getOriginalFilename();
         String storedName = String.format("%s_%s", UUID.randomUUID(), originalName);
         long contentLength = multipartFile.getSize();
         FileType fileType = convertMimeTypeToFileType(multipartFile.getContentType());
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            putObjectToS3(uploadDir + storedName, inputStream, contentLength);
-            File file = fileRepository.save(createFile(originalName, storedName, uploadDir, fileType, contentLength));
+            putObjectToS3(UPLOAD_PATH + storedName, inputStream, contentLength);
+            File file = fileRepository.save(createFile(originalName, storedName, UPLOAD_PATH, fileType, contentLength));
 
             return FileResponse.fromEntity(file);
         } catch (IOException e) {

--- a/src/main/java/balancetalk/module/file/domain/File.java
+++ b/src/main/java/balancetalk/module/file/domain/File.java
@@ -45,4 +45,8 @@ public class File {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notice_id")
     private Notice notice;
+
+    public String getUrl() {
+        return path + storedName;
+    }
 }

--- a/src/main/java/balancetalk/module/file/presentation/FileController.java
+++ b/src/main/java/balancetalk/module/file/presentation/FileController.java
@@ -1,6 +1,6 @@
 package balancetalk.module.file.presentation;
 
-import balancetalk.module.file.application.FileUploadService;
+import balancetalk.module.file.application.FileService;
 import balancetalk.module.file.dto.FileResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,12 +16,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "file", description = "파일 API")
 public class FileController {
 
-    private final FileUploadService fileUploadService;
+    private final FileService fileService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(value = "/image/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "파일 업로드", description = "파일을 업로드 한다.")
     public FileResponse uploadImage(@RequestPart("file") MultipartFile file) {
-        return fileUploadService.uploadImage(file);
+        return fileService.uploadImage(file);
     }
 }

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -11,7 +11,7 @@ import balancetalk.module.member.domain.Member;
 import balancetalk.module.member.domain.MemberRepository;
 import balancetalk.module.member.domain.Role;
 import balancetalk.module.post.domain.*;
-import balancetalk.module.post.dto.BalanceOptionDto;
+import balancetalk.module.post.dto.BalanceOptionRequest;
 import balancetalk.module.post.dto.PostRequest;
 import balancetalk.module.post.dto.PostResponse;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +39,7 @@ public class PostService {
         if (redisService.getValues(writer.getEmail()) == null) {
             throw new BalanceTalkException(FORBIDDEN_POST_CREATE);
         }
+
         List<File> images = getImages(request);
         Post post = request.toEntity(writer, images);
 
@@ -54,11 +55,11 @@ public class PostService {
         return PostResponse.fromEntity(postRepository.save(post), false, false);
     }
 
-    private List<File> getImages(PostRequest postRequestDto) {
-        List<BalanceOptionDto> balanceOptions = postRequestDto.getBalanceOptions();
+    private List<File> getImages(PostRequest postRequest) {
+        List<BalanceOptionRequest> balanceOptions = postRequest.getBalanceOptions();
         return balanceOptions.stream()
-                .filter(optionDto -> optionDto.getStoredFileName() != null && !optionDto.getStoredFileName().isEmpty())
-                .map(optionDto -> fileRepository.findByStoredName(optionDto.getStoredFileName())
+                .filter(optionDto -> optionDto.getStoredImageName() != null && !optionDto.getStoredImageName().isEmpty())
+                .map(optionDto -> fileRepository.findByStoredName(optionDto.getStoredImageName())
                         .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE)))
                 .toList();
     }

--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionRequest.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionRequest.java
@@ -2,6 +2,7 @@ package balancetalk.module.post.dto;
 
 import balancetalk.module.file.domain.File;
 import balancetalk.module.post.domain.BalanceOption;
+import balancetalk.module.post.domain.BalanceOption.BalanceOptionBuilder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import org.springframework.lang.Nullable;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class BalanceOptionDto {
+public class BalanceOptionRequest {
 
     @Schema(description = "선택지 제목", example = "선택지 제목1")
     private String title;
@@ -22,10 +23,10 @@ public class BalanceOptionDto {
     private String description;
 
     @Schema(description = "DB에 저장되는 이미지 이름", example = "4df23447-2355-45h2-8783-7f6gd2ceb848_고양이.jpg")
-    private String storedFileName;
+    private String storedImageName;
 
     public BalanceOption toEntity(@Nullable File image) {
-        BalanceOption.BalanceOptionBuilder builder = BalanceOption.builder()
+        BalanceOptionBuilder builder = BalanceOption.builder()
                 .title(title)
                 .description(description);
         if (image != null) {
@@ -34,12 +35,12 @@ public class BalanceOptionDto {
         return builder.build();
     }
 
-    public static BalanceOptionDto fromEntity(BalanceOption balanceOption) {
-        BalanceOptionDtoBuilder builder = BalanceOptionDto.builder()
+    public static BalanceOptionRequest fromEntity(BalanceOption balanceOption) {
+        BalanceOptionRequestBuilder builder = BalanceOptionRequest.builder()
                 .title(balanceOption.getTitle())
                 .description(balanceOption.getDescription());
         if (balanceOption.getFile() != null) {
-            builder.storedFileName(balanceOption.getFile().getStoredName());
+            builder.storedImageName(balanceOption.getFile().getStoredName());
         }
         return builder.build();
     }

--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionResponse.java
@@ -1,0 +1,49 @@
+package balancetalk.module.post.dto;
+
+import balancetalk.module.file.domain.File;
+import balancetalk.module.post.domain.BalanceOption;
+import balancetalk.module.post.domain.BalanceOption.BalanceOptionBuilder;
+import balancetalk.module.post.dto.BalanceOptionRequest.BalanceOptionRequestBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BalanceOptionResponse {
+
+    @Schema(description = "선택지 제목", example = "선택지 제목1")
+    private String title;
+
+    @Schema(description = "선택지 내용", example = "선택지 내용1")
+    private String description;
+
+    @Schema(description = "이미지 URL",
+            example = "https://balance-talk-static-files4df23447-2355-45h2-8783-7f6gd2ceb848_고양이.jpg")
+    private String imageUrl;
+
+    public BalanceOption toEntity(@Nullable File image) {
+        BalanceOptionBuilder builder = BalanceOption.builder()
+                .title(title)
+                .description(description);
+        if (image != null) {
+            builder.file(image);
+        }
+        return builder.build();
+    }
+
+    public static BalanceOptionResponse fromEntity(BalanceOption balanceOption) {
+        BalanceOptionResponseBuilder builder = BalanceOptionResponse.builder()
+                .title(balanceOption.getTitle())
+                .description(balanceOption.getDescription());
+        if (balanceOption.getFile() != null) {
+            builder.imageUrl(balanceOption.getFile().getUrl());
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/balancetalk/module/post/dto/PostRequest.java
+++ b/src/main/java/balancetalk/module/post/dto/PostRequest.java
@@ -34,9 +34,12 @@ public class PostRequest {
     @Schema(description = "게시글 카테고리", example = "CASUAL")
     private PostCategory category;
 
-    @Schema(description = "선택지 옵션 리스트", example = "[{\"title\": \"선택지 제목1\", \"description\": \"선택지 내용1\" , \"storedFileName\": null}," +
-            "{\"title\": \"선택지 제목2\", \"description\": \"선택지 내용2\", \"storedFileName\": null}]")
-    private List<BalanceOptionDto> balanceOptions;
+    @Schema(description = "선택지 옵션 리스트", example =
+            "[{\"title\": \"선택지 제목1\", \"description\": \"선택지 내용1\" , "
+            + "\"storedFileName\": 4df23447-2355-45h2-8783-7f6gd2ceb848_강아지.jpg}," +
+            "{\"title\": \"선택지 제목2\", \"description\": \"선택지 내용2\", "
+            + "\"storedFileName\": 4df23447-2355-45h2-8783-7f6gd2ceb848_고양이.jpg}]")
+    private List<BalanceOptionRequest> balanceOptions;
 
     @Schema(description = "태그 리스트", example = "[\"태그1\", \"태그2\", \"태그3\"]")
     private List<PostTagDto> tags;
@@ -55,15 +58,16 @@ public class PostRequest {
     private List<BalanceOption> getBalanceOptions(List<File> images) {
         if (images.isEmpty()) {
             return balanceOptions.stream()
-                    .map(balanceOptionDto -> balanceOptionDto.toEntity(null))
+                    .map(balanceOption -> balanceOption.toEntity(null))
                     .collect(Collectors.toList());
         } else {
             Map<String, File> fileNameToFileMap = images.stream()
                     .collect(Collectors.toMap(File::getStoredName, Function.identity()));
 
             return balanceOptions.stream()
-                    .map(balanceOptionDto -> balanceOptionDto.toEntity(fileNameToFileMap.getOrDefault(balanceOptionDto.getStoredFileName(),
-                            null)))
+                    .map(balanceOption ->
+                            balanceOption.toEntity(
+                                    fileNameToFileMap.getOrDefault(balanceOption.getStoredImageName(), null)))
                     .collect(Collectors.toList());
         }
     }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -39,9 +39,11 @@ public class PostResponse {
     @Schema(description = "게시글 카테고리", example = "CASUAL")
     private PostCategory category;
 
-    @Schema(description = "선택지 옵션 리스트", example = "[{\"title\": \"선택지 제목1\", \"description\": \"선택지 내용1\" , \"storedFileName\": null}," +
-            "{\"title\": \"선택지 제목2\", \"description\": \"선택지 내용2\", \"storedFileName\": null}]")
-    private List<BalanceOptionDto> balanceOptions;
+    @Schema(description = "선택지 옵션 리스트", example =
+            "[{\"title\": \"선택지 제목1\", \"description\": \"선택지 내용1\" , \"storedFileName\": null}," +
+                    "{\"title\": \"선택지 제목2\", \"description\": \"선택지 내용2\", "
+                    + "\"imageUrl\": https://balance-talk-static-files/4df23447-2355-45h2-8783-7f6gd2ceb848_고양이.jpg}]")
+    private List<BalanceOptionResponse> balanceOptions;
 
     @Schema(description = "태그 리스트", example = "[\"태그1\", \"태그2\", \"태그3\"]")
     private List<PostTagDto> postTags;
@@ -77,9 +79,9 @@ public class PostResponse {
                 .collect(Collectors.toList());
     }
 
-    private static List<BalanceOptionDto> getBalanceOptions(Post post) {
+    private static List<BalanceOptionResponse> getBalanceOptions(Post post) {
         return post.getOptions().stream()
-                .map(BalanceOptionDto::fromEntity)
+                .map(BalanceOptionResponse::fromEntity)
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/balancetalk/module/post/application/PostServiceTest.java
+++ b/src/test/java/balancetalk/module/post/application/PostServiceTest.java
@@ -1,36 +1,8 @@
 package balancetalk.module.post.application;
 
-import balancetalk.global.redis.application.RedisService;
-import balancetalk.module.file.domain.File;
-import balancetalk.module.file.domain.FileRepository;
-import balancetalk.module.member.domain.Member;
-import balancetalk.module.member.domain.MemberRepository;
-import balancetalk.module.post.domain.*;
-import balancetalk.module.post.dto.BalanceOptionDto;
-import balancetalk.module.post.dto.PostRequest;
-import balancetalk.module.post.dto.PostResponse;
-import balancetalk.module.post.dto.PostTagDto;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.IntStream;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.*;
 
 //@ExtendWith(MockitoExtension.class)
 //class PostServiceTest {


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 응답에 있는 선택지의 이미지 이름(storedFileName)을 해당 이미지의 url로 수정
- [x] 기존 BalanceOptionDto를 요청과 응답 DTO로 분리
- [x] 이미지 파일 저장 시 path에 최상위 경로까지 포함해 저장되도록 수정

## 💡 자세한 설명
게시글을 작성할 때는 BalanceOption에 이미지 이름을 전달하고, 게시글을 응답으로 보낼 때는 이미지의 URL을 보내면 클라이언트 입장에서 효율적인 작업이 가능해집니다.
이를 가능하도록 하려면 기존 BalanceOptionDto를 요청과 응답 각각의 DTO로 분리해야 한다고 판단했습니다.
따라서 BalanceOptionRequest에는 storedImageName을, BalanceOptionResponse에는 imageUrl을 필드로 설정했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #208 
