### PR TITLE
댓글 좋아요, 좋아요 취소 구현 완료

### DIFF
--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "comment", description = "댓글 API")
 public class CommentController {
 
-    private static final String SUCCESS_RESPONSE_MESSAGE = "OK";
+    private static final String SUCCESS_RESPONSE_MESSAGE = "OK"; // TODO : 상수 클래스로 분리
 
     private final CommentService commentService;
 

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -1,0 +1,61 @@
+package balancetalk.like.application;
+
+import balancetalk.comment.domain.Comment;
+import balancetalk.comment.domain.CommentRepository;
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
+import balancetalk.like.domain.Like;
+import balancetalk.like.domain.LikeRepository;
+import balancetalk.like.dto.LikeDto;
+import balancetalk.member.domain.Member;
+import balancetalk.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static balancetalk.global.utils.SecurityUtils.getCurrentMember;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentLikeService {
+
+    private final CommentRepository commentRepository;
+
+    private final LikeRepository likeRepository;
+
+    private final MemberRepository memberRepository;
+
+    public LikeDto.Response likeComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_COMMENT));
+
+        Member member = getCurrentMember(memberRepository);
+        /* TODO : 추후 예외처리
+        boolean alreadyLiked = likeRepository.existsByCommentIdAndMemberId(commentId, member.getId());
+        if (alreadyLiked) {
+            throw new BalanceTalkException(ErrorCode.ALREADY_LIKED);
+        }
+
+         */
+
+        Like commentLike = LikeDto.Request.toCommentLikeEntity(comment, member);
+        likeRepository.save(commentLike);
+
+        return LikeDto.Response.fromEntity(commentLike);
+    }
+
+    public void unLikeComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_COMMENT)); // TODO : 추후 메서드 분리
+
+        Member member = getCurrentMember(memberRepository);
+
+        Like commentLike = likeRepository.findByCommentIdAndMemberId(commentId, member.getId());
+
+        commentLike.deActive();
+
+    }
+
+    // TODO : 추후 예외처리
+}

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -39,7 +39,7 @@ public class CommentLikeService {
 
          */
 
-        Like commentLike = LikeDto.Request.toCommentLikeEntity(comment, member);
+        Like commentLike = LikeDto.Request.toEntity(comment, member);
         likeRepository.save(commentLike);
 
         return LikeDto.Response.fromEntity(commentLike);

--- a/src/main/java/balancetalk/like/domain/Like.java
+++ b/src/main/java/balancetalk/like/domain/Like.java
@@ -5,11 +5,13 @@ import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
+@Builder
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "likes")
 public class Like extends BaseTimeEntity {
 
@@ -33,4 +35,8 @@ public class Like extends BaseTimeEntity {
     private Comment comment;
 
     private Boolean active = true;
+
+    public void deActive() {
+        this.active = false;
+    }
 }

--- a/src/main/java/balancetalk/like/domain/LikeRepository.java
+++ b/src/main/java/balancetalk/like/domain/LikeRepository.java
@@ -1,0 +1,9 @@
+package balancetalk.like.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    Like findByCommentIdAndMemberId(Long commentId, Long MemberId);
+
+    boolean existsByCommentIdAndMemberId(Long commentId, Long MemberId);
+}

