### PR TITLE
답글 목록 조회 응답에 작성자 ID 추가

### DIFF
--- a/src/main/java/balancetalk/module/comment/dto/ReplyResponse.java
+++ b/src/main/java/balancetalk/module/comment/dto/ReplyResponse.java
@@ -45,6 +45,9 @@ public class ReplyResponse {
     @Schema(description = "답글 수정 날짜")
     private LocalDateTime lastModifiedAt;
 
+    @Schema(description = "답글 작성자 ID")
+    private Long writerId;
+
     @Schema(description = "답글 작성자 프로필 사진 경로", example = "https://balance-talk-static-files4df23447-2355-45h2-8783-7f6gd2ceb848_프로필.jpg")
     private String profileImageUrl;
 
@@ -60,6 +63,7 @@ public class ReplyResponse {
                 .myLike(myLike)
                 .createdAt(comment.getCreatedAt())
                 .lastModifiedAt(comment.getLastModifiedAt())
+                .writerId(comment.getMember().getId())
                 .profileImageUrl(getProfileImageUrl(comment.getMember()))
                 .build();
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 답글 목록 조회 API 응답에 작성자 ID 추가

## 💡 자세한 설명
기존 답글 목록 조회 시 작성자 ID가 누락되었습니다.
따라서 답글 목록 조회 API 응답에 작성자 ID를 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #310 
