### PR TITLE
댓글 목록 조회 API에서 댓글마다 답글 개수 포함하도록 수정 완료

### DIFF
--- a/src/main/java/balancetalk/module/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/module/comment/domain/Comment.java
@@ -46,6 +46,9 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> replies = new ArrayList<>();
+
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
     private List<CommentLike> likes = new ArrayList<>();
 

--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -43,6 +43,9 @@ public class CommentResponse {
     @Schema(description = "추천 여부", example = "true")
     private boolean myLike;
 
+    @Schema(description = "답글 수", example = "3")
+    private int replyCount;
+
     @Schema(description = "댓글 생성 날짜")
     private LocalDateTime createdAt;
 
@@ -63,6 +66,7 @@ public class CommentResponse {
                 .likesCount(comment.getLikes().size())
                 //.reportedCount(comment.reportedCount())
                 .myLike(myLike)
+                .replyCount(comment.getReplies().size())
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())
                 .profileImageUrl(getProfileImageUrl(comment.getMember()))


### PR DESCRIPTION
## 💡 작업 내용
- [x] `Comment` 엔티티에 답글 필드 추가
- [x] `CommentResponse` 에 답글 수 반환 구현

## 💡 자세한 설명
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/5f5c99d0-692d-4cbc-b0f5-e69ccbd5f1f1)
postman 테스트 완료했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #286 
