### PR TITLE
게시글 조회 응답에 댓글 개수 추가

### DIFF
--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -87,6 +87,13 @@ public class Post extends BaseTimeEntity {
         }
         return likes.size();
     }
+
+    public long commentsCount() {
+        if (comments == null) {
+            return 0;
+        }
+        return comments.size();
+    }
     
     @PrePersist
     public void init() {

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -86,7 +86,7 @@ public class PostResponse {
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
                 .totalVotesCount(getTotalVotes(post))
-                .commentsCount(post.getComments().size())
+                .commentsCount(post.commentsCount())
                 .createdAt(post.getCreatedAt())
                 .createdBy(post.getMember().getNickname())
                 .profileImageUrl(getProfileImageUrl(post.getMember()))

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -57,6 +57,9 @@ public class PostResponse {
     @Schema(description = "전체 투표 수", example = "15")
     private int totalVotesCount;
 
+    @Schema(description = "댓글 개수", example = "12")
+    private long commentsCount;
+
     @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
     @Schema(description = "게시글 작성일", example = "2023-12-25T15:30:00")
     private LocalDateTime createdAt;
@@ -83,6 +86,7 @@ public class PostResponse {
                 .balanceOptions(getBalanceOptions(post))
                 .postTags(getPostTags(post))
                 .totalVotesCount(getTotalVotes(post))
+                .commentsCount(post.getComments().size())
                 .createdAt(post.getCreatedAt())
                 .createdBy(post.getMember().getNickname())
                 .profileImageUrl(getProfileImageUrl(post.getMember()))


### PR DESCRIPTION
## 💡 작업 내용
- [x] PostResponse에 `long commentsCount` 추가

## 💡 자세한 설명
PostResponse 클래스에 commentsCount라는 필드를 추가했습니다.
commentsCount는 post 엔티티의 comments의 size를 통해 도출했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #270 
