### PR TITLE
API 명세 수정(댓글, 댓글 좋아요) 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -84,7 +84,7 @@ public class CommentService {
 
     public Comment updateComment(Long commentId, Long talkPickId, String content) {
         Comment comment = validateCommentId(commentId);
-        validateTalkPickId(talkPickId);
+        validateTalkPickId(talkPickId); // TODO: talkPickId를 굳이 클라이언트로 받아야하는가?
 
         if (!getCurrentMember(memberRepository).equals(comment.getMember())) {
             throw new BalanceTalkException(FORBIDDEN_COMMENT_MODIFY);

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -74,7 +74,7 @@ public class CommentDto {
         @Schema(description = "현재 사용자의 좋아요 여부", example = "true")
         private Boolean myLike;
 
-        @Schema(description = "부모 댓글 id", example = "null")
+        @Schema(description = "부모 댓글 id (답글이 아닐 경우, null 반환)", example = "5")
         private Long parentId;
 
         @Schema(description = "답글 수", example = "3")

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -74,8 +74,14 @@ public class CommentDto {
         @Schema(description = "현재 사용자의 좋아요 여부", example = "true")
         private Boolean myLike;
 
+        @Schema(description = "부모 댓글 id", example = "null")
+        private Long parentId;
+
         @Schema(description = "답글 수", example = "3")
         private int replyCount;
+
+        @Schema(description = "베스트 댓글 여부", example = "true")
+        private boolean isBest;
 
         @Schema(description = "댓글 생성 날짜")
         private LocalDateTime createdAt;
@@ -92,7 +98,9 @@ public class CommentDto {
                     .option(comment.getVoteOption())
                     //.likesCount(comment.getLikes().size()) TODO : 좋아요 구현 시 작성
                     .myLike(myLike)
+                    .parentId(comment.getParent() == null ? null : comment.getParent().getId())
                     //.replyCount(comment.getReplies().size())
+                    .isBest(comment.isBest())
                     .createdAt(comment.getCreatedAt())
                     .lastModifiedAt(comment.getLastModifiedAt())
                     .build();

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -29,14 +29,14 @@ public class CommentController {
     }
 
     @GetMapping
-    @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글을 최신순으로 정렬해 조회한다.")
+    @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 최신순으로 정렬해 조회한다.")
     public Page<CommentDto.Response> findAllCommentsByPostId(@PathVariable Long talkPickId, Pageable pageable,
                                                              @RequestHeader(value = "Authorization", required = false) String token) {
         return commentService.findAllComments(talkPickId, token, pageable);
     }
 
     @GetMapping("/best")
-    @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
+    @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
     public Page<CommentDto.Response> findAllBestCommentsByPostId(@PathVariable Long talkPickId, Pageable pageable,
                                                                  @RequestHeader(value = "Authorization", required = false) String token) {
         return commentService.findAllComments(talkPickId, token, pageable);
@@ -54,15 +54,15 @@ public class CommentController {
      */
 
     @PutMapping("/{commentId}")
-    @Operation(summary = "댓글 수정", description = "talkPick-id에 해당하는 댓글 내용을 수정한다.")
+    @Operation(summary = "댓글 수정", description = "commentId에 해당하는 댓글 내용을 수정한다.")
     public String updateComment(@PathVariable Long commentId, @PathVariable Long talkPickId, @RequestBody CommentDto.UpdateRequest request) {
-        commentService.updateComment(commentId, talkPickId, request.getContent());
+            commentService.updateComment(commentId, talkPickId, request.getContent());
         return SUCCESS_RESPONSE_MESSAGE;
     }
 
 
     @DeleteMapping("/{commentId}")
-    @Operation(summary = "댓글 삭제", description = "talkPick-id에 해당하는 댓글을 삭제한다.")
+    @Operation(summary = "댓글 삭제", description = "commentId에 해당하는 댓글을 삭제한다.")
     public String deleteComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
         commentService.deleteComment(commentId, talkPickId);
         return SUCCESS_RESPONSE_MESSAGE;
@@ -70,8 +70,8 @@ public class CommentController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{commentId}/replies")
-    @Operation(summary = "답글 작성", description = "talkPick-id에 해당하는 댓글에 답글을 작성한다.")
-    public String createComment(@PathVariable Long postId, @PathVariable Long commentId, @Valid @RequestBody CommentDto.Request request) {
+    @Operation(summary = "답글 작성", description = "commentId에 해당하는 댓글에 답글을 작성한다.")
+    public String createReply(@PathVariable Long commentId, @Valid @RequestBody CommentDto.Request request) {
         return SUCCESS_RESPONSE_MESSAGE;
     }
 

--- a/src/main/java/balancetalk/like/presentation/LikeController.java
+++ b/src/main/java/balancetalk/like/presentation/LikeController.java
@@ -14,14 +14,14 @@ public class LikeController {
     private static final String SUCCESS_RESPONSE_MESSAGE = "OK";
 
     @PostMapping("/{talkPickId}/{commentId}/likes")
-    @Operation(summary = "댓글 좋아요", description = "talkPick-id에 해당하는 댓글에 추천을 누른다.")
-    public String likeComment(@PathVariable Long talkPickId, @PathVariable Long commentId) {
+    @Operation(summary = "댓글 좋아요", description = "commentId에 해당하는 댓글에 좋아요를 활성화합니다.")
+    public String likeComment(@PathVariable Long commentId) {
         //commentService.likeComment(postId, commentId);
         return SUCCESS_RESPONSE_MESSAGE;
     }
 
     @DeleteMapping("/{talkPickId}/{commentId}/likes")
-    @Operation(summary = "댓글 좋아요 취소", description = "talkPick-id에 해당하는 댓글에 누른 추천을 취소한다.")
+    @Operation(summary = "댓글 좋아요 취소", description = "commentId에 해당하는 댓글의 좋아요를 취소합니다.")
     public String cancelLikeComment(@PathVariable Long commentId) {
         //commentService.cancelLikeComment(commentId);
         return SUCCESS_RESPONSE_MESSAGE;


### PR DESCRIPTION
## 💡 작업 내용
- [x] 답글 작성 API에서 parameter로 commentId만 받도록 수정
- [x] 댓글 목록 조회 API 명세에서 '답글' 까지 반환해줌을 명시
- [x] 댓글 좋아요, 댓글 좋아요 취소 API에서 parameter로 commentId만 받도록 수정
- [x] 댓글 반환 시 댓글 답글 여부 판단 필드 추가 작성 (parentId : "null" or parentId : "1")

## 💡 자세한 설명
위 명시한 사항들 업데이트 완료했습니다.
다만 #363 에러 이슈 발생했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
#363 에러 해결

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #360 
