### PR TITLE
댓글 좋아요/좋아요 취소 URI 수정 및 추가 예외 처리 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -4,6 +4,7 @@ import balancetalk.comment.domain.Comment;
 import balancetalk.comment.domain.CommentRepository;
 import balancetalk.comment.dto.CommentDto;
 import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.talkpick.domain.TalkPick;
@@ -122,50 +123,42 @@ public class CommentService {
         List<CommentDto.CommentResponse> result = new ArrayList<>();
         result.addAll(bestComments);
         result.addAll(otherComments);
+
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), result.size());
 
         return new PageImpl<>(result.subList(start, end), pageable, result.size());
     }
 
-    public Comment updateComment(Long commentId, Long talkPickId, String content) {
-        Comment comment = validateCommentId(commentId);
-        validateTalkPickId(talkPickId); // TODO: talkPickId를 굳이 클라이언트로 받아야하는가?
+    public void updateComment(Long commentId, Long talkPickId, String content) {
+        Comment comment = validateCommentByMemberAndTalkPick(commentId, talkPickId, FORBIDDEN_COMMENT_MODIFY);
+        comment.updateContent(content);
+    }
 
-        if (!getCurrentMember(memberRepository).equals(comment.getMember())) {
-            throw new BalanceTalkException(FORBIDDEN_COMMENT_MODIFY);
+    public void deleteComment(Long commentId, Long talkPickId) {
+        validateCommentByMemberAndTalkPick(commentId, talkPickId, FORBIDDEN_COMMENT_DELETE);
+        commentRepository.deleteById(commentId);
+    }
+
+    private Comment validateCommentByMemberAndTalkPick(Long commentId, Long talkPickId, ErrorCode errorCode) {
+        Member member = getCurrentMember(memberRepository);
+        Comment comment = validateCommentId(commentId);
+        validateTalkPickId(talkPickId);
+
+        if (!member.equals(comment.getMember())) {
+            throw new BalanceTalkException(errorCode);
         }
 
         if (!comment.getTalkPick().getId().equals(talkPickId)) {
             throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_TALK_PICK);
         }
 
-        comment.updateContent(content);
-    }
-
-    public void deleteComment(Long commentId, Long talkPickId) {
-        validateCommentByMemberAndTalkPick(commentId, talkPickId);
-        commentRepository.deleteById(commentId);
-    }
-
-    private Comment validateCommentByMemberAndTalkPick(Long commentId, Long talkPickId) {
-        Member member = getCurrentMember(memberRepository);
-        Comment comment = validateCommentId(commentId);
-        validateTalkPickId(talkPickId);
-
-        if (!member.equals(comment.getMember())) {
-            throw new BalanceTalkException(FORBIDDEN_COMMENT_MODIFY);
-        }
-
-        if (!comment.getTalkPick().getId().equals(talkPickId)) {
-            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
-        }
         return comment;
     }
 
     private TalkPick validateTalkPickId(Long talkPickId) {
         return talkPickRepository.findById(talkPickId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK)); // TODO : 에러메시지 수정 필요
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
     }
 
     private Comment validateCommentId(Long commentId) {

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -167,7 +167,7 @@ public class CommentService {
         }
 
         if (!comment.getTalkPick().getId().equals(talkPickId)) {
-            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_TALK_PICK);
         }
 
         comment.updateContent(content);
