### PR TITLE
댓글 목록 조회 시 답글 제외

### DIFF
--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -62,7 +62,7 @@ public class CommentService {
     public Page<CommentResponse> findAllComments(Long postId, String token, Pageable pageable) {
         validatePostId(postId);
 
-        Page<Comment> comments = commentRepository.findAllByPostId(postId, pageable);
+        Page<Comment> comments = commentRepository.findAllByPostIdAndParentIsNull(postId, pageable);
 
         return comments.map(comment -> {
             Optional<Vote> voteForComment = voteRepository.findByMemberIdAndBalanceOption_PostId(

--- a/src/main/java/balancetalk/module/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/module/comment/domain/CommentRepository.java
@@ -12,7 +12,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findAllByMemberEmail(String email, Pageable pageable);
 
-    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
+    Page<Comment> findAllByPostIdAndParentIsNull(Long postId, Pageable pageable);
 
     @Query("select c from Comment c left join c.likes l "
             + "where c.post.id = :postId and c.member.id in :memberIds "


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 목록 조회 시 답글 제외하는 로직 추가

## 💡 자세한 설명
쿼리 메서드에서 제공하는 기능을 사용해 댓글 목록 조회 API 응답에서 답글을 제외시켰습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #245 