### PR TITLE
본인 게시글, 댓글을 신고할 때 에러 메세지 수정 및 데드라인 지난 게시글 조회 시 에러

### DIFF
--- a/src/main/java/balancetalk/module/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/module/comment/application/CommentService.java
@@ -265,7 +265,7 @@ public class CommentService {
     public void reportComment(Long postId, Long commentId, ReportRequest reportRequest) {
         Comment comment = validateCommentId(commentId);
         Member member = getCurrentMember(memberRepository);
-        if (reportRepository.existsByReporter(member)) {
+        if (reportRepository.existsByReporterAndComment(member, comment)) {
             throw new BalanceTalkException(ALREADY_REPORTED_COMMENT);
         }
         if (comment.getMember().equals(member)) {

--- a/src/main/java/balancetalk/module/post/application/PostService.java
+++ b/src/main/java/balancetalk/module/post/application/PostService.java
@@ -241,7 +241,7 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_POST));
         Member member = getCurrentMember(memberRepository);
-        if (reportRepository.existsByReporter(member)) {
+        if (reportRepository.existsByReporterAndPost(member, post)) {
             throw new BalanceTalkException(ALREADY_REPORTED_POST);
         }
         if (post.getMember().equals(member)) {

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -34,6 +34,7 @@ public class Post extends BaseTimeEntity {
 
     @NotNull
     @Future
+    //
     @Column(nullable = false)
     private LocalDateTime deadline;
 

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -34,7 +34,6 @@ public class Post extends BaseTimeEntity {
 
     @NotNull
     @Future
-    //
     @Column(nullable = false)
     private LocalDateTime deadline;
 

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -33,7 +33,6 @@ public class Post extends BaseTimeEntity {
     private String title;
 
     @NotNull
-    @Future
     @Column(nullable = false)
     private LocalDateTime deadline;
 

--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -33,6 +33,7 @@ public class Post extends BaseTimeEntity {
     private String title;
 
     @NotNull
+    @Future
     @Column(nullable = false)
     private LocalDateTime deadline;
 

--- a/src/main/java/balancetalk/module/report/domain/ReportRepository.java
+++ b/src/main/java/balancetalk/module/report/domain/ReportRepository.java
@@ -1,9 +1,13 @@
 package balancetalk.module.report.domain;
 
+import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.member.domain.Member;
+import balancetalk.module.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    boolean existsByReporter(Member reporter);
+    boolean existsByReporterAndPost(Member reporter, Post post);
+
+    boolean existsByReporterAndComment(Member reporter, Comment comment);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 본인 게시글, 댓글을 신고할 때 Forbidden이 아닌 Conflict 리턴

## 💡 자세한 설명

`ReportRepository`에서 `existsByReporter`로 쿼리를 작성하여 해당 사용자가 한번이라도 신고를 한 경우 중복되었다는 에러 메세지를 리턴하는 문제가 있었습니다.

`existsByReporterAndPost`, `existsByReporterAndComment`로 수정해 주었습니다.

![스크린샷 2024-04-11 오후 7 43 33](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/1b320d9d-3d3b-443a-b8e0-22f707094e3a)

![스크린샷 2024-04-11 오후 7 44 17](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/39e97fbb-271c-46ea-9dfa-76a158ca1f51)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #306 