### PR TITLE
게시글 응답에 선택지별 득표 수, 게시글 전체 투표 수 반환 구현

### DIFF
--- a/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
+++ b/src/main/java/balancetalk/module/post/dto/BalanceOptionDto.java
@@ -9,6 +9,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 
+import java.util.List;
+import java.util.Optional;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -27,6 +30,9 @@ public class BalanceOptionDto {
     @Schema(description = "DB에 저장되는 이미지 이름", example = "4df23447-2355-45h2-8783-7f6gd2ceb848_고양이.jpg")
     private String storedFileName;
 
+    @Schema(description = "선택지 득표 수", example = "15")
+    private int votesCount;
+
     public BalanceOption toEntity(@Nullable File image) {
         BalanceOption.BalanceOptionBuilder builder = BalanceOption.builder()
                 .title(title)
@@ -38,10 +44,16 @@ public class BalanceOptionDto {
     }
 
     public static BalanceOptionDto fromEntity(BalanceOption balanceOption) {
+        int votesCount = Optional.ofNullable(balanceOption.getVotes())
+                .map(List::size)
+                .orElse(0);
+
         BalanceOptionDtoBuilder builder = BalanceOptionDto.builder()
                 .balanceOptionId(balanceOption.getId())
                 .title(balanceOption.getTitle())
-                .description(balanceOption.getDescription());
+                .description(balanceOption.getDescription())
+                .votesCount(votesCount);
+
         if (balanceOption.getFile() != null) {
             builder.storedFileName(balanceOption.getFile().getStoredName());
         }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -52,7 +52,7 @@ public class PostResponse {
     private List<PostTagDto> postTags;
 
     @Schema(description = "전체 투표 수", example = "15")
-    private int totalVotes;
+    private int totalVoteCount;
 
     @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
     @Schema(description = "게시글 작성일", example = "2023-12-25T15:30:00")
@@ -75,7 +75,7 @@ public class PostResponse {
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
-                .totalVotes(getTotalVotes(post))
+                .totalVoteCount(getTotalVotes(post))
                 .createdAt(post.getCreatedAt())
                 .createdBy(post.getMember().getNickname())
                 .build();

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -52,7 +52,7 @@ public class PostResponse {
     private List<PostTagDto> postTags;
 
     @Schema(description = "전체 투표 수", example = "15")
-    private int totalVoteCount;
+    private int totalVotesCount;
 
     @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
     @Schema(description = "게시글 작성일", example = "2023-12-25T15:30:00")
@@ -75,7 +75,7 @@ public class PostResponse {
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
-                .totalVoteCount(getTotalVotes(post))
+                .totalVotesCount(getTotalVotes(post))
                 .createdAt(post.getCreatedAt())
                 .createdBy(post.getMember().getNickname())
                 .build();

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -1,5 +1,6 @@
 package balancetalk.module.post.dto;
 
+import balancetalk.module.post.domain.BalanceOption;
 import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -7,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Data
@@ -49,6 +51,9 @@ public class PostResponse {
     @Schema(description = "태그 리스트", example = "[\"태그1\", \"태그2\", \"태그3\"]")
     private List<PostTagDto> postTags;
 
+    @Schema(description = "전체 투표 수", example = "15")
+    private int totalVotes;
+
     @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
     @Schema(description = "게시글 작성일", example = "2023-12-25T15:30:00")
     private LocalDateTime createdAt;
@@ -70,6 +75,7 @@ public class PostResponse {
                 .category(post.getCategory())
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
+                .totalVotes(getTotalVotes(post))
                 .createdAt(post.getCreatedAt())
                 .createdBy(post.getMember().getNickname())
                 .build();
@@ -85,5 +91,13 @@ public class PostResponse {
         return post.getOptions().stream()
                 .map(BalanceOptionDto::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    private static int getTotalVotes(Post post) {
+        return Optional.ofNullable(post.getOptions())
+                .map(options -> options.stream()
+                        .mapToInt(option -> Optional.ofNullable(option.getVotes()).map(List::size).orElse(0))
+                        .sum())
+                .orElse(0);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 선택지별 득표 수 반환 구현
- [x] 게시글 전체 투표 수 반환 구현
- [x] Postman 테스트

## 💡 자세한 설명
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/6047a777-3273-434b-9e99-e6a74283c87e)
선택지별 득표 수 반환 Postman 테스트 완료

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/d1538d1c-198f-4714-b14a-969214d2e264)
게시글 전체 투표 수 반환 Postman 테스트 완료

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #216 
