### PR TITLE
로그인 후 게시글 조회 시 에러 발생 해결

### DIFF
--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -116,6 +116,7 @@ public class PostResponse {
                 .filter(option -> Optional.ofNullable(option.getVotes())
                         .orElseGet(Collections::emptyList)
                         .stream()
+                        .filter(vote -> vote.getMember() != null && vote.getMember().getId() != null)
                         .anyMatch(vote -> vote.getMember().getId().equals(member.getId())))
                 .findFirst()
                 .map(BalanceOption::getId)


### PR DESCRIPTION
## 💡 작업 내용
- [x] Vote.getMember() 값이 NULL일 경우를 처리

## 💡 자세한 설명
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/c665de38-24c6-4b09-9ecd-97cd51d5ebdc)
`vote.getMember() 또는 vote.getMember().getId() 반환값이 NULL일 경우를 스트림으로 처리해서 해결했습니다.

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/bbe317be-074d-45ea-ac44-e07c39b4cc67)
dev 기준 정상 작동 확인했습니다.
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #262 
