### PR TITLE
Redis에 저장되는 값을 직렬화 하는 빈 추가

### DIFF
--- a/src/main/java/balancetalk/global/config/RedisConfig.java
+++ b/src/main/java/balancetalk/global/config/RedisConfig.java
@@ -7,6 +7,9 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
@@ -27,6 +30,16 @@ public class RedisConfig {
     public RedisTemplate<?, ?> redisTemplate() {
         RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        redisTemplate.afterPropertiesSet();
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
+        return new GenericJackson2JsonRedisSerializer();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] Redis에 직렬화 하는 빈 추가

## 💡 자세한 설명
<img width="304" alt="스크린샷 2024-04-05 오후 3 53 54" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/014873ed-5a76-4f48-a77f-2a574a7df420">

기존에 Redis에 Key값으로 룬문자가 붙은 형태로 저장되는 문제가 있었습니다.

<img width="574" alt="스크린샷 2024-04-05 오후 3 51 37" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/1e0ace07-9558-44ca-ac6a-c3abf4588e24">


<img width="131" alt="스크린샷 2024-04-05 오후 3 54 20" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/2a1d3ca4-da9d-4127-8445-5f3577ca71bb">

수정 후, 정상적으로 key 값이 저장되는 것을 확인할 수 있습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #284 
