### PR TITLE
회원 조회 시 응답에 있는 프로필 사진의 storedName을 url로 수정

### DIFF
--- a/src/main/java/balancetalk/global/config/SecurityConfig.java
+++ b/src/main/java/balancetalk/global/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOriginPattern("http://localhost:8080");
         configuration.addAllowedOriginPattern("http://localhost:3000"); // 프론트 쪽에서 허용
-        configuration.addAllowedOriginPattern("http://balancetalk.kro.kr"); // 도메인 주소
+        configuration.addAllowedOriginPattern("https://balancetalk.kro.kr"); // 도메인 주소
         configuration.addExposedHeader("Authorization");
         configuration.addExposedHeader("refreshToken");
         configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH","DELETE"));

--- a/src/main/java/balancetalk/module/member/dto/MemberResponse.java
+++ b/src/main/java/balancetalk/module/member/dto/MemberResponse.java
@@ -21,8 +21,8 @@ public class MemberResponse {
     @Schema(description = "회원 닉네임", example = "닉네임")
     private String nickname;
 
-    @Schema(description = "회원 프로필", example = "../")
-    private String profilePhoto; // TODO: File 타입으로 수정 예정
+    @Schema(description = "회원 프로필 URL", example = "https://balance-talk-static-files.s3.ap-northeast-2.amazonaws.com/balance-talk-images/balance-option/a723b360-f42f-4dc9-be69-72904b6861d9_강아지.jpeg")
+    private String profileImageUrl;
 
     @Schema(description = "가입일", example = "2024-02-16 13:37:17.391706")
     private LocalDateTime createdAt;
@@ -37,14 +37,14 @@ public class MemberResponse {
     private int level;
 
     public static MemberResponse fromEntity(Member member) {
-        String profilePhotoName = Optional.ofNullable(member.getProfilePhoto())
-                .map(File::getStoredName)
+        String profileImageUrl = Optional.ofNullable(member.getProfilePhoto())
+                .map(File::getUrl)
                 .orElse(null);
 
         return MemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
-                .profilePhoto(profilePhotoName)
+                .profileImageUrl(profileImageUrl)
                 .createdAt(member.getCreatedAt())
                 .postsCount(member.getPostCount())
                 .totalPostLike(member.getPostLikes())

--- a/src/main/java/balancetalk/module/vote/dto/VoteRequest.java
+++ b/src/main/java/balancetalk/module/vote/dto/VoteRequest.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class VoteRequest {


### PR DESCRIPTION
## 💡 작업 내용
- [x] MemberResponse에 프로필 사진의 storedName 대신 url 추가
- [x] 스웨거 예시 수정

## 💡 자세한 설명
기존 회원 조회 시 응답에는 프로필 사진의 storedName이 포함되어 있었습니다. 이를 이미지의 전체 URL이 반환되도록 수정하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #266 
