### PR TITLE
톡픽 투표 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,6 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
-	implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
-	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,9 @@ dependencies {
 
 	// emailAuth
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/balancetalk/global/config/SwaggerConfig.java
+++ b/src/main/java/balancetalk/global/config/SwaggerConfig.java
@@ -10,9 +10,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(info = @Info(title = "Balance Talk API 명세서", version = "v1"))
-
 @Configuration
-public class SwaggerConfig{
+public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
 

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -75,4 +75,9 @@ public class Member extends BaseTimeEntity {
                 .filter(vote -> vote.matchesTalkPick(talkPick))
                 .findAny();
     }
+
+    public boolean hasVoted(TalkPick talkPick) {
+        return votes.stream()
+                .anyMatch(vote -> vote.matchesTalkPick(talkPick));
+    }
 }

--- a/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
@@ -4,6 +4,7 @@ import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.application.TalkPickService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -24,10 +25,11 @@ public class TalkPickController {
     public void createTalkPick(@RequestBody final CreateTalkPickRequest request) {
     }
 
+    // TODO 투표수 포함
     @Operation(summary = "톡픽 상세 조회", description = "톡픽 상세 페이지를 조회합니다.")
     @GetMapping("/{talkPickId}")
     public TalkPickDetailResponse findTalkPickDetail(@PathVariable final Long talkPickId,
-                                                     @AuthPrincipal final GuestOrApiMember guestOrApiMember) {
+                                                     @Parameter(hidden = true) @AuthPrincipal final GuestOrApiMember guestOrApiMember) {
         return talkPickService.findById(talkPickId, guestOrApiMember);
     }
 

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -4,14 +4,19 @@ import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickReader;
+import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteRepository;
+import balancetalk.vote.dto.VoteTalkPickDto;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,5 +41,18 @@ public class VoteTalkPickService {
         }
 
         voteRepository.save(request.toEntity(member, talkPick));
+    }
+
+    @Transactional
+    public void updateVote(Long talkPickId, VoteRequest request, ApiMember apiMember) {
+        TalkPick talkPick = talkPickReader.readTalkPickById(talkPickId);
+        Member member = apiMember.toMember(memberRepository);
+
+        Optional<Vote> vote = member.getVoteOnTalkPick(talkPick);
+        if (vote.isEmpty()) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE);
+        }
+
+        vote.get().updateVoteOption(request.getVoteOption());
     }
 }

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -11,6 +11,7 @@ import balancetalk.vote.domain.VoteRepository;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class VoteTalkPickService {
     private final VoteRepository voteRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public void createVote(long talkPickId, VoteRequest request, GuestOrApiMember guestOrApiMember) {
         TalkPick talkPick = talkPickReader.readTalkPickById(talkPickId);
 

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -1,0 +1,38 @@
+package balancetalk.vote.application;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
+import balancetalk.member.domain.Member;
+import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.GuestOrApiMember;
+import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.talkpick.domain.TalkPickReader;
+import balancetalk.vote.domain.VoteRepository;
+import balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VoteTalkPickService {
+
+    private final TalkPickReader talkPickReader;
+    private final VoteRepository voteRepository;
+    private final MemberRepository memberRepository;
+
+    public void createVote(long talkPickId, VoteRequest request, GuestOrApiMember guestOrApiMember) {
+        TalkPick talkPick = talkPickReader.readTalkPickById(talkPickId);
+
+        if (guestOrApiMember.isGuest()) {
+            voteRepository.save(request.toEntity(null, talkPick));
+            return;
+        }
+
+        Member member = guestOrApiMember.toMember(memberRepository);
+        if (member.hasVoted(talkPick)) {
+            throw new BalanceTalkException(ErrorCode.ALREADY_VOTE);
+        }
+
+        voteRepository.save(request.toEntity(member, talkPick));
+    }
+}

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -55,4 +55,17 @@ public class VoteTalkPickService {
 
         vote.get().updateVoteOption(request.getVoteOption());
     }
+
+    @Transactional
+    public void deleteVote(Long talkPickId, ApiMember apiMember) {
+        TalkPick talkPick = talkPickReader.readTalkPickById(talkPickId);
+        Member member = apiMember.toMember(memberRepository);
+
+        Optional<Vote> vote = member.getVoteOnTalkPick(talkPick);
+        if (vote.isEmpty()) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE);
+        }
+
+        voteRepository.delete(vote.get());
+    }
 }

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -10,7 +10,6 @@ import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickReader;
 import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteRepository;
