### PR TITLE
답글 작성 기능 구현 및 예외 처리 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -52,16 +52,11 @@ public class CommentService {
         return CommentDto.CommentResponse.fromEntity(comment, false);
     }
 
-    public void createCommentReply(CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId) {
+    @Transactional
+    public void createCommentReply(CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId, Long commentId) {
         Member member = getCurrentMember(memberRepository);
         TalkPick talkPick = validateTalkPickId(talkPickId);
-
-        // 요청 본문에 parentId가 없는 경우 예외 처리 TODO : 추후 예외처리 메서드들 분리
-        if (createCommentRequest.getParentId() == null) {
-            throw new BalanceTalkException(NOT_INPUT_PARENT_COMMENT_ID);
-        }
-
-        Comment parentComment = validateCommentId(createCommentRequest.getParentId());
+        Comment parentComment = validateCommentId(commentId);
 
         // 부모 댓글 존재 여부 예외 처리
         validateCommentId(parentComment.getId());

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -56,11 +56,24 @@ public class CommentService {
         Member member = getCurrentMember(memberRepository);
         TalkPick talkPick = validateTalkPickId(talkPickId);
 
+        // 요청 본문에 parentId가 없는 경우 예외 처리 TODO : 추후 예외처리 메서드들 분리
         if (createCommentRequest.getParentId() == null) {
             throw new BalanceTalkException(NOT_INPUT_PARENT_COMMENT_ID);
         }
 
         Comment parentComment = validateCommentId(createCommentRequest.getParentId());
+
+        // 부모 댓글 존재 여부 예외 처리
+        validateCommentId(parentComment.getId());
+
+        // 부모 댓글과 연결된 게시글이 아닌 경우 예외 처리
+        if (!parentComment.getTalkPick().equals(talkPick)) {
+            throw new BalanceTalkException(NOT_FOUND_PARENT_COMMENT_AT_THAT_TALK_PICK);
+        }
+
+        // 부모 댓글의 depth가 maxDepth를 초과하는 경우 예외 처리 (답글에 답글 불가)
+        validateDepth(parentComment);
+
 
         Comment commentReply = createCommentRequest.toEntity(member, talkPick, parentComment);
         commentRepository.save(commentReply);

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -52,6 +52,20 @@ public class CommentService {
         return CommentDto.CommentResponse.fromEntity(comment, false);
     }
 
+    public void createCommentReply(CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId) {
+        Member member = getCurrentMember(memberRepository);
+        TalkPick talkPick = validateTalkPickId(talkPickId);
+
+        if (createCommentRequest.getParentId() == null) {
+            throw new BalanceTalkException(NOT_INPUT_PARENT_COMMENT_ID);
+        }
+
+        Comment parentComment = validateCommentId(createCommentRequest.getParentId());
+
+        Comment commentReply = createCommentRequest.toEntity(member, talkPick, parentComment);
+        commentRepository.save(commentReply);
+    }
+
     @Transactional(readOnly = true)
     public Page<CommentDto.CommentResponse> findAllComments(Long talkPickId, String token, Pageable pageable) {
         validateTalkPickId(talkPickId);

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -58,9 +58,6 @@ public class CommentService {
         TalkPick talkPick = validateTalkPickId(talkPickId);
         Comment parentComment = validateCommentId(commentId);
 
-        // 부모 댓글 존재 여부 예외 처리
-        validateCommentId(parentComment.getId());
-
         // 부모 댓글과 연결된 게시글이 아닌 경우 예외 처리
         if (!parentComment.getTalkPick().equals(talkPick)) {
             throw new BalanceTalkException(NOT_FOUND_PARENT_COMMENT_AT_THAT_TALK_PICK);

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -5,12 +5,10 @@ import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public class CommentDto {
     @Data
@@ -25,6 +23,9 @@ public class CommentDto {
         @Schema(description = "선택지", example = "A")
         private VoteOption option;
 
+        @Schema(description = "부모 댓글 id (답글 작성이 아닐 경우, 작성 x)", example = "5")
+        private Long parentId;
+
         public Comment toEntity(Member member, TalkPick talkPick) {
             return Comment.builder()
                     .content(content)
@@ -32,6 +33,17 @@ public class CommentDto {
                     .talkPick(talkPick)
                     .voteOption(option) // TODO : Vote 구현 완료 후 member와 talkPick 이용해서 선택한 option 가져오기
                     .isBest(false)
+                    .build();
+        }
+
+        public Comment toEntity(Member member, TalkPick talkPick, Comment parent) {
+            return Comment.builder()
+                    .content(content)
+                    .member(member)
+                    .talkPick(talkPick)
+                    .voteOption(option) // TODO : Vote 구현 완료 후 member와 talkPick 이용해서 선택한 option 가져오기
+                    .isBest(false)
+                    .parent(parent)
                     .build();
         }
     }
@@ -104,7 +116,7 @@ public class CommentDto {
                     .likesCount(comment.getLikesCount())
                     .myLike(myLike)
                     .parentId(comment.getParent() == null ? null : comment.getParent().getId())
-                    //.replyCount(comment.getReplies().size())
+                    //.replyCount(comment.getReplies().size()) // TODO : 작업
                     .isBest(comment.getIsBest())
                     .createdAt(comment.getCreatedAt())
                     .lastModifiedAt(comment.getLastModifiedAt())

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -28,10 +28,10 @@ public class CommentController {
         commentService.createComment(createCommentRequest, talkPickId);
     }
 
-    @PostMapping("/replies")
+    @PostMapping("/{commentId}/replies")
     @Operation(summary = "답글 작성", description = "commentId에 해당하는 댓글에 답글을 작성한다.")
-    public void createCommentReply(@PathVariable Long talkPickId, @Valid @RequestBody CommentDto.CreateCommentRequest createCommentRequest) {
-        commentService.createCommentReply(createCommentRequest, talkPickId);
+    public void createCommentReply(@PathVariable Long talkPickId, @PathVariable Long commentId, @Valid @RequestBody CommentDto.CreateCommentRequest createCommentRequest) {
+        commentService.createCommentReply(createCommentRequest, talkPickId, commentId);
     }
 
     @GetMapping
@@ -73,13 +73,6 @@ public class CommentController {
     @Operation(summary = "댓글 삭제", description = "commentId에 해당하는 댓글을 삭제한다.")
     public void deleteComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
         commentService.deleteComment(commentId, talkPickId);
-    }
-
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/{commentId}/replies")
-    @Operation(summary = "답글 작성", description = "commentId에 해당하는 댓글에 답글을 작성한다.")
-    public void createReply(@PathVariable Long commentId,
-                            @Valid @RequestBody CommentDto.CreateCommentRequest createCommentRequest) {
     }
 
     /*

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -28,6 +28,12 @@ public class CommentController {
         commentService.createComment(createCommentRequest, talkPickId);
     }
 
+    @PostMapping("/replies")
+    @Operation(summary = "답글 작성", description = "commentId에 해당하는 댓글에 답글을 작성한다.")
+    public void createCommentReply(@PathVariable Long talkPickId, @Valid @RequestBody CommentDto.CreateCommentRequest createCommentRequest) {
+        commentService.createCommentReply(createCommentRequest, talkPickId);
+    }
+
     @GetMapping
     @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 최신순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllCommentsByPostIdSortedByCreatedAt(@PathVariable Long talkPickId, Pageable pageable,

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     EXCEED_VALIDATION_LENGTH(BAD_REQUEST, "입력값이 제약 조건에 맞지 않습니다."),
     AUTHORIZATION_CODE_MISMATCH(BAD_REQUEST, "인증 번호가 일치하지 않습니다."),
     EMPTY_JWT_TOKEN(BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
+    NOT_INPUT_PARENT_COMMENT_ID(BAD_REQUEST, "원 댓글 ID가 입력되지 않았습니다."),
 
 
     // 401

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -64,7 +64,7 @@ public enum ErrorCode {
     NOT_FOUND_DIRECTORY(NOT_FOUND, "존재하지 않는 디렉토리입니다."),
     NOT_SUPPORTED_FILE_TYPE(NOT_FOUND, "지원하지 않는 파일 형식입니다."),
     NOT_FOUND_FILE(NOT_FOUND, "존재하지 않는 파일입니다."),
-    NOT_FOUND_PARENT_COMMENT(NOT_FOUND, "존재하지 않는 원 댓글입니다."),
+    NOT_FOUND_PARENT_COMMENT_AT_THAT_TALK_PICK(NOT_FOUND, "해당 톡픽에 존재하지 않는 원 댓글입니다."),
     NOT_FOUND_COMMENT_AT_THAT_POST(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
     NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
     NOT_LIKED_COMMENT(NOT_FOUND, "해당 댓글을 좋아요한 기록이 존재하지 않습니다."),


### PR DESCRIPTION
## 💡 작업 내용
- [x] 답글 작성 기능 구현
- [x] 답글 예외 처리 구현

## 💡 자세한 설명
### postman 테스트 완료

### 답글 작성 기능 구현 및 예외 처리
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/4f5e9881-d0af-438e-bcea-11d2de20fe2b)

메서드 오버로딩으로 댓글 작성의 경우와 답글 작성의 경우를 분리했습니다.

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/5ab5c658-a3b3-42fd-ad90-a9207756b6ba)
그리고 다음 예외 처리들을 구현했습니다.

1. 멤버 존재 여부
2. 해당 톡픽 존재 여부
3. 부모 댓글 존재 여부
4. 해당 톡픽에 해당 부모 댓글이 존재하는지 여부
5. 부모 댓글의 depth가 maxDepth를 초과하는 경우(답글에 답글 불가)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
**혹시 놓친 예외가 있을까요?**

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #377
