### PR TITLE
댓글 좋아요 기능 예외 처리 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -238,7 +238,7 @@ public class CommentService {
 
     private TalkPick validateTalkPickId(Long talkPickId) {
         return talkPickRepository.findById(talkPickId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_POST)); // TODO : 에러메시지 수정 필요
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK)); // TODO : 에러메시지 수정 필요
     }
 
     private Comment validateCommentId(Long commentId) {

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -53,7 +53,7 @@ public enum ErrorCode {
     FORBIDDEN_COMMENT_REPORT(FORBIDDEN, "본인 댓글을 신고할 수 없습니다."),
 
     // 404
-    NOT_FOUND_POST(NOT_FOUND, "존재하지 않는 게시글입니다."),
+    NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 게시글입니다."),
     NOT_FOUND_BALANCE_OPTION(NOT_FOUND, "존재하지 않는 선택지입니다."),
     NOT_FOUND_MEMBER(NOT_FOUND, "존재하지 않는 회원입니다."),
     NOT_FOUND_VOTE(NOT_FOUND, "해당 게시글에서 투표한 기록이 존재하지 않습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -66,12 +66,13 @@ public enum ErrorCode {
     NOT_FOUND_PARENT_COMMENT(NOT_FOUND, "존재하지 않는 원 댓글입니다."),
     NOT_FOUND_COMMENT_AT_THAT_POST(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
     NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
+    NOT_LIKED_COMMENT(NOT_FOUND, "해당 댓글을 좋아요한 기록이 존재하지 않습니다."),
 
 
     // 409
     ALREADY_VOTE(CONFLICT, "이미 투표한 게시글입니다."),
-    ALREADY_LIKE_COMMENT(CONFLICT, "이미 추천을 누른 댓글입니다."),
-    ALREADY_LIKE_POST(CONFLICT, "이미 추천을 누른 게시글입니다."),
+    ALREADY_LIKED_COMMENT(CONFLICT, "이미 추천을 누른 댓글입니다."),
+    ALREADY_LIKED_POST(CONFLICT, "이미 추천을 누른 게시글입니다."),
     ALREADY_CANCEL_LIKE_POST(CONFLICT, "이미 추천 취소를 누른 게시글입니다"),
     ALREADY_REGISTERED_NICKNAME(CONFLICT, "이미 등록된 닉네임입니다."),
     ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 등록된 이메일입니다."),

--- a/src/main/java/balancetalk/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/balancetalk/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package balancetalk.global.exception;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,9 +20,10 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BalanceTalkException.class)
-    public ErrorResponse handleBalanceTalkException(BalanceTalkException e) {
+    public ResponseEntity<ErrorResponse> handleBalanceTalkException(BalanceTalkException e) {
+        ErrorResponse response = ErrorResponse.from(e.getErrorCode().getHttpStatus(), e.getMessage());
         log.error("exception message = {}", e.getMessage());
-        return ErrorResponse.from(e.getErrorCode().getHttpStatus(), e.getMessage());
+        return ResponseEntity.status(response.getHttpStatus()).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -8,13 +8,10 @@ import balancetalk.like.domain.LikeRepository;
 import balancetalk.like.dto.LikeDto;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
-import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 import static balancetalk.global.exception.ErrorCode.*;
 import static balancetalk.global.utils.SecurityUtils.getCurrentMember;
@@ -32,7 +29,7 @@ public class CommentLikeService {
 
     private final TalkPickRepository talkPickRepository;
 
-    public LikeDto.LikeResponse likeComment(Long commentId, Long talkPickId) {
+    public void likeComment(Long commentId, Long talkPickId) {
         // 톡픽, 댓글, 회원 존재 여부 예외 처리
         validateTalkPick(talkPickId);
         Comment comment = validateComment(commentId);
@@ -47,8 +44,6 @@ public class CommentLikeService {
 
         Like commentLike = LikeDto.CreateLikeRequest.toEntity(comment, member);
         likeRepository.save(commentLike);
-
-        return LikeDto.LikeResponse.fromEntity(commentLike); // TODO : 제거
     }
 
     public void unLikeComment(Long commentId, Long talkPickId) {
@@ -68,8 +63,8 @@ public class CommentLikeService {
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_COMMENT));
     }
 
-    private TalkPick validateTalkPick(Long talkPickId) {
-        return talkPickRepository.findById(talkPickId)
+    private void validateTalkPick(Long talkPickId) {
+        talkPickRepository.findById(talkPickId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
     }
 }

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -29,6 +29,7 @@ public class CommentLikeService {
 
     private final TalkPickRepository talkPickRepository;
 
+    @Transactional
     public void likeComment(Long commentId, Long talkPickId) {
         // 톡픽, 댓글, 회원 존재 여부 예외 처리
         validateTalkPick(talkPickId);
@@ -46,6 +47,7 @@ public class CommentLikeService {
         likeRepository.save(commentLike);
     }
 
+    @Transactional
     public void unLikeComment(Long commentId, Long talkPickId) {
         validateTalkPick(talkPickId);
         validateComment(commentId);
@@ -54,6 +56,10 @@ public class CommentLikeService {
         // 좋아요를 누르지 않은 댓글에 좋아요 취소를 누를 경우 예외 처리
         Like commentLike = likeRepository.findByCommentIdAndMemberId(commentId, member.getId())
                 .orElseThrow(() -> new BalanceTalkException(NOT_LIKED_COMMENT));
+
+        if (!commentLike.getActive()) {
+            throw new BalanceTalkException(NOT_LIKED_COMMENT);
+        }
 
         commentLike.deActive();
     }

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -8,6 +8,8 @@ import balancetalk.like.domain.LikeRepository;
 import balancetalk.like.dto.LikeDto;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
+import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.talkpick.domain.TalkPickRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,9 +30,12 @@ public class CommentLikeService {
 
     private final MemberRepository memberRepository;
 
-    public LikeDto.LikeResponse likeComment(Long commentId) {
-        Comment comment = validateComment(commentId);
+    private final TalkPickRepository talkPickRepository;
 
+    public LikeDto.LikeResponse likeComment(Long commentId, Long talkPickId) {
+        // 톡픽, 댓글, 회원 존재 여부 예외 처리
+        validateTalkPick(talkPickId);
+        Comment comment = validateComment(commentId);
         Member member = getCurrentMember(memberRepository);
 
         // 이미 좋아요를 누른 댓글일 경우 예외 처리
@@ -46,9 +51,9 @@ public class CommentLikeService {
         return LikeDto.LikeResponse.fromEntity(commentLike); // TODO : 제거
     }
 
-    public void unLikeComment(Long commentId) {
+    public void unLikeComment(Long commentId, Long talkPickId) {
+        validateTalkPick(talkPickId);
         validateComment(commentId);
-
         Member member = getCurrentMember(memberRepository);
 
         // 좋아요를 누르지 않은 댓글에 좋아요 취소를 누를 경우 예외 처리
@@ -61,5 +66,10 @@ public class CommentLikeService {
     private Comment validateComment(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_COMMENT));
+    }
+
+    private TalkPick validateTalkPick(Long talkPickId) {
+        return talkPickRepository.findById(talkPickId)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
     }
 }

--- a/src/main/java/balancetalk/like/domain/LikeRepository.java
+++ b/src/main/java/balancetalk/like/domain/LikeRepository.java
@@ -1,9 +1,10 @@
 package balancetalk.like.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-    Like findByCommentIdAndMemberId(Long commentId, Long MemberId);
+    Optional<Like> findByCommentIdAndMemberId(Long commentId, Long MemberId);
 
     boolean existsByCommentIdAndMemberId(Long commentId, Long MemberId);
 }

--- a/src/main/java/balancetalk/like/dto/LikeDto.java
+++ b/src/main/java/balancetalk/like/dto/LikeDto.java
@@ -41,13 +41,13 @@ public class LikeDto {
         @Builder
         @AllArgsConstructor
         @JsonInclude
-        @Schema(description = "좋아요 조회 응답")
+        @Schema(description = "좋아요 조회 응답 (현재 미사용)")
         public static class LikeResponse {
 
             @Schema(description = "좋아요 id", example = "1")
             private Long id;
 
-            @Schema(description = "좋아요 타입", example = "TALK_PICK")
+            @Schema(description = "좋아요 타입", example = "COMMENT")
             private LikeType likeType;
 
             @Schema(description = "좋아요한 멤버 id", example = "1")

--- a/src/main/java/balancetalk/like/presentation/LikeController.java
+++ b/src/main/java/balancetalk/like/presentation/LikeController.java
@@ -16,13 +16,13 @@ public class LikeController {
 
     @PostMapping("/{talkPickId}/{commentId}/likes")
     @Operation(summary = "댓글 좋아요", description = "commentId에 해당하는 댓글에 좋아요를 활성화합니다.")
-    public void likeComment(@PathVariable Long commentId) {
-        commentLikeService.likeComment(commentId);
+    public void likeComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
+        commentLikeService.likeComment(commentId, talkPickId);
     }
 
     @DeleteMapping("/{talkPickId}/{commentId}/likes")
     @Operation(summary = "댓글 좋아요 취소", description = "commentId에 해당하는 댓글의 좋아요를 취소합니다.")
-    public void unlikeComment(@PathVariable Long commentId) { // TODO : 추후 talkPickId 파라미터를 받아 validate 필요
-        commentLikeService.unLikeComment(commentId);
+    public void unlikeComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
+        commentLikeService.unLikeComment(commentId, talkPickId);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 좋아요 기능 예외 처리

## 💡 자세한 설명
### postman 테스트 완료

### 댓글 좋아요 기능 예외 처리
1. 멤버 존재 여부
2. 해당 톡픽 존재 여부
3. 해당 댓글 존재 여부
4. 이미 좋아요 상태인지

### 댓글 좋아요 취소 기능 예외 처리
1. 멤버 존재 여부
2. 해당 톡픽 존재 여부
3. 해당 댓글 존재 여부
4. 이미 좋아요 취소 상태인지
    - `Like` 객체 미생성인 경우
    - `Like` 객체는 존재하나, `active` 필드가 false인 경우 

### 서비스 메서드 void 타입 처리 + `LikeDto`의 `LikeResponse` 비활성화
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/77971759-fda3-4a9a-8222-07bfea14839b)
컨트롤러에서 더 이상 추가적인 응답을 필요로 하지 않으므로, 메서드들을 void 타입으로 바꿨습니다.  따라서 응답 Dto도 사용하지 않으므로, 해당 Schema 설명을 변경했습니다.

### [Error] 예외 처리 시 상태 코드가 `200 OK` 로 통일되던 에러 해결
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/5e432db5-f337-4531-843f-52524ff7266a)
핸들러 메서드의 반환 타입을 동적인 `ResponseEntity` 로 바꿔줌으로서 해결됐습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #375 