-import balancetalk.vote.dto.VoteTalkPickDto;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -44,7 +44,7 @@ public class VoteTalkPickService {
     }
 
     @Transactional
-    public void updateVote(Long talkPickId, VoteRequest request, ApiMember apiMember) {
+    public void updateVote(long talkPickId, VoteRequest request, ApiMember apiMember) {
         TalkPick talkPick = talkPickReader.readTalkPickById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 
@@ -57,7 +57,7 @@ public class VoteTalkPickService {
     }
 
     @Transactional
-    public void deleteVote(Long talkPickId, ApiMember apiMember) {
+    public void deleteVote(long talkPickId, ApiMember apiMember) {
         TalkPick talkPick = talkPickReader.readTalkPickById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 

--- a/src/main/java/balancetalk/vote/domain/Vote.java
+++ b/src/main/java/balancetalk/vote/domain/Vote.java
@@ -36,4 +36,8 @@ public class Vote extends BaseTimeEntity {
     public boolean matchesTalkPick(TalkPick talkPick) {
         return this.talkPick.equals(talkPick);
     }
+
+    public void updateVoteOption(VoteOption newVoteOption) {
+        this.voteOption = newVoteOption;
+    }
 }

--- a/src/main/java/balancetalk/vote/domain/Vote.java
+++ b/src/main/java/balancetalk/vote/domain/Vote.java
@@ -6,21 +6,18 @@ import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Vote extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Enumerated(value = EnumType.STRING)
-    private VoteType voteType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/balancetalk/vote/domain/Vote.java
+++ b/src/main/java/balancetalk/vote/domain/Vote.java
@@ -5,7 +5,6 @@ import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Entity
@@ -31,7 +30,6 @@ public class Vote extends BaseTimeEntity {
     @JoinColumn(name = "game_id")
     private Game game;
 
-    @NotBlank
     @Enumerated(value = EnumType.STRING)
     private VoteOption voteOption;
 

--- a/src/main/java/balancetalk/vote/domain/VoteType.java
+++ b/src/main/java/balancetalk/vote/domain/VoteType.java
@@ -1,5 +1,0 @@
-package balancetalk.vote.domain;
-
-public enum VoteType {
-    TALK_PICK, GAME
-}

--- a/src/main/java/balancetalk/vote/dto/VoteGameDto.java
+++ b/src/main/java/balancetalk/vote/dto/VoteGameDto.java
@@ -1,0 +1,30 @@
+package balancetalk.vote.dto;
+
+import balancetalk.vote.domain.VoteOption;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public class VoteGameDto {
+
+    @Data
+    @AllArgsConstructor
+    @Schema(description = "밸런스 게임 투표 생성 요청")
+    public static class VoteRequest {
+
+        @Schema(description = "투표할 선택지", example = "A")
+        private VoteOption voteOption;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @Schema(description = "밸런스 게임 투표 결과 응답")
+    public static class VoteResultResponse {
+
+        @Schema(description = "선택지 B 투표 개수", example = "23")
+        private int optionACount;
+
+        @Schema(description = "선택지 B 투표 개수", example = "12")
+        private int optionBCount;
+    }
+}

--- a/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
+++ b/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
@@ -5,10 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-public class VoteDto {
+public class VoteTalkPickDto {
 
     @Data
-    @Schema(description = "투표 생성 요청")
+    @AllArgsConstructor
+    @Schema(description = "톡픽 투표 생성 요청")
     public static class VoteRequest {
 
         @Schema(description = "투표할 선택지", example = "A")
@@ -17,8 +18,8 @@ public class VoteDto {
 
     @Data
     @AllArgsConstructor
-    @Schema(description = "투표 결과 응답")
-    public static class VoteResponse {
+    @Schema(description = "톡픽 투표 결과 응답")
+    public static class VoteResultResponse {
 
         @Schema(description = "선택지 B 투표 개수", example = "23")
         private int optionACount;

--- a/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
+++ b/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
@@ -1,19 +1,32 @@
 package balancetalk.vote.dto;
 
+import balancetalk.member.domain.Member;
+import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 public class VoteTalkPickDto {
 
     @Data
     @AllArgsConstructor
+    @NoArgsConstructor
     @Schema(description = "톡픽 투표 생성 요청")
     public static class VoteRequest {
 
         @Schema(description = "투표할 선택지", example = "A")
         private VoteOption voteOption;
+
+        public Vote toEntity(Member member, TalkPick talkPick) {
+            return Vote.builder()
+                    .member(member)
+                    .talkPick(talkPick)
+                    .voteOption(voteOption)
+                    .build();
+        }
     }
 
     @Data

--- a/src/main/java/balancetalk/vote/presentation/VoteGameController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteGameController.java
@@ -1,11 +1,11 @@
 package balancetalk.vote.presentation;
 
-import balancetalk.vote.dto.VoteDto.VoteResponse;
+import balancetalk.vote.dto.VoteGameDto.VoteResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
-import static balancetalk.vote.dto.VoteDto.VoteRequest;
+import static balancetalk.vote.dto.VoteGameDto.VoteRequest;
 
 @RestController
 @RequestMapping("/votes/games/{gameId}")
@@ -19,8 +19,8 @@ public class VoteGameController {
 
     @Operation(summary = "밸런스 게임 투표 결과 조회", description = "밸런스 게임 투표 결과를 조회합니다.")
     @GetMapping
-    public VoteResponse getVoteResultGame(@PathVariable Long gameId) {
-        return new VoteResponse(23, 12);
+    public VoteResultResponse getVoteResultGame(@PathVariable Long gameId) {
+        return new VoteResultResponse(23, 12);
     }
 
     @Operation(summary = "밸런스 게임 투표 수정", description = "밸런스 게임 투표를 수정합니다.")

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -1,6 +1,7 @@
 package balancetalk.vote.presentation;
 
 import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.application.VoteTalkPickService;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteResultResponse;
@@ -28,6 +29,7 @@ public class VoteTalkPickController {
         voteTalkPickService.createVote(talkPickId, request, guestOrApiMember);
     }
 
+    // TODO 톡픽 조회에 포함하기
     @Operation(summary = "톡픽 투표 결과 조회", description = "톡픽 투표 결과를 조회합니다.")
     @GetMapping
     public VoteResultResponse getVoteResultTalkPick(@PathVariable Long talkPickId) {
@@ -37,6 +39,8 @@ public class VoteTalkPickController {
     @Operation(summary = "톡픽 투표 수정", description = "톡픽 투표를 수정합니다.")
     @PutMapping
     public void updateVoteResultTalkPick(@PathVariable Long talkPickId,
-                                         @RequestBody VoteRequest request) {
+                                         @RequestBody VoteRequest request,
+                                         @AuthPrincipal ApiMember apiMember) {
+        voteTalkPickService.updateVote(talkPickId, request, apiMember);
     }
 }

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -38,7 +38,7 @@ public class VoteTalkPickController {
 
     @Operation(summary = "톡픽 투표 수정", description = "톡픽 투표를 수정합니다.")
     @PutMapping
-    public void updateVoteResultTalkPick(@PathVariable Long talkPickId,
+    public void updateVoteResultTalkPick(@PathVariable long talkPickId,
                                          @RequestBody VoteRequest request,
                                          @AuthPrincipal ApiMember apiMember) {
         voteTalkPickService.updateVote(talkPickId, request, apiMember);
@@ -46,7 +46,7 @@ public class VoteTalkPickController {
 
     @Operation(summary = "톡픽 투표 삭제", description = "톡픽 투표를 삭제합니다.")
     @DeleteMapping
-    public void deleteVoteTalkPick(@PathVariable Long talkPickId,
+    public void deleteVoteTalkPick(@PathVariable long talkPickId,
                                    @AuthPrincipal ApiMember apiMember) {
         voteTalkPickService.deleteVote(talkPickId, apiMember);
     }

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -25,7 +25,7 @@ public class VoteTalkPickController {
     public void createVoteTalkPick(@PathVariable long talkPickId,
                                    @RequestBody VoteRequest request,
                                    @AuthPrincipal GuestOrApiMember guestOrApiMember) {
-        voteTalkPickService.vote(talkPickId, request, guestOrApiMember);
+        voteTalkPickService.createVote(talkPickId, request, guestOrApiMember);
     }
 
     @Operation(summary = "톡픽 투표 결과 조회", description = "톡픽 투표 결과를 조회합니다.")

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -6,6 +6,7 @@ import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.application.VoteTalkPickService;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -22,10 +23,9 @@ public class VoteTalkPickController {
 
     @Operation(summary = "톡픽 투표 생성", description = "톡픽에서 원하는 선택지에 투표합니다.")
     @PostMapping
-
     public void createVoteTalkPick(@PathVariable long talkPickId,
                                    @RequestBody VoteRequest request,
-                                   @AuthPrincipal GuestOrApiMember guestOrApiMember) {
+                                   @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         voteTalkPickService.createVote(talkPickId, request, guestOrApiMember);
     }
 
@@ -40,14 +40,14 @@ public class VoteTalkPickController {
     @PutMapping
     public void updateVoteResultTalkPick(@PathVariable long talkPickId,
                                          @RequestBody VoteRequest request,
-                                         @AuthPrincipal ApiMember apiMember) {
+                                         @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         voteTalkPickService.updateVote(talkPickId, request, apiMember);
     }
 
     @Operation(summary = "톡픽 투표 삭제", description = "톡픽 투표를 삭제합니다.")
     @DeleteMapping
     public void deleteVoteTalkPick(@PathVariable long talkPickId,
-                                   @AuthPrincipal ApiMember apiMember) {
+                                   @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         voteTalkPickService.deleteVote(talkPickId, apiMember);
     }
 }

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -1,26 +1,37 @@
 package balancetalk.vote.presentation;
 
-import balancetalk.vote.dto.VoteDto.VoteRequest;
-import balancetalk.vote.dto.VoteDto.VoteResponse;
+import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.dto.GuestOrApiMember;
+import balancetalk.vote.application.VoteTalkPickService;
+import balancetalk.vote.dto.VoteTalkPickDto.VoteResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
+
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/votes/talks/{talkPickId}")
 @Tag(name = "vote", description = "투표 API")
 public class VoteTalkPickController {
 
+    private final VoteTalkPickService voteTalkPickService;
+
     @Operation(summary = "톡픽 투표 생성", description = "톡픽에서 원하는 선택지에 투표합니다.")
     @PostMapping
-    public void createVoteTalkPick(@PathVariable Long talkPickId,
-                                   @RequestBody VoteRequest request) {
+
+    public void createVoteTalkPick(@PathVariable long talkPickId,
+                                   @RequestBody VoteRequest request,
+                                   @AuthPrincipal GuestOrApiMember guestOrApiMember) {
+        voteTalkPickService.vote(talkPickId, request, guestOrApiMember);
     }
 
     @Operation(summary = "톡픽 투표 결과 조회", description = "톡픽 투표 결과를 조회합니다.")
     @GetMapping
-    public VoteResponse getVoteResultTalkPick(@PathVariable Long talkPickId) {
-        return new VoteResponse(23, 12);
+    public VoteResultResponse getVoteResultTalkPick(@PathVariable Long talkPickId) {
+        return new VoteResultResponse(23, 12);
     }
 
     @Operation(summary = "톡픽 투표 수정", description = "톡픽 투표를 수정합니다.")

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -43,4 +43,11 @@ public class VoteTalkPickController {
                                          @AuthPrincipal ApiMember apiMember) {
         voteTalkPickService.updateVote(talkPickId, request, apiMember);
     }
+
+    @Operation(summary = "톡픽 투표 삭제", description = "톡픽 투표를 삭제합니다.")
+    @DeleteMapping
+    public void deleteVoteTalkPick(@PathVariable Long talkPickId,
+                                   @AuthPrincipal ApiMember apiMember) {
+        voteTalkPickService.deleteVote(talkPickId, apiMember);
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 투표 생성 기능 구현
- [x] 톡픽 투표 수정 기능 구현
- [x] 톡픽 투표 삭제 기능 구현
- [x] Swagger UI에서 `@AuthPrincipal` 파라미터 제거

## 💡 자세한 설명
### Swagger UI에서 `@AuthPrincipal` 파라미터 제거
인증을 위해 사용하는 GuestOrApiMember와 ApiMember가 Swagger UI에 포함되는 문제를 발견했습니다.
<img width="1325" alt="스크린샷 2024-07-21 오전 1 08 27" src="https://github.com/user-attachments/assets/38a6c45f-7e0e-4f4e-8eb3-06c73a9faaa2">
<img width="1318" alt="image" src="https://github.com/user-attachments/assets/c440664c-72fa-4230-aee5-548dde5cb34e">
따라서 이를 `@Parameter(hidden = true)`로 해결하였습니다.

Swagger 3.0 기준 `@Parameter(hidden = true)` 어노테이션을 이용해 특정 파라미터를 Swagger UI에서 숨길 수 있습니다. 

다만, 모든 파라미터에 해당 어노테이션을 붙여야 한다는 번거로움이 생긴다는 단점이 존재합니다.
따라서 더 좋은 방법을 찾게 된다면 수정할 예정입니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #421 
