### PR TITLE
비회원 상태에서 프로필 조회 시 401에러

### DIFF
--- a/src/main/java/balancetalk/module/member/dto/ProfileResponse.java
+++ b/src/main/java/balancetalk/module/member/dto/ProfileResponse.java
@@ -1,5 +1,6 @@
 package balancetalk.module.member.dto;
 
+import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -8,6 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Data
 @Builder
@@ -33,8 +35,11 @@ public class ProfileResponse {
     private int level;
 
     public static ProfileResponse fromEntity(Member member) {
+        String profileImageUrl = Optional.ofNullable(member.getProfilePhoto())
+                .map(File::getUrl)
+                .orElse(null);
         return ProfileResponse.builder()
-                .profileImageUrl(member.getProfilePhoto().getUrl())
+                .profileImageUrl(profileImageUrl)
                 .nickname(member.getNickname())
                 .createdAt(member.getCreatedAt())
                 .postsCount(member.getPostCount())

--- a/src/main/java/balancetalk/module/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/module/member/presentation/MemberController.java
@@ -118,6 +118,7 @@ public class MemberController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{memberId}/profile")
+    @Operation(summary = "회원 프로필 조회", description = "회원 프로필을 조회한다.")
     public ProfileResponse memberProfile(@PathVariable("memberId") Long memberId) {
         return memberService.memberProfile(memberId);
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 비회원 상태에서 프로필 조회 시 401에러 

## 💡 자세한 설명
회원 프로필이 없는 경우, `null`값을 잡지 못해서 에러가 발생했습니다.

![스크린샷 2024-04-11 오후 7 40 25](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/b4924f35-5a1c-4c82-8d36-73f383d96c03)

위 코드를 추가했습니다.

![스크린샷 2024-04-11 오후 7 39 28](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/36fb1124-4d86-4d5f-aee7-70f19692550b)

![스크린샷 2024-04-11 오후 7 39 35](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/622d5c95-ad9b-44fc-8964-08b370715621)

프로필이 있는 경우, 없는 경우 둘다 정상적으로 비회원 상태에서 반환되는 것을 확인했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #305 
