### PR TITLE
회원 로직 변경에 따른 기존 댓글, 댓글 좋아요 코드 수정 및 추가 기능 구현

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -9,6 +9,7 @@ import balancetalk.like.domain.LikeRepository;
 import balancetalk.like.domain.LikeType;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import balancetalk.vote.domain.VoteOption;
@@ -44,9 +45,9 @@ public class CommentService {
     @Value("${comments.max-depth}")
     private int maxDepth;
 
-    public void createComment(@Valid CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId) {
+    public void createComment(@Valid CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId, ApiMember apiMember) {
         //TODO : Vote 기능 구현 완료 후 추가 예외 처리 필요
-        Member member = getCurrentMember(memberRepository);
+        Member member = apiMember.toMember(memberRepository);
         TalkPick talkPick = validateTalkPickId(talkPickId);
 
         // option이 VoteOption에 존재하는 값인지 확인 및 예외 처리
@@ -60,8 +61,9 @@ public class CommentService {
     }
 
     @Transactional
-    public void createCommentReply(CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId, Long commentId) {
-        Member member = getCurrentMember(memberRepository);
+    public void createCommentReply(CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId, Long commentId,
+                                   ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
         TalkPick talkPick = validateTalkPickId(talkPickId);
         Comment parentComment = validateCommentId(commentId);
 
@@ -142,18 +144,18 @@ public class CommentService {
         return new PageImpl<>(result.subList(start, end), pageable, result.size());
     }
 
-    public void updateComment(Long commentId, Long talkPickId, String content) {
-        Comment comment = validateCommentByMemberAndTalkPick(commentId, talkPickId, FORBIDDEN_COMMENT_MODIFY);
+    public void updateComment(Long commentId, Long talkPickId, String content, ApiMember apiMember) {
+        Comment comment = validateCommentByMemberAndTalkPick(commentId, talkPickId, apiMember, FORBIDDEN_COMMENT_MODIFY);
         comment.updateContent(content);
     }
 
-    public void deleteComment(Long commentId, Long talkPickId) {
-        validateCommentByMemberAndTalkPick(commentId, talkPickId, FORBIDDEN_COMMENT_DELETE);
+    public void deleteComment(Long commentId, Long talkPickId, ApiMember apiMember) {
+        validateCommentByMemberAndTalkPick(commentId, talkPickId, apiMember, FORBIDDEN_COMMENT_DELETE);
         commentRepository.deleteById(commentId);
     }
 
-    private Comment validateCommentByMemberAndTalkPick(Long commentId, Long talkPickId, ErrorCode errorCode) {
-        Member member = getCurrentMember(memberRepository);
+    private Comment validateCommentByMemberAndTalkPick(Long commentId, Long talkPickId, ApiMember apiMember, ErrorCode errorCode) {
+        Member member = apiMember.toMember(memberRepository);
         Comment comment = validateCommentId(commentId);
         validateTalkPickId(talkPickId);
 

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -81,7 +81,7 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CommentDto.CommentResponse> findAllComments(Long talkPickId, String token, Pageable pageable,
+    public Page<CommentDto.CommentResponse> findAllComments(Long talkPickId, Pageable pageable,
                                                             GuestOrApiMember guestOrApiMember) {
         validateTalkPickId(talkPickId);
 

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -43,18 +43,15 @@ public class CommentController {
     @GetMapping
     @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 최신순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllCommentsByPostIdSortedByCreatedAt(@PathVariable Long talkPickId, Pageable pageable,
-                                                                          @RequestHeader(value = "Authorization",
-                                                                                  required = false) String token,
                                                                           @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         Pageable sortedByCreatedAtDesc = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
                 Sort.by("createdAt").descending());
-        return commentService.findAllComments(talkPickId, token, sortedByCreatedAtDesc, guestOrApiMember);
+        return commentService.findAllComments(talkPickId, sortedByCreatedAtDesc, guestOrApiMember);
     }
 
     @GetMapping("/best")
     @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllBestCommentsByPostId(@PathVariable Long talkPickId, Pageable pageable,
-                                                             @RequestHeader(value = "Authorization", required = false) String token,
                                                              @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         return commentService.findAllBestComments(talkPickId, pageable, guestOrApiMember);
     }

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -4,6 +4,9 @@ import balancetalk.comment.application.CommentService;
 import balancetalk.comment.dto.CommentDto.CommentResponse;
 import balancetalk.comment.dto.CommentDto.CreateCommentRequest;
 import balancetalk.comment.dto.CommentDto.UpdateCommentRequest;
+import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.dto.ApiMember;
+import balancetalk.member.dto.GuestOrApiMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,20 +27,25 @@ public class CommentController {
 
     @PostMapping
     @Operation(summary = "댓글 작성", description = "talkPick-id에 해당하는 게시글에 댓글을 작성한다.")
-    public void createComment(@PathVariable Long talkPickId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
-        commentService.createComment(createCommentRequest, talkPickId);
+    public void createComment(@PathVariable Long talkPickId, @Valid @RequestBody CreateCommentRequest createCommentRequest,
+                              @AuthPrincipal ApiMember apiMember) {
+        commentService.createComment(createCommentRequest, talkPickId, apiMember);
     }
 
     @PostMapping("/{commentId}/replies")
     @Operation(summary = "답글 작성", description = "commentId에 해당하는 댓글에 답글을 작성한다.")
-    public void createCommentReply(@PathVariable Long talkPickId, @PathVariable Long commentId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
-        commentService.createCommentReply(createCommentRequest, talkPickId, commentId);
+    public void createCommentReply(@PathVariable Long talkPickId, @PathVariable Long commentId,
+                                   @Valid @RequestBody CreateCommentRequest createCommentRequest,
+                                   @AuthPrincipal ApiMember apiMember) {
+        commentService.createCommentReply(createCommentRequest, talkPickId, commentId, apiMember);
     }
 
     @GetMapping
     @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 최신순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllCommentsByPostIdSortedByCreatedAt(@PathVariable Long talkPickId, Pageable pageable,
-                                                                          @RequestHeader(value = "Authorization", required = false) String token) {
+                                                                          @RequestHeader(value = "Authorization",
+                                                                                  required = false) String token,
+                                                                          @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         Pageable sortedByCreatedAtDesc = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
                 Sort.by("createdAt").descending());
         return commentService.findAllComments(talkPickId, token, sortedByCreatedAtDesc);
@@ -53,14 +61,14 @@ public class CommentController {
     @PutMapping("/{commentId}")
     @Operation(summary = "댓글 수정", description = "commentId에 해당하는 댓글 내용을 수정한다.")
     public void updateComment(@PathVariable Long commentId, @PathVariable Long talkPickId,
-                              @RequestBody UpdateCommentRequest request) {
-        commentService.updateComment(commentId, talkPickId, request.getContent());
+                              @RequestBody UpdateCommentRequest request, @AuthPrincipal ApiMember apiMember) {
+        commentService.updateComment(commentId, talkPickId, request.getContent(), apiMember);
     }
 
 
     @DeleteMapping("/{commentId}")
     @Operation(summary = "댓글 삭제", description = "commentId에 해당하는 댓글을 삭제한다.")
-    public void deleteComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
-        commentService.deleteComment(commentId, talkPickId);
+    public void deleteComment(@PathVariable Long commentId, @PathVariable Long talkPickId, @AuthPrincipal ApiMember apiMember) {
+        commentService.deleteComment(commentId, talkPickId, apiMember);
     }
 }

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -48,14 +48,15 @@ public class CommentController {
                                                                           @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         Pageable sortedByCreatedAtDesc = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
                 Sort.by("createdAt").descending());
-        return commentService.findAllComments(talkPickId, token, sortedByCreatedAtDesc);
+        return commentService.findAllComments(talkPickId, token, sortedByCreatedAtDesc, guestOrApiMember);
     }
 
     @GetMapping("/best")
     @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllBestCommentsByPostId(@PathVariable Long talkPickId, Pageable pageable,
-                                                             @RequestHeader(value = "Authorization", required = false) String token) {
-        return commentService.findAllBestComments(talkPickId, pageable);
+                                                             @RequestHeader(value = "Authorization", required = false) String token,
+                                                             @AuthPrincipal GuestOrApiMember guestOrApiMember) {
+        return commentService.findAllBestComments(talkPickId, pageable, guestOrApiMember);
     }
 
     @PutMapping("/{commentId}")

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     NOT_FOUND_COMMENT_AT_THAT_TALK_PICK(NOT_FOUND, "해당 게시글에 존재하지 않는 댓글입니다."),
     NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
     NOT_LIKED_COMMENT(NOT_FOUND, "해당 댓글을 좋아요한 기록이 존재하지 않습니다."),
+    NOT_FOUND_LIKE(NOT_FOUND, "해당 좋아요가 존재하지 않습니다."),
 
 
     // 409

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -8,6 +8,7 @@ import balancetalk.like.domain.LikeRepository;
 import balancetalk.like.dto.LikeDto;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,10 +31,10 @@ public class CommentLikeService {
     private final TalkPickRepository talkPickRepository;
 
     @Transactional
-    public void likeComment(Long commentId, Long talkPickId) {
+    public void likeComment(Long commentId, Long talkPickId, ApiMember apiMember) {
         // 톡픽, 댓글, 회원 존재 여부 예외 처리
         validateTalkPick(talkPickId);
-        Member member = getCurrentMember(memberRepository);
+        Member member = apiMember.toMember(memberRepository);
 
         // 톡픽에 속한 댓글이 아닐 경우 예외 처리
         Comment comment = validateCommentByTalkPick(commentId, talkPickId);
@@ -55,9 +56,9 @@ public class CommentLikeService {
     }
 
     @Transactional
-    public void unLikeComment(Long commentId, Long talkPickId) {
+    public void unLikeComment(Long commentId, Long talkPickId, ApiMember apiMember) {
         validateTalkPick(talkPickId);
-        Member member = getCurrentMember(memberRepository);
+        Member member = apiMember.toMember(memberRepository);
 
         // 톡픽에 속한 댓글이 아닐 경우 예외 처리
         Comment comment = validateCommentByTalkPick(commentId, talkPickId);

--- a/src/main/java/balancetalk/like/domain/Like.java
+++ b/src/main/java/balancetalk/like/domain/Like.java
@@ -30,6 +30,10 @@ public class Like extends BaseTimeEntity {
 
     private Boolean active = true;
 
+    public void activate() {
+        this.active = true;
+    }
+
     public void deActive() {
         this.active = false;
     }

--- a/src/main/java/balancetalk/like/presentation/LikeController.java
+++ b/src/main/java/balancetalk/like/presentation/LikeController.java
@@ -1,6 +1,8 @@
 package balancetalk.like.presentation;
 
+import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.like.application.CommentLikeService;
+import balancetalk.member.dto.ApiMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +18,13 @@ public class LikeController {
 
     @PostMapping
     @Operation(summary = "댓글 좋아요", description = "commentId에 해당하는 댓글에 좋아요를 활성화합니다.")
-    public void likeComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
-        commentLikeService.likeComment(commentId, talkPickId);
+    public void likeComment(@PathVariable Long commentId, @PathVariable Long talkPickId, @AuthPrincipal ApiMember apiMember) {
+        commentLikeService.likeComment(commentId, talkPickId, apiMember);
     }
 
     @DeleteMapping
     @Operation(summary = "댓글 좋아요 취소", description = "commentId에 해당하는 댓글의 좋아요를 취소합니다.")
-    public void unlikeComment(@PathVariable Long commentId, @PathVariable Long talkPickId) {
-        commentLikeService.unLikeComment(commentId, talkPickId);
+    public void unlikeComment(@PathVariable Long commentId, @PathVariable Long talkPickId, @AuthPrincipal ApiMember apiMember) {
+        commentLikeService.unLikeComment(commentId, talkPickId, apiMember);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] #414 번 PR 수정사항에 따른 기존 댓글, 댓글 좋아요 코드 수정
- [x] 댓글 좋아요 취소 후 다시 좋아요 누르는 경우 반영
- [x] 댓글 조회시 `myLike` 응답 기능 구현
- [x] 미사용 `token` 파라미터 제거

## 💡 자세한 설명
#### postman 테스트 완료

### #414 번 PR 수정사항에 따른 기존 댓글, 댓글 좋아요 코드 수정
```java
@Transactional
    public void createCommentReply(CommentDto.CreateCommentRequest createCommentRequest, Long talkPickId, Long commentId,
                                   ApiMember apiMember) {
        Member member = apiMember.toMember(memberRepository);
        TalkPick talkPick = validateTalkPickId(talkPickId);
        Comment parentComment = validateCommentId(commentId);

        // 부모 댓글과 연결된 게시글이 아닌 경우 예외 처리
        if (!parentComment.getTalkPick().equals(talkPick)) {
            throw new BalanceTalkException(NOT_FOUND_PARENT_COMMENT_AT_THAT_TALK_PICK);
        }

        // 부모 댓글의 depth가 maxDepth를 초과하는 경우 예외 처리 (답글에 답글 불가)
        validateDepth(parentComment);

        Comment commentReply = createCommentRequest.toEntity(member, talkPick, parentComment);
        commentRepository.save(commentReply);
    }

```
댓글, 댓글 좋아요 기능에서 `ApiMember` 와 `GuestOrApiMember` 클래스를 사용하여 위와 같이 현재 로그인한 멤버 조회 로직을 변경했습니다.

### 댓글 좋아요 취소 후 다시 좋아요 누르는 경우 반영
댓글 좋아요 취소 후 다시 좋아요를 누를 시, `이미 좋아요를 누른 댓글입니다` 예외가 발생함을 발견했습니다.

이를 `이미 좋아요를 누른 댓글일 경우` 와 `이미 좋아요가 존재하지만 비활성화 상태인 경우` 로 나뉘어 로직을 처리했습니다.

```java
// 이미 좋아요를 누른 댓글일 경우 예외 처리
        Optional<Like> existingLike = likeRepository.findByResourceIdAndMemberId(commentId, member.getId());

        if (existingLike.isPresent() && existingLike.get().getActive()) {
            throw new BalanceTalkException(ALREADY_LIKED_COMMENT);
        }

        // 이미 좋아요가 존재하지만 비활성화 상태인 경우 활성화 처리
        if (existingLike.isPresent()) {
            Like commentLike = existingLike.get();
            commentLike.activate();
        } else {
            Like commentLike = LikeDto.CreateLikeRequest.toEntity(commentId, member);
            likeRepository.save(commentLike);
        }
```

### 댓글 조회시 myLike 응답 기능 구현

```java
// 좋아요 10개 이상인 댓글이 있는 경우
        if (maxLikes >= MIN_COUNT_FOR_BEST_COMMENT) {
            for (Comment comment : allComments) {
                boolean myLike = isCommentMyLiked(comment.getId(), guestOrApiMember);
                int likeCount = likeRepository.countByResourceIdAndLikeType(comment.getId(), LikeType.COMMENT);
                comment.setIsBest(likeCount >= MIN_COUNT_FOR_BEST_COMMENT);
                CommentDto.CommentResponse response = CommentDto.CommentResponse.fromEntity(comment, likeCount, myLike);
                if (comment.getIsBest()) {
                    bestComments.add(response);
                } else {
                    otherComments.add(response);
                }
            }
....
private boolean isCommentMyLiked(Long commentId, GuestOrApiMember guestOrApiMember) {
        if (guestOrApiMember.isGuest()) {
            return false;
        }

        Long memberId = guestOrApiMember.toMember(memberRepository).getId();

        return likeRepository.existsByResourceIdAndMemberId(commentId, memberId);
    }
```

기존에 무조건 `myLike` 를 `false` 로 처리했던 댓글 조회 로직에서 본인이 좋아요를 누른 댓글일 경우, `myLike` 를 `true`로 반환하도록 구현했습니다.

### 미사용 token 파라미터 제거
![image](https://github.com/user-attachments/assets/4e9a77b7-053e-42ce-aae4-8ab4a80f3e3e)
`CommentService` , `CommentController` 에서 이전에 사용하던 token 파라미터를 제거했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #418 
