### PR TITLE
스웨거 문서 수정 및 시큐리티 URL 허용

### DIFF
--- a/src/main/java/balancetalk/global/config/SecurityConfig.java
+++ b/src/main/java/balancetalk/global/config/SecurityConfig.java
@@ -38,7 +38,6 @@ public class SecurityConfig {
             "/swagger-ui/**", "/v3/api-docs/**",
 
             "/",
-            "/email/password",
             "/members/duplicate",
             "/posts", "/posts/{postId}", "/posts/{postId}/vote", "/posts/{postId}/comments/**",
             "/notices", "/notices/{noticeId}"
@@ -46,7 +45,7 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_POST = {
             "/members/join", "/members/login",
-            "/email/request", "/email/verify",
+            "/email/request", "/email/verify", "/email/password",
             "/posts/{postId}/vote", "/files/image/upload"
     };
 

--- a/src/main/java/balancetalk/module/authmail/presentation/MailController.java
+++ b/src/main/java/balancetalk/module/authmail/presentation/MailController.java
@@ -35,7 +35,7 @@ public class MailController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/password")
+    @PostMapping("/password")
     @Operation(summary = "비밀 번호 찾기", description = "가입된 회원 이메일로 임시 비밀번호를 발송한다.")
     public String sendTempPassword(@Valid @RequestBody EmailRequest request) {
         mailService.sendTempPassword(request);

--- a/src/main/java/balancetalk/module/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/module/member/presentation/MemberController.java
@@ -2,6 +2,8 @@ package balancetalk.module.member.presentation;
 
 import balancetalk.module.member.application.MemberService;
 import balancetalk.module.member.dto.*;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -57,7 +59,7 @@ public class MemberController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @PutMapping("/nickname")
+    @PutMapping(value = "/nickname", consumes = "text/plain")
     @Operation(summary = "회원 닉네임 수정", description = "회원 닉네임을 수정한다.")
     public String updateNickname(@Valid @NotBlank @RequestBody @Size(min = 2, max = 10)String newNickname, HttpServletRequest request) {
         // TODO: RequestBody 빈 값일 때 에러체킹 x
@@ -66,7 +68,7 @@ public class MemberController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @PutMapping("/password")
+    @PutMapping(value = "/password", consumes = "text/plain")
     @Operation(summary = "회원 비밀번호 수정", description = "회원 패스워드를 수정한다.")
     public String updatePassword(@RequestBody @Size(min = 10, max = 20)
                                  @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{10,20}$")
@@ -77,7 +79,7 @@ public class MemberController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @PutMapping("/image")
+    @PutMapping(value = "/image", consumes = "text/plain")
     @Operation(summary = "회원 이미지 변경", description = "회원 프로필 이미지를 변경한다.")
     public String updateImage(@RequestBody String storedFileName, HttpServletRequest request) {
         memberService.updateImage(storedFileName, request);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 스웨거에서 헤더 타입을 application/json 에서 text/plain으로 수정
- [x] 임시 비밀번호 발송 로직 시큐리티 URL 허용

## 💡 자세한 설명
![스크린샷 2024-03-27 오후 8 12 11](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/a53f1fe6-5875-4621-ac69-07b482a6d046)

세가지 api (회원 닉네임 수정, 비밀번호 수정, 이미지 수정)에 대해서 헤더 타입을 `application/json` 에서 `plain/text` 으로 변경하였습니다.

그리고, 임시 비밀번호 발송 로직이 GET으로 되어 있어서 `401 Unauthorized` 에러가 발생했는데, `POST`로 변경하고 시큐리티 URL까지 허용해줬습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #265 
