### PR TITLE
태그 검색 시 401 에러가 뜨던 오류 해결 

### DIFF
--- a/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
@@ -28,9 +28,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                 Authentication auth = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
-            else if (token == null) {
-                throw new BalanceTalkException(ErrorCode.EMPTY_JWT_TOKEN);
-            }
         } catch (Exception e) {
             log.error("error={}", e.getMessage());
             request.setAttribute("exception", e.getMessage());

--- a/src/main/java/balancetalk/module/post/domain/PostRepository.java
+++ b/src/main/java/balancetalk/module/post/domain/PostRepository.java
@@ -19,10 +19,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByTitleContaining(String keyword);
 
-    @Query(value = "SELECT * " +
-            "FROM post p " +
-            "NATURAL JOIN post_tag pt " +
-            "NATURAL JOIN tag t " +
-            "WHERE p.post_id = pt.post_id AND pt.tag_id = t.tag_id AND t.name = :tagName", nativeQuery = true)
+    @Query("SELECT p " +
+            "FROM Post p " +
+            "JOIN p.postTags pt " +
+            "JOIN pt.tag t " +
+            "WHERE t.name = :tagName")
     List<Post> findByPostTagsContaining(String tagName);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 태그 검색 쿼리 수정

## 💡 자세한 설명

기존에 태그 검색 쿼리를 Natural Join을 사용해서 구현했으나, 비 로그인시 401에러, 로그인 시 500 에러가 발생하여 INNER JOIN으로 

로직을 변경해서 해결했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #285 
