### PR TITLE
톡픽 상세 조회 API 응답에 각 선택지에 대한 투표수 필드 추가

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -3,6 +3,7 @@ package balancetalk.talkpick.domain;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
 import balancetalk.vote.domain.Vote;
+import balancetalk.vote.domain.VoteOption;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -59,5 +60,11 @@ public class TalkPick extends BaseTimeEntity {
 
     public void increaseViews() {
         this.views++;
+    }
+
+    public long votesCountOf(VoteOption voteOption) {
+        return votes.stream()
+                .filter(vote -> vote.isVoteOptionEquals(voteOption))
+                .count();
     }
 }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import static balancetalk.vote.domain.VoteOption.*;
+
 public class TalkPickDto {
 
     @Schema(description = "톡픽 생성/수정 요청")
@@ -37,7 +39,7 @@ public class TalkPickDto {
     public static class TalkPickDetailResponse {
 
         @Schema(description = "톡픽 ID", example = "톡픽 ID")
-        private Long id;
+        private long id;
 
         @Schema(description = "제목", example = "톡픽 제목")
         private String title;
@@ -53,8 +55,14 @@ public class TalkPickDto {
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB; // TODO "X"로 자동 지정
 
+        @Schema(description = "선택지 A 투표수", example = "12")
+        private long votesCountOfOptionA;
+
+        @Schema(description = "선택지 B 투표수", example = "12")
+        private long votesCountOfOptionB;
+
         @Schema(description = "조회수", example = "152")
-        private Long views;
+        private long views;
 
         @Schema(description = "북마크 여부", example = "true")
         private Boolean myBookmark;
@@ -70,6 +78,8 @@ public class TalkPickDto {
                     .summary(new SummaryDto(entity.getSummary()))
                     .optionA(entity.getOptionA())
                     .optionB(entity.getOptionB())
+                    .votesCountOfOptionA(entity.votesCountOf(A))
+                    .votesCountOfOptionB(entity.votesCountOf(B))
                     .views(entity.getViews())
                     .myBookmark(myBookmark)
                     .votedOption(votedOption)

--- a/src/main/java/balancetalk/talkpick/dto/TodayTalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TodayTalkPickDto.java
@@ -17,10 +17,10 @@ public class TodayTalkPickDto {
         private String title;
 
         @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
-        private String optionA; // TODO "O"로 자동 지정
+        private String optionA;
 
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
-        private String optionB; // TODO "X"로 자동 지정
+        private String optionB;
 
         @QueryProjection
         public TodayTalkPickResponse(Long id, String title, String optionA, String optionB) {

--- a/src/main/java/balancetalk/vote/domain/Vote.java
+++ b/src/main/java/balancetalk/vote/domain/Vote.java
@@ -40,4 +40,8 @@ public class Vote extends BaseTimeEntity {
     public void updateVoteOption(VoteOption newVoteOption) {
         this.voteOption = newVoteOption;
     }
+
+    public boolean isVoteOptionEquals(VoteOption voteOption) {
+        return this.voteOption.equals(voteOption);
+    }
 }

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -4,7 +4,6 @@ import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.application.VoteTalkPickService;
-import balancetalk.vote.dto.VoteTalkPickDto.VoteResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,13 +26,6 @@ public class VoteTalkPickController {
                                    @RequestBody VoteRequest request,
                                    @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         voteTalkPickService.createVote(talkPickId, request, guestOrApiMember);
-    }
-
-    // TODO 톡픽 조회에 포함하기
-    @Operation(summary = "톡픽 투표 결과 조회", description = "톡픽 투표 결과를 조회합니다.")
-    @GetMapping
-    public VoteResultResponse getVoteResultTalkPick(@PathVariable Long talkPickId) {
-        return new VoteResultResponse(23, 12);
     }
 
     @Operation(summary = "톡픽 투표 수정", description = "톡픽 투표를 수정합니다.")

--- a/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
+++ b/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
@@ -12,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +36,7 @@ class TalkPickServiceTest {
         TalkPick talkPick = TalkPick.builder()
                 .id(1L)
                 .summary(new Summary())
+                .votes(List.of())
                 .views(0L)
                 .build();
 
@@ -54,6 +57,7 @@ class TalkPickServiceTest {
         TalkPick talkPick = TalkPick.builder()
                 .id(1L)
                 .summary(new Summary())
+                .votes(List.of())
                 .views(0L)
                 .build();
 
@@ -74,6 +78,7 @@ class TalkPickServiceTest {
         TalkPick talkPick = TalkPick.builder()
                 .id(1L)
                 .summary(new Summary())
+                .votes(List.of())
                 .views(0L)
                 .build();
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 상세 조회 API 응답에 각 선택지에 대한 투표수 필드 추가

## 💡 자세한 설명
톡픽 상세 조회 API 응답에 각 선택지에 대한 투표수 필드를 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #423 
