### PR TITLE
게시글, 댓글 응답에 작성자 ID 추가

### DIFF
--- a/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/CommentResponse.java
@@ -27,7 +27,7 @@ public class CommentResponse {
 
     @Schema(description = "해당 댓글에 맞는 게시글 id", example = "1")
     private Long postId;
-  
+
     @Schema(description = "해당 댓글에 맞는 선택지 id", example = "23")
     private Long selectedOptionId;
 
@@ -52,6 +52,9 @@ public class CommentResponse {
     @Schema(description = "댓글 수정 날짜")
     private LocalDateTime lastModifiedAt;
 
+    @Schema(description = "댓글 작성자 ID")
+    private Long writerId;
+
     @Schema(description = "댓글 작성자 프로필 사진 경로", example = "https://balance-talk-static-files4df23447-2355-45h2-8783-7f6gd2ceb848_프로필.jpg")
     private String profileImageUrl;
 
@@ -69,6 +72,7 @@ public class CommentResponse {
                 .replyCount(comment.getReplies().size())
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())
+                .writerId(comment.getMember().getId())
                 .profileImageUrl(getProfileImageUrl(comment.getMember()))
                 .build();
     }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -71,6 +71,9 @@ public class PostResponse {
     @Schema(description = "게시글 작성일", example = "2024/03/30 11:12:37")
     private LocalDateTime createdAt;
 
+    @Schema(description = "게시글 작성자 ID", example = "5")
+    private Long memberId;
+
     @Schema(description = "게시글 작성자", example = "작성자 닉네임")
     private String createdBy;
 
@@ -97,6 +100,7 @@ public class PostResponse {
                 .totalVotesCount(getTotalVotes(post))
                 .commentsCount(post.commentsCount())
                 .createdAt(post.getCreatedAt())
+                .memberId(post.getMember().getId())
                 .createdBy(post.getMember().getNickname())
                 .profileImageUrl(getProfileImageUrl(post.getMember()))
                 .build();

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -72,7 +72,7 @@ public class PostResponse {
     private LocalDateTime createdAt;
 
     @Schema(description = "게시글 작성자 ID", example = "5")
-    private Long memberId;
+    private Long writerId;
 
     @Schema(description = "게시글 작성자", example = "작성자 닉네임")
     private String createdBy;
@@ -100,7 +100,7 @@ public class PostResponse {
                 .totalVotesCount(getTotalVotes(post))
                 .commentsCount(post.commentsCount())
                 .createdAt(post.getCreatedAt())
-                .memberId(post.getMember().getId())
+                .writerId(post.getMember().getId())
                 .createdBy(post.getMember().getNickname())
                 .profileImageUrl(getProfileImageUrl(post.getMember()))
                 .build();


### PR DESCRIPTION
## 💡 작업 내용
- [ ] 게시글 응답에 작성자 ID 추가
- [ ] 게시글 응답에 작성자 ID 추가

## 💡 자세한 설명
게시글과 댓글 작성자의 사진을 클릭 시 해당 유저의 프로필 모달이 뜨도록 하기 위해서는 게시글, 댓글 응답에 memberId가 필요하다고 합니다.
따라서 게시글과 댓글 응답에 작성자 ID를 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #302 
