### PR TITLE
댓글 예외 처리 및 Code CleanUp 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -65,7 +65,6 @@ public class CommentService {
         // 부모 댓글의 depth가 maxDepth를 초과하는 경우 예외 처리 (답글에 답글 불가)
         validateDepth(parentComment);
 
-
         Comment commentReply = createCommentRequest.toEntity(member, talkPick, parentComment);
         commentRepository.save(commentReply);
     }

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -44,7 +44,7 @@ public class CommentService {
         // option이 VoteOption에 존재하는 값인지 확인 및 예외 처리
         VoteOption option = createCommentRequest.getOption();
         if (option == null || !EnumSet.allOf(VoteOption.class).contains(option)) {
-            throw new BalanceTalkException(NOT_FOUND_OPTION);
+            throw new BalanceTalkException(NOT_FOUND_VOTE_OPTION);
         }
 
         Comment comment = createCommentRequest.toEntity(member, talkPick);

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -9,7 +9,6 @@ import balancetalk.member.domain.MemberRepository;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import balancetalk.vote.domain.VoteOption;
-import balancetalk.vote.domain.VoteRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,19 +27,16 @@ import static balancetalk.global.utils.SecurityUtils.getCurrentMember;
 @Transactional
 @RequiredArgsConstructor
 public class CommentService {
-
-    private static final int BEST_COMMENTS_SIZE = 3;
     private static final int MIN_COUNT_FOR_BEST_COMMENT = 10;
 
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final TalkPickRepository talkPickRepository;
-    private final VoteRepository voteRepository;
 
     @Value("${comments.max-depth}")
     private int maxDepth;
 
-    public CommentDto.CommentResponse createComment(@Valid CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId) {
+    public void createComment(@Valid CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId) {
         //TODO : Vote 기능 구현 완료 후 추가 예외 처리 필요
         Member member = getCurrentMember(memberRepository);
         TalkPick talkPick = validateTalkPickId(talkPickId);
@@ -53,7 +49,6 @@ public class CommentService {
 
         Comment comment = createCommentRequest.toEntity(member, talkPick);
         commentRepository.save(comment);
-        return CommentDto.CommentResponse.fromEntity(comment, false);
     }
 
     @Transactional

--- a/src/main/java/balancetalk/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/comment/domain/Comment.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.lang.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +48,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "talk_pick_id")
     private TalkPick talkPick;
 
+    @Nullable
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parent;

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -116,7 +116,7 @@ public class CommentDto {
                     .likesCount(comment.getLikesCount())
                     .myLike(myLike)
                     .parentId(comment.getParent() == null ? null : comment.getParent().getId())
-                    //.replyCount(comment.getReplies().size()) // TODO : 작업
+                    .replyCount(comment.getReplies() == null ? 0 : comment.getReplies().size())
                     .isBest(comment.getIsBest())
                     .createdAt(comment.getCreatedAt())
                     .lastModifiedAt(comment.getLastModifiedAt())

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -1,7 +1,8 @@
 package balancetalk.comment.presentation;
 
 import balancetalk.comment.application.CommentService;
-import balancetalk.comment.dto.CommentDto;
+import balancetalk.comment.dto.CommentDto.CreateCommentRequest;
+import balancetalk.comment.dto.CommentDto.UpdateCommentRequest;
 import balancetalk.comment.dto.CommentDto.CommentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,7 +12,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -24,13 +24,13 @@ public class CommentController {
 
     @PostMapping
     @Operation(summary = "댓글 작성", description = "talkPick-id에 해당하는 게시글에 댓글을 작성한다.")
-    public void createComment(@PathVariable Long talkPickId, @Valid @RequestBody CommentDto.CreateCommentRequest createCommentRequest) {
+    public void createComment(@PathVariable Long talkPickId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
         commentService.createComment(createCommentRequest, talkPickId);
     }
 
     @PostMapping("/{commentId}/replies")
     @Operation(summary = "답글 작성", description = "commentId에 해당하는 댓글에 답글을 작성한다.")
-    public void createCommentReply(@PathVariable Long talkPickId, @PathVariable Long commentId, @Valid @RequestBody CommentDto.CreateCommentRequest createCommentRequest) {
+    public void createCommentReply(@PathVariable Long talkPickId, @PathVariable Long commentId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
         commentService.createCommentReply(createCommentRequest, talkPickId, commentId);
     }
 
@@ -50,21 +50,10 @@ public class CommentController {
         return commentService.findAllBestComments(talkPickId, pageable);
     }
 
-    /*
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/best")
-    @Operation(summary = "인기 댓글 조회", description = "추천 수가 가장 많은 댓글을 각 선택지별로 3개씩 조회한다.")
-    public List<BestCommentResponse> findBestComments(@PathVariable Long postId,
-                                                      @RequestHeader(value = "Authorization", required = false) String token) {
-        return null;
-    }
-
-     */
-
     @PutMapping("/{commentId}")
     @Operation(summary = "댓글 수정", description = "commentId에 해당하는 댓글 내용을 수정한다.")
     public void updateComment(@PathVariable Long commentId, @PathVariable Long talkPickId,
-                              @RequestBody CommentDto.UpdateCommentRequest request) {
+                              @RequestBody UpdateCommentRequest request) {
         commentService.updateComment(commentId, talkPickId, request.getContent());
     }
 
@@ -74,25 +63,4 @@ public class CommentController {
     public void deleteComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
         commentService.deleteComment(commentId, talkPickId);
     }
-
-    /*
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/{commentId}/replies")
-    @Operation(summary = "답글 목록 조회", description = "post-id 하위의 comment-id에 해당하는 댓글에 있는 모든 답글을 조회한다.")
-    public List<ReplyResponse> findAllReplies(@PathVariable Long postId, @PathVariable Long commentId,
-                                              @RequestHeader(value = "Authorization", required = false) String token) {
-        return commentService.findAllReplies(postId, commentId, token);
-    }
-    */
-    /*
-
-    @ResponseStatus(HttpStatus.OK)
-    @PostMapping("/{commentId}/report")
-    @Operation(summary = "댓글 신고", description = "comment-id에 해당하는 댓글을 신고 처리한다.")
-    public String reportComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody ReportRequest reportRequest) {
-        commentService.reportComment(postId, commentId, reportRequest);
-        return "신고가 성공적으로 접수되었습니다.";
-    }
-
-     */
 }

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -56,7 +56,7 @@ public enum ErrorCode {
 
     // 404
     NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 게시글입니다."),
-    NOT_FOUND_OPTION(NOT_FOUND, "존재하지 않는 선택지입니다."),
+    NOT_FOUND_VOTE_OPTION(NOT_FOUND, "존재하지 않는 선택지입니다."),
     NOT_FOUND_MEMBER(NOT_FOUND, "존재하지 않는 회원입니다."),
     NOT_FOUND_VOTE(NOT_FOUND, "해당 게시글에서 투표한 기록이 존재하지 않습니다."),
     NOT_FOUND_BOOKMARK(NOT_FOUND, "해당 게시글에서 북마크한 기록이 존재하지 않습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     AUTHORIZATION_CODE_MISMATCH(BAD_REQUEST, "인증 번호가 일치하지 않습니다."),
     EMPTY_JWT_TOKEN(BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
     NOT_INPUT_PARENT_COMMENT_ID(BAD_REQUEST, "원 댓글 ID가 입력되지 않았습니다."),
+    INVALID_VOTE_OPTION(BAD_REQUEST, "존재하지 않는 선택지입니다."),
 
 
     // 401

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -55,7 +55,7 @@ public enum ErrorCode {
 
     // 404
     NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 게시글입니다."),
-    NOT_FOUND_BALANCE_OPTION(NOT_FOUND, "존재하지 않는 선택지입니다."),
+    NOT_FOUND_OPTION(NOT_FOUND, "존재하지 않는 선택지입니다."),
     NOT_FOUND_MEMBER(NOT_FOUND, "존재하지 않는 회원입니다."),
     NOT_FOUND_VOTE(NOT_FOUND, "해당 게시글에서 투표한 기록이 존재하지 않습니다."),
     NOT_FOUND_BOOKMARK(NOT_FOUND, "해당 게시글에서 북마크한 기록이 존재하지 않습니다."),

--- a/src/main/java/balancetalk/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/balancetalk/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package balancetalk.global.exception;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,13 +35,15 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ErrorResponse handleConstraintViolationException(ConstraintViolationException e) {
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
         Set<ConstraintViolation<?>> violations = e.getConstraintViolations();
         String message = violations.stream()
                 .map(ConstraintViolation::getMessage)
                 .collect(Collectors.joining("\n"));
         log.error("exception message = {}", message);
-        return ErrorResponse.from(BAD_REQUEST, message);
+
+        ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, message);
+        return ResponseEntity.status(response.getHttpStatus()).body(response);
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)

--- a/src/main/java/balancetalk/vote/domain/VoteOption.java
+++ b/src/main/java/balancetalk/vote/domain/VoteOption.java
@@ -1,5 +1,26 @@
 package balancetalk.vote.domain;
 
+import balancetalk.global.exception.BalanceTalkException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import static balancetalk.global.exception.ErrorCode.INVALID_VOTE_OPTION;
+
 public enum VoteOption {
-    A, B
+    A, B;
+
+    @JsonCreator
+    public static VoteOption from(String value) {
+        for (VoteOption option : VoteOption.values()) {
+            if (option.name().equals(value)) {
+                return option;
+            }
+        }
+        throw new BalanceTalkException(INVALID_VOTE_OPTION);
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name();
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 제약 조건 검증시 상태 코드 반환 구현
- [x] RequestBody의 `option`과 VoteOption 일치 여부 예외 처리
- [x] `CommentResponse` 응답 시 답글 갯수 반환 구현
- [x] 댓글 코드 cleanup

## 💡 자세한 설명
### postman 테스트 완료

### 제약 조건 검증시 상태 코드 반환 구현
![화면 캡처 2024-07-06 011005](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/843c848f-2ac8-422d-a8c9-eb90b765c292)
위 사진처럼 제약 조건 예외 발생 시, 올바른 상태 코드가 반환되지 않음을 확인했습니다.

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/91f58b88-d9c5-44af-92ef-64732ea74461)
`ConstraintViolationException` 발생 시에도 ResponseEntity를 반환하게 함으로써 올바른 상태 코드를 반환하도록 했습니다.

### RequestBody의 `option`과 `VoteOption` 일치 여부 예외 처리
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/485a185d-18b2-46fb-9cc9-12cdae805621)
댓글, 답글 작성 시 RequestBody로 받는 `option` 값이 `VoteOption` 에 존재하지 않는 값일 때의 예외를 처리하던 중, 역직렬화 문제가 발생했습니다.
``` 
DefaultHandlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Cannot deserialize value of type `balancetalk.vot....
```

이를 처리하기 위해 `VoteOption`에 `@JsonCreator`로 역직렬화 문제를 해결했습니다. postman 테스트 결과 정상적으로 예외 처리 및 상태 코드 반환이 이뤄집니다.

### 댓글 코드 cleanup
사용하지 않는 주석 코드, 필드 등을 제거했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
혹시 빠트린 예외 처리가 있을까요?

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
