### PR TITLE
오늘의 톡픽 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -7,7 +7,7 @@ import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.talkpick.domain.TalkPick;
-import balancetalk.talkpick.domain.TalkPickRepository;
+import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import balancetalk.vote.domain.VoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/balancetalk/global/config/QuerydslConfig.java
+++ b/src/main/java/balancetalk/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package balancetalk.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -8,7 +8,7 @@ import balancetalk.like.domain.LikeRepository;
 import balancetalk.like.dto.LikeDto;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
-import balancetalk.talkpick.domain.TalkPickRepository;
+import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/balancetalk/talkpick/application/TodayTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TodayTalkPickService.java
@@ -1,0 +1,18 @@
+package balancetalk.talkpick.application;
+
+import balancetalk.talkpick.domain.repository.TalkPickRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static balancetalk.talkpick.dto.TodayTalkPickDto.TodayTalkPickResponse;
+
+@Service
+@RequiredArgsConstructor
+public class TodayTalkPickService {
+
+    private final TalkPickRepository talkPickRepository;
+
+    public TodayTalkPickResponse findTodayTalkPick() {
+        return talkPickRepository.findTodayTalkPick();
+    }
+}

--- a/src/main/java/balancetalk/talkpick/domain/TalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPickRepository.java
@@ -1,6 +1,0 @@
-package balancetalk.talkpick.domain;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface TalkPickRepository extends JpaRepository<TalkPick, Long> {
-}

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
@@ -1,0 +1,7 @@
+package balancetalk.talkpick.domain.repository;
+
+import balancetalk.talkpick.domain.TalkPick;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TalkPickRepository extends JpaRepository<TalkPick, Long>, TalkPickRepositoryCustom {
+}

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryCustom.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryCustom.java
@@ -1,0 +1,8 @@
+package balancetalk.talkpick.domain.repository;
+
+import static balancetalk.talkpick.dto.TodayTalkPickDto.TodayTalkPickResponse;
+
+public interface TalkPickRepositoryCustom {
+
+    TodayTalkPickResponse findTodayTalkPick();
+}

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -1,0 +1,30 @@
+package balancetalk.talkpick.domain.repository;
+
+import balancetalk.talkpick.dto.QTodayTalkPickDto_TodayTalkPickResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static balancetalk.talkpick.domain.QTalkPick.talkPick;
+import static balancetalk.talkpick.dto.TodayTalkPickDto.TodayTalkPickResponse;
+import static balancetalk.vote.domain.QVote.vote;
+
+@RequiredArgsConstructor
+public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public TodayTalkPickResponse findTodayTalkPick() {
+        return queryFactory
+                .select(new QTodayTalkPickDto_TodayTalkPickResponse(
+                        talkPick.id, talkPick.title, talkPick.summary, talkPick.optionA, talkPick.optionB
+                ))
+                .from(vote)
+                .join(vote.talkPick, talkPick)
+                .where(talkPick.id.eq(vote.talkPick.id))
+                .groupBy(talkPick.id)
+                .orderBy(vote.count().desc())
+                .limit(1)
+                .fetchOne();
+    }
+}

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -23,7 +23,7 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
                 .join(vote.talkPick, talkPick)
                 .where(talkPick.id.eq(vote.talkPick.id))
                 .groupBy(talkPick.id)
-                .orderBy(vote.count().desc())
+                .orderBy(vote.count().desc(), talkPick.createdAt.desc())
                 .limit(1)
                 .fetchOne();
     }

--- a/src/main/java/balancetalk/talkpick/dto/TodayTalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TodayTalkPickDto.java
@@ -1,14 +1,13 @@
 package balancetalk.talkpick.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 public class TodayTalkPickDto {
 
     @Schema(description = "오늘의 톡픽 조회 (메인 페이지) 응답")
     @Data
-    @AllArgsConstructor
     public static class TodayTalkPickResponse {
 
         @Schema(description = "톡픽 ID", example = "톡픽 ID")
@@ -25,5 +24,14 @@ public class TodayTalkPickDto {
 
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB; // TODO "X"로 자동 지정
+
+        @QueryProjection
+        public TodayTalkPickResponse(Long id, String title, String summary, String optionA, String optionB) {
+            this.id = id;
+            this.title = title;
+            this.summary = summary;
+            this.optionA = optionA;
+            this.optionB = optionB;
+        }
     }
 }

--- a/src/main/java/balancetalk/talkpick/presentation/TodayTalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/TodayTalkPickController.java
@@ -1,22 +1,26 @@
 package balancetalk.talkpick.presentation;
 
+import balancetalk.talkpick.application.TodayTalkPickService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Pageable;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static balancetalk.talkpick.dto.TodayTalkPickDto.TodayTalkPickResponse;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/talks/today")
 @Tag(name = "talk_pick", description = "톡픽 API")
 public class TodayTalkPickController {
 
+    private final TodayTalkPickService todayTalkPickService;
+
     @Operation(summary = "오늘의 톡픽 조회 (메인)", description = "메인 페이지에서 오늘의 톡픽을 조회합니다.")
     @GetMapping
-    public TodayTalkPickResponse findTodayTalkPick(final Pageable pageable) {
-        return new TodayTalkPickResponse(1L, "제목", "요약", "O", "X");
+    public TodayTalkPickResponse findTodayTalkPick() {
+        return todayTalkPickService.findTodayTalkPick();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] QueryDSL 세팅
- [x] 오늘의 톡픽 조회 기능 구현

## 💡 자세한 설명
### QueryDSL 세팅
QueryDSL을 사용하기 위해 의존성 추가 및 설정 클래스를 작성했습니다.

<img width="967" alt="스크린샷 2024-07-05 오후 11 15 15" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/110653660/9b9d1e93-1116-4c69-9f62-6c01a2903aff">

<img width="499" alt="스크린샷 2024-07-05 오후 11 15 24" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/110653660/508c1379-de37-4cf2-ba05-3c02f8a2b8cb">

### 오늘의 톡픽 조회 기능 구현
현재 요구사항에 따르면, 투표수가 가장 많으면서 최근에 생성된 톡픽이 오늘의 톡픽으로 선정됩니다.
따라서 오늘의 톡픽을 따로 선정하는 과정 없이, 그룹과 정렬을 통해 조회하도록 구현했습니다.

<img width="863" alt="스크린샷 2024-07-05 오후 11 30 23" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/110653660/19b17b7f-77ca-49da-97fe-8d6a2bab8e70">

QueryDSL을 이용해 기능을 구현했으며, 다음과 같이 실제 쿼리가 잘 생성되는 것을 확인했습니다.

<img width="471" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/110653660/26311c29-ceda-4dfc-93f5-c51e32c64057">

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #371 
