### PR TITLE
마감시간 지난 게시글 조회 시 에러 발생

### DIFF
--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -33,7 +33,6 @@ public class Post extends BaseTimeEntity {
     private String title;
 
     @NotNull
-    @Future
     @Column(nullable = false)
     private LocalDateTime deadline;
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] @Future 어노테이션 제거

## 💡 자세한 설명
마감 시간이 지난 게시글 조회 시 `{"message":"must be a future date"}`와 같은 에러가 발생헀습니다.

이유를 찾아보니, 게시글 조회를 할 때 조회수를 올려주기 위해서 update 쿼리도 같이 실행되는데, 그 때 게시글의 작성일자도 새로 업데이트 되기 떄문에 발생한 문제 였습니다.

![스크린샷 2024-04-16 오후 9 55 43](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/78118588/bac06bc3-6f76-4978-a23a-7461019b0da9)

Post의 deadline attribute에서 `@Future` 어노테이션을 삭제하니, 조회할 때 더 이상 에러가 발생하지 않았습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #309 
