### PR TITLE
게시글 조회 시 조회수가 증가하지 않던 문제 해결

### DIFF
--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -92,7 +92,7 @@ public class PostService {
                 member.hasVoted(post)));
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public PostResponse findById(Long postId, String token) {
         Post post = getCurrentPost(postId);
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 단건 조회 메서드의 readOnly 설정 해제

## 💡 자세한 설명
게시글 조회 시 조회수가 증가하지 않는 문제의 원인을 파악한 결과, 다음과 같이 @Transactional 옵션에 readOnly=true가 설정되어 있음을 확인했습니다.
```java
@Transactional(readOnly = true)
public PostResponse findById(Long postId, String token) {
    ...
}
```
이로 인해 데이터 수정 작업이 수행되지 않았고, readOnly 설정을 해제함으로써 문제를 해결했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #288 