--- a/src/main/java/balancetalk/like/dto/LikeDto.java
+++ b/src/main/java/balancetalk/like/dto/LikeDto.java
@@ -30,10 +30,19 @@ public class LikeDto {
         @Schema(description = "좋아요한 톡픽 id", example = "1")
         private Long talkPickId;
 
-        public static Like toCommentLikeEntity(Comment comment, Member member) {
+        public static Like toEntity(Comment comment, Member member) {
             return Like.builder()
                     .likeType(LikeType.COMMENT)
                     .comment(comment)
+                    .member(member)
+                    .active(true)
+                    .build();
+        }
+
+        public static Like toEntity(TalkPick talkPick, Member member) {
+            return Like.builder()
+                    .likeType(LikeType.TALK_PICK)
+                    .talkPick(talkPick)
                     .member(member)
                     .active(true)
                     .build();

--- a/src/main/java/balancetalk/like/dto/LikeDto.java
+++ b/src/main/java/balancetalk/like/dto/LikeDto.java
@@ -1,10 +1,18 @@
 package balancetalk.like.dto;
 
+import balancetalk.comment.domain.Comment;
+import balancetalk.like.domain.Like;
 import balancetalk.like.domain.LikeType;
+import balancetalk.member.domain.Member;
+import balancetalk.talkpick.domain.TalkPick;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 public class LikeDto {
 
@@ -21,12 +29,54 @@ public class LikeDto {
 
         @Schema(description = "좋아요한 톡픽 id", example = "1")
         private Long talkPickId;
+
+        public static Like toCommentLikeEntity(Comment comment, Member member) {
+            return Like.builder()
+                    .likeType(LikeType.COMMENT)
+                    .comment(comment)
+                    .member(member)
+                    .active(true)
+                    .build();
+        }
     }
 
-    @Data
-    @Builder
-    @AllArgsConstructor
-    public static class Response { // TODO : 추후 likeType 별로 분리 필요
+        @Data
+        @Builder
+        @AllArgsConstructor
+        @JsonInclude
+        public static class Response {
 
+            @Schema(description = "좋아요 id", example = "1")
+            private Long id;
+
+            @Schema(description = "좋아요 타입", example = "TALK_PICK")
+            private LikeType likeType;
+
+            @Schema(description = "좋아요한 멤버 id", example = "1")
+            private Long memberId;
+
+            @Schema(description = "좋아요한 댓글 id", example = "1")
+            private Long commentId;
+
+            @Schema(description = "좋아요한 톡픽 id", example = "1")
+            private Long talkPickId;
+
+            @Schema(description = "좋아요 생성 날짜")
+            private LocalDateTime createdAt;
+
+            @Schema(description = "좋아요 변경 날짜")
+            private LocalDateTime lastModifiedAt;
+
+            public static Response fromEntity(Like like) {
+                return Response.builder()
+                        .id(like.getId())
+                        .likeType(like.getLikeType())
+                        .memberId(like.getMember().getId())
+                        .commentId(Optional.ofNullable(like.getComment()).map(Comment::getId).orElse(null))
+                        .talkPickId(Optional.ofNullable(like.getTalkPick()).map(TalkPick::getId).orElse(null))
+                        .createdAt(like.getCreatedAt())
+                        .lastModifiedAt(like.getLastModifiedAt())
+                        .build();
+            }
     }
 }

--- a/src/main/java/balancetalk/like/presentation/LikeController.java
+++ b/src/main/java/balancetalk/like/presentation/LikeController.java
@@ -25,7 +25,7 @@ public class LikeController {
 
     @DeleteMapping("/{talkPickId}/{commentId}/likes")
     @Operation(summary = "댓글 좋아요 취소", description = "commentId에 해당하는 댓글의 좋아요를 취소합니다.")
-    public String cancelLikeComment(@PathVariable Long commentId) {
+    public String unlikeComment(@PathVariable Long commentId) { // TODO : 추후 talkPickId 파라미터를 받아 validate 필요
         commentLikeService.unLikeComment(commentId);
         return SUCCESS_RESPONSE_MESSAGE;
     }

--- a/src/main/java/balancetalk/like/presentation/LikeController.java
+++ b/src/main/java/balancetalk/like/presentation/LikeController.java
@@ -1,5 +1,6 @@
 package balancetalk.like.presentation;
 
+import balancetalk.like.application.CommentLikeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,17 +14,19 @@ public class LikeController {
 
     private static final String SUCCESS_RESPONSE_MESSAGE = "OK";
 
+    private final CommentLikeService commentLikeService;
+
     @PostMapping("/{talkPickId}/{commentId}/likes")
     @Operation(summary = "댓글 좋아요", description = "commentId에 해당하는 댓글에 좋아요를 활성화합니다.")
     public String likeComment(@PathVariable Long commentId) {
-        //commentService.likeComment(postId, commentId);
+        commentLikeService.likeComment(commentId);
         return SUCCESS_RESPONSE_MESSAGE;
     }
 
     @DeleteMapping("/{talkPickId}/{commentId}/likes")
     @Operation(summary = "댓글 좋아요 취소", description = "commentId에 해당하는 댓글의 좋아요를 취소합니다.")
     public String cancelLikeComment(@PathVariable Long commentId) {
-        //commentService.cancelLikeComment(commentId);
+        commentLikeService.unLikeComment(commentId);
         return SUCCESS_RESPONSE_MESSAGE;
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 좋아요 구현
- [x] 댓글 좋아요 취소 구현

## 💡 자세한 설명
#### Postman 테스트 완료

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/c19af734-bdcb-48d5-b903-5166d9b2f1e4)
`LikeDto` 의 `Request` 에서 메서드 오버로딩을 이용해 `toEntity` 메서드를 2개 작성했습니다.
매개변수로 받는 값이 `Comment` 인지 `TalkPick` 인지에 따라 다른 `LikeType`을 가지는 `Like` 객체를 반환합니다.

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/36e80d0e-ff7f-4fff-a1a4-c583cbf5b24d)
또한 CommentLikeService 클래스를 작성했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
1. `CommentLikeService`, `TalkPickLikeService` 두 개로 분할해야 할까요, 아니면 `LikeService` 하나로 통합해야 할까요?

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/7125c2e1-ab2f-4258-bc09-125b31cd3121)

2. 좋아요 취소 시 Like 객체를 삭제하지 않고, deActive() 메서드로 객체를 그대로 유지하면서 `boolean active` 값만 변경하는 게 좋은 방법일까요? 

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/2ed341c2-e8cb-4ef0-a7f3-d255a725e63f)

3. unlikeComment 메서드에 사용된 `@DeleteMapping` 이 적절할까요?
## 🚩 후속 작업 (선택)
1. 댓글 정렬 기능 구현
2. 메서드 분리
3. 예외 처리

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #366 
