### PR TITLE
변경된 요구사항에 따라 오늘의 톡픽 조회 로직 수정

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -23,7 +23,7 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
                 .join(vote.talkPick, talkPick)
                 .where(talkPick.id.eq(vote.talkPick.id))
                 .groupBy(talkPick.id)
-                .orderBy(vote.count().desc(), talkPick.createdAt.desc())
+                .orderBy(talkPick.views.desc(), vote.count().desc(), talkPick.createdAt.desc())
                 .limit(1)
                 .fetchOne();
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 오늘의 톡픽 조회 로직 수정

## 💡 자세한 설명
기존 오늘의 톡픽 조회 기준은 '투표수 > 생성일'이었지만, 요구사항 변경으로 인해 기준이 다음과 같이 변경되었습니다.
'조회수 > 투표수 > 생성일'

따라서 기존에 구현한 오늘의 톡픽 조회 기능 중 정렬 부분을 수정하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #406 
