### PR TITLE
투표 생성 시 회원/비회원 구분 로직 개선

### DIFF
--- a/src/main/java/balancetalk/module/vote/application/VoteService.java
+++ b/src/main/java/balancetalk/module/vote/application/VoteService.java
@@ -30,7 +30,7 @@ public class VoteService {
     private final BalanceOptionRepository balanceOptionRepository;
     private final PostRepository postRepository;
 
-    public Vote createVote(Long postId, VoteRequest voteRequest) {
+    public Vote createVote(Long postId, VoteRequest voteRequest, String token) {
         Post post = getPost(postId);
         if (post.hasDeadlineExpired()) {
             throw new BalanceTalkException(EXPIRED_POST_DEADLINE);
@@ -41,11 +41,10 @@ public class VoteService {
             throw new BalanceTalkException(MISMATCHED_BALANCE_OPTION);
         }
 
-        if (voteRequest.isUser()) {
-            return voteForMember(voteRequest, post, balanceOption);
+        if (token == null) {
+            return voteForGuest(voteRequest, balanceOption);
         }
-
-        return voteForGuest(voteRequest, balanceOption);
+        return voteForMember(voteRequest, post, balanceOption);
     }
 
     private Post getPost(Long postId) {

--- a/src/main/java/balancetalk/module/vote/dto/VoteRequest.java
+++ b/src/main/java/balancetalk/module/vote/dto/VoteRequest.java
@@ -13,11 +13,8 @@ import lombok.Data;
 @Builder
 public class VoteRequest {
 
-    @Schema(description = "투표한 선택지 id", example = "2")
+    @Schema(description = "투표한 선택지 id", example = "23")
     private Long selectedOptionId;
-
-    @Schema(description = "회원 여부", example = "true")
-    private boolean isUser;
 
     public Vote toEntity(BalanceOption balanceOption) {
         return Vote.builder()

--- a/src/main/java/balancetalk/module/vote/presentation/VoteController.java
+++ b/src/main/java/balancetalk/module/vote/presentation/VoteController.java
@@ -9,7 +9,6 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,8 +24,10 @@ public class VoteController {
     @PostMapping
     @Operation(summary = "선택지 투표", description = "post-id에 해당하는 게시글에서 마음에 드는 선택지에 투표한다.")
     @ApiResponse(responseCode = "201", description = "투표가 정상적으로 처리되었습니다.")
-    public String createVote(@PathVariable Long postId, final @Valid @RequestBody VoteRequest voteRequest) {
-        voteService.createVote(postId, voteRequest);
+    public String createVote(@PathVariable Long postId,
+                             @RequestBody VoteRequest voteRequest,
+                             @RequestHeader(value = "Authorization", required = false) String token) {
+        voteService.createVote(postId, voteRequest, token);
         return "투표가 정상적으로 처리되었습니다.";
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 기존의 isUser를 통해 회원/비회원을 구분하던 투표 로직을 토큰으로 구분하도록 개선한다.

## 💡 자세한 설명
기존에는 boolean 타입인 isUser를 통해 투표를 하는 주체가 회원인지 비회원인지 구분했습니다.
이를 JWT 토큰을 사용해 구분하도록 로직을 개선하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #213 
