### PR TITLE
게시글 응답 DTO에 마감 여부 필드 추가

### DIFF
--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -7,13 +7,17 @@ import balancetalk.module.comment.domain.Comment;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.report.domain.Report;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Formula;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.hibernate.annotations.Formula;
 
 @Entity
 @Getter
@@ -93,7 +97,7 @@ public class Post extends BaseTimeEntity {
         }
         return comments.size();
     }
-    
+
     @PrePersist
     public void init() {
         this.views = 0L;
@@ -114,5 +118,9 @@ public class Post extends BaseTimeEntity {
 
     public void increaseViews() {
         views++;
+    }
+
+    public boolean isClosed() {
+        return LocalDateTime.now().isAfter(deadline);
     }
 }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -1,6 +1,5 @@
 package balancetalk.module.post.dto;
 
-import balancetalk.module.ViewStatus;
 import balancetalk.module.file.domain.File;
 import balancetalk.module.member.domain.Member;
 import balancetalk.module.post.domain.BalanceOption;
@@ -8,7 +7,10 @@ import balancetalk.module.post.domain.Post;
 import balancetalk.module.post.domain.PostCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +31,9 @@ public class PostResponse {
     @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
     @Schema(description = "투료 종료 기한", example = "2024/12/25 15:30:00")
     private LocalDateTime deadline;
+
+    @Schema(description = "마감 여부", example = "true")
+    private Boolean isClosed;
 
     @Schema(description = "게시글 조회수", example = "126")
     private long views;
@@ -86,6 +91,7 @@ public class PostResponse {
                 .id(post.getId())
                 .title(post.getTitle())
                 .deadline(post.getDeadline())
+                .isClosed(post.isClosed())
                 .views(post.getViews())
 //                .viewStatus(post.getViewStatus())
                 .likesCount(post.likesCount())
@@ -140,11 +146,11 @@ public class PostResponse {
                 .orElse(null);
     }
 
-        private static int getTotalVotes (Post post){
-            return Optional.ofNullable(post.getOptions())
-                    .map(options -> options.stream()
-                            .mapToInt(option -> Optional.ofNullable(option.getVotes()).map(List::size).orElse(0))
-                            .sum())
-                    .orElse(0);
+    private static int getTotalVotes(Post post) {
+        return Optional.ofNullable(post.getOptions())
+                .map(options -> options.stream()
+                        .mapToInt(option -> Optional.ofNullable(option.getVotes()).map(List::size).orElse(0))
+                        .sum())
+                .orElse(0);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] Post에 마감 여부 체크 메서드 추가
- [x] PostResponse에 마감 여부 필드 추가

## 💡 자세한 설명
프론트엔드 요청으로 게시글 조회 시 마감 여부 필드를 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #314 