@@ -184,7 +184,7 @@ public class CommentService {
         }
 
         if (!comment.getTalkPick().getId().equals(talkPickId)) {
-            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_POST);
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_TALK_PICK);
         }
 
         commentRepository.deleteById(commentId);

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -56,7 +56,7 @@ public enum ErrorCode {
     FORBIDDEN_LIKE_OWN_COMMENT(FORBIDDEN, "본인 댓글에는 좋아요를 누를 수 없습니다."),
 
     // 404
-    NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 게시글입니다."),
+    NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 톡픽입니다."),
     NOT_FOUND_VOTE_OPTION(NOT_FOUND, "존재하지 않는 선택지입니다."),
     NOT_FOUND_MEMBER(NOT_FOUND, "존재하지 않는 회원입니다."),
     NOT_FOUND_VOTE(NOT_FOUND, "해당 게시글에서 투표한 기록이 존재하지 않습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     FORBIDDEN_DELETE_NOTICE(FORBIDDEN, "공지사항 삭제 권한이 없습니다."),
     FORBIDDEN_POST_REPORT(FORBIDDEN, "본인 게시글을 신고할 수 없습니다."),
     FORBIDDEN_COMMENT_REPORT(FORBIDDEN, "본인 댓글을 신고할 수 없습니다."),
+    FORBIDDEN_LIKE_OWN_COMMENT(FORBIDDEN, "본인 댓글에는 좋아요를 누를 수 없습니다."),
 
     // 404
     NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 게시글입니다."),
@@ -65,7 +66,7 @@ public enum ErrorCode {
     NOT_SUPPORTED_FILE_TYPE(NOT_FOUND, "지원하지 않는 파일 형식입니다."),
     NOT_FOUND_FILE(NOT_FOUND, "존재하지 않는 파일입니다."),
     NOT_FOUND_PARENT_COMMENT_AT_THAT_TALK_PICK(NOT_FOUND, "해당 톡픽에 존재하지 않는 원 댓글입니다."),
-    NOT_FOUND_COMMENT_AT_THAT_POST(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
+    NOT_FOUND_COMMENT_AT_THAT_TALK_PICK(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
     NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
     NOT_LIKED_COMMENT(NOT_FOUND, "해당 댓글을 좋아요한 기록이 존재하지 않습니다."),
 

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -73,11 +73,6 @@ public class CommentLikeService {
         commentLike.deActive();
     }
 
-    private Comment validateComment(Long commentId) {
-        return commentRepository.findById(commentId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_COMMENT));
-    }
-
     private void validateTalkPick(Long talkPickId) {
         talkPickRepository.findById(talkPickId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -33,8 +33,15 @@ public class CommentLikeService {
     public void likeComment(Long commentId, Long talkPickId) {
         // 톡픽, 댓글, 회원 존재 여부 예외 처리
         validateTalkPick(talkPickId);
-        Comment comment = validateComment(commentId);
         Member member = getCurrentMember(memberRepository);
+
+        // 톡픽에 속한 댓글이 아닐 경우 예외 처리
+        Comment comment = validateCommentByTalkPick(commentId, talkPickId);
+
+        // 본인 댓글에는 좋아요 불가
+        if (comment.getMember().getId().equals(member.getId())) {
+            throw new BalanceTalkException(FORBIDDEN_LIKE_OWN_COMMENT);
+        }
 
         // 이미 좋아요를 누른 댓글일 경우 예외 처리
         boolean alreadyLiked = likeRepository.existsByCommentIdAndMemberId(commentId, member.getId());
@@ -50,11 +57,13 @@ public class CommentLikeService {
     @Transactional
     public void unLikeComment(Long commentId, Long talkPickId) {
         validateTalkPick(talkPickId);
-        validateComment(commentId);
         Member member = getCurrentMember(memberRepository);
 
+        // 톡픽에 속한 댓글이 아닐 경우 예외 처리
+        Comment comment = validateCommentByTalkPick(commentId, talkPickId);
+
         // 좋아요를 누르지 않은 댓글에 좋아요 취소를 누를 경우 예외 처리
-        Like commentLike = likeRepository.findByCommentIdAndMemberId(commentId, member.getId())
+        Like commentLike = likeRepository.findByCommentIdAndMemberId(comment.getId(), member.getId())
                 .orElseThrow(() -> new BalanceTalkException(NOT_LIKED_COMMENT));
 
         if (!commentLike.getActive()) {
@@ -72,5 +81,16 @@ public class CommentLikeService {
     private void validateTalkPick(Long talkPickId) {
         talkPickRepository.findById(talkPickId)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
+    }
+
+    private Comment validateCommentByTalkPick(Long commentId, Long talkPickId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_COMMENT));
+
+        if (!comment.getTalkPick().getId().equals(talkPickId)) {
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_TALK_PICK);
+        }
+
+        return comment;
     }
 }

--- a/src/main/java/balancetalk/like/presentation/LikeController.java
+++ b/src/main/java/balancetalk/like/presentation/LikeController.java
@@ -14,13 +14,13 @@ public class LikeController {
 
     private final CommentLikeService commentLikeService;
 
-    @PostMapping("/{talkPickId}/{commentId}/likes")
+    @PostMapping("/{talkPickId}/comments/{commentId}/likes")
     @Operation(summary = "댓글 좋아요", description = "commentId에 해당하는 댓글에 좋아요를 활성화합니다.")
     public void likeComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
         commentLikeService.likeComment(commentId, talkPickId);
     }
 
-    @DeleteMapping("/{talkPickId}/{commentId}/likes")
+    @DeleteMapping("/{talkPickId}/comments/{commentId}/likes")
     @Operation(summary = "댓글 좋아요 취소", description = "commentId에 해당하는 댓글의 좋아요를 취소합니다.")
     public void unlikeComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
         commentLikeService.unLikeComment(commentId, talkPickId);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 좋아요/좋아요 취소 URI 수정
- [x] 추가 예외 처리

## 💡 자세한 설명
### postman 테스트 완료

### URI 수정
![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/926d2ce9-e0c5-4b28-b32a-1fe16ce135cf)
URI를 기존의 `/{talkPickId}/{commentId}/likes` 에서 `/{talkPickId}/comments/{commentId}/likes` 로 더 직관적으로 변경했습니다.

### 추가 예외 처리

![image](https://github.com/CHZZK-Study/Balance-Talk-Backend/assets/73704053/32bd183e-2e48-4f4e-9b55-41143f4a152e)

1. talkPickId와 CommentId 의 일치 여부
2. 본인 댓글 좋아요 불가
3. 좋아요를 누르지 않은 댓글에 좋아요 취소를 누를 경우

의 예외 처리를 추가했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
놓친 예외 처리가 있을까요?

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #379 
