### PR TITLE
게시글 조회 시 마감 여부 필터링 로직 추가

### DIFF
--- a/src/main/java/balancetalk/module/post/domain/Post.java
+++ b/src/main/java/balancetalk/module/post/domain/Post.java
@@ -119,8 +119,4 @@ public class Post extends BaseTimeEntity {
     public void increaseViews() {
         views++;
     }
-
-    public boolean isClosed() {
-        return LocalDateTime.now().isAfter(deadline);
-    }
 }

--- a/src/main/java/balancetalk/module/post/domain/PostRepository.java
+++ b/src/main/java/balancetalk/module/post/domain/PostRepository.java
@@ -1,10 +1,11 @@
 package balancetalk.module.post.domain;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByMemberId(Long id, Pageable pageable);
@@ -25,4 +26,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "JOIN pt.tag t " +
             "WHERE t.name = :tagName")
     List<Post> findByPostTagsContaining(String tagName);
+
+    @Query("select p from Post p where p.deadline > function('now')")
+    Page<Post> findAllOnlyOpened(Pageable pageable);
 }

--- a/src/main/java/balancetalk/module/post/dto/PostResponse.java
+++ b/src/main/java/balancetalk/module/post/dto/PostResponse.java
@@ -32,9 +32,6 @@ public class PostResponse {
     @Schema(description = "투료 종료 기한", example = "2024/12/25 15:30:00")
     private LocalDateTime deadline;
 
-    @Schema(description = "마감 여부", example = "true")
-    private Boolean isClosed;
-
     @Schema(description = "게시글 조회수", example = "126")
     private long views;
 
@@ -91,7 +88,6 @@ public class PostResponse {
                 .id(post.getId())
                 .title(post.getTitle())
                 .deadline(post.getDeadline())
-                .isClosed(post.isClosed())
                 .views(post.getViews())
 //                .viewStatus(post.getViewStatus())
                 .likesCount(post.likesCount())

--- a/src/main/java/balancetalk/module/post/presentation/PostController.java
+++ b/src/main/java/balancetalk/module/post/presentation/PostController.java
@@ -6,7 +6,6 @@ import balancetalk.module.post.dto.PostResponse;
 import balancetalk.module.report.dto.ReportRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -26,7 +27,7 @@ public class PostController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    @Operation(summary = "게시글 생성" , description = "로그인 상태인 회원이 게시글을 작성한다.")
+    @Operation(summary = "게시글 생성", description = "로그인 상태인 회원이 게시글을 작성한다.")
     public PostResponse createPost(@Valid @RequestBody final PostRequest postRequestDto) {
         return postService.save(postRequestDto);
     }
@@ -35,8 +36,9 @@ public class PostController {
     @GetMapping
     @Operation(summary = "모든 게시글 조회", description = "해당 회원이 쓴 모든 글을 조회한다.")
     public Page<PostResponse> findAllPosts(@RequestHeader(value = "Authorization", required = false) String token,
+                                           @RequestParam Boolean closed,
                                            Pageable pageable) {
-        return postService.findAll(token, pageable);
+        return postService.findAll(token, closed, pageable);
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -66,7 +68,7 @@ public class PostController {
     @GetMapping("/tag")
     @Operation(summary = "게시글 태그 검색 기능", description = "태그에 맞는 모든 게시글을 조회한다.")
     public List<PostResponse> findPostsByTag(@RequestHeader(value = "Authorization", required = false) String token,
-                                               @RequestParam String tagName) {
+                                             @RequestParam String tagName) {
         return postService.findPostsByTag(token, tagName);
     }
 

--- a/src/test/java/balancetalk/module/post/application/PostServiceTest.java
+++ b/src/test/java/balancetalk/module/post/application/PostServiceTest.java
@@ -49,7 +49,7 @@ class PostServiceTest {
 
     @InjectMocks
     PostService postService;
-    
+
     Member member = Member.builder()
             .id(1L)
             .email("member@gmail.com")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 마감 여부에 따른 분기 처리를 통해 게시글 조회 메서드 분리

## 💡 자세한 설명
```java
@Transactional(readOnly = true)
public Page<PostResponse> findAll(String token, Boolean containsClosed, Pageable pageable) {
    Page<Post> posts = getPosts(containsClosed, pageable);

    // 기존 로직과 동일
}

// 마감 여부에 따른 분기 처리
private Page<Post> getPosts(Boolean containsClosed, Pageable pageable) {
    if (containsClosed) {
        return postRepository.findAll(pageable);
    }
    return postRepository.findAllOnlyOpened(pageable);
}
```
```java
@Query("select p from Post p where p.deadline > function('now')")
Page<Post> findAllOnlyOpened(Pageable pageable);
```

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #319 
