### PR TITLE
댓글 신고 기능 구현 완료

### DIFF
--- a/src/main/java/balancetalk/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/comment/domain/Comment.java
@@ -2,6 +2,7 @@ package balancetalk.comment.domain;
 
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
+import balancetalk.report.domain.Report;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.ViewStatus;
 import balancetalk.vote.domain.VoteOption;
@@ -22,6 +23,8 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Comment extends BaseTimeEntity {
 
+    private static final int MIN_COUNT_FOR_BLIND = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -38,6 +41,14 @@ public class Comment extends BaseTimeEntity {
     private ViewStatus viewStatus;
 
     private Boolean isBest;
+
+    private Boolean isBlind;
+
+    @NotNull
+    private int reportedCount;
+
+    @OneToMany(mappedBy = "comment")
+    private List<Report> reports;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -61,5 +72,14 @@ public class Comment extends BaseTimeEntity {
 
     public void setIsBest(boolean isBest) {
         this.isBest = isBest;
+    }
+
+    public void incrementReportCount() { // TODO : 옵저버 패턴 도입 해도 좋을지도
+        this.reportedCount++;
+
+        if (this.reportedCount >= MIN_COUNT_FOR_BLIND) {
+            this.content = "신고된 댓글입니다.";
+            this.isBlind = true;
+        }
     }
 }

--- a/src/main/java/balancetalk/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/comment/domain/Comment.java
@@ -47,9 +47,6 @@ public class Comment extends BaseTimeEntity {
     @NotNull
     private int reportedCount;
 
-    @OneToMany(mappedBy = "comment")
-    private List<Report> reports;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -35,6 +35,8 @@ public class CommentDto {
                     .talkPick(talkPick)
                     .voteOption(option) // TODO : Vote 구현 완료 후 member와 talkPick 이용해서 선택한 option 가져오기
                     .isBest(false)
+                    .isBlind(false)
+                    .reportedCount(0)
                     .build();
         }
 
@@ -102,6 +104,12 @@ public class CommentDto {
         @Schema(description = "베스트 댓글 여부", example = "true")
         private boolean isBest;
 
+        @Schema(description = "댓글 블라인드 처리 여부", example = "false")
+        private boolean isBlind;
+
+        @Schema(description = "댓글이 신고당한 횟수", example = "0")
+        private int reportedCount;
+
         @Schema(description = "댓글 생성 날짜")
         private LocalDateTime createdAt;
 
@@ -119,7 +127,9 @@ public class CommentDto {
                     .myLike(myLike)
                     .parentId(comment.getParent() == null ? null : comment.getParent().getId())
                     .replyCount(comment.getReplies() == null ? 0 : comment.getReplies().size())
+                    .reportedCount(comment.getReportedCount())
                     .isBest(comment.getIsBest())
+                    .isBlind(comment.getIsBlind())
                     .createdAt(comment.getCreatedAt())
                     .lastModifiedAt(comment.getLastModifiedAt())
                     .build();

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     INVALID_VOTE_OPTION(BAD_REQUEST, "존재하지 않는 선택지입니다."),
     NOT_ATTACH_IMAGE(BAD_REQUEST, "이미지를 첨부하지 않아 문제가 발생했습니다."),
     NOT_SUPPORTED_FILE_FORMAT(BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+    REPORT_MY_COMMENT(BAD_REQUEST, "본인의 댓글을 신고할 수 없습니다"),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),

--- a/src/main/java/balancetalk/like/dto/LikeDto.java
+++ b/src/main/java/balancetalk/like/dto/LikeDto.java
@@ -20,10 +20,10 @@ public class LikeDto {
     public static class CreateLikeRequest {
 
         @Schema(description = "좋아요 타입", example = "COMMENT")
-        private LikeType likeType;
+        private LikeType likeType; // TODO : 변경 필
 
         @Schema(description = "좋아요한 댓글 id", example = "1")
-        private Long commentId;
+        private Long commentId; // TODO : 변경 필
 
         public static Like toEntity(Long resourceId, Member member) {
             return Like.builder()

--- a/src/main/java/balancetalk/report/application/ReportCommentService.java
+++ b/src/main/java/balancetalk/report/application/ReportCommentService.java
@@ -1,0 +1,60 @@
+package balancetalk.report.application;
+
+import static balancetalk.global.exception.ErrorCode.NOT_FOUND_COMMENT;
+import static balancetalk.global.exception.ErrorCode.NOT_FOUND_COMMENT_AT_THAT_TALK_PICK;
+import static balancetalk.global.exception.ErrorCode.REPORT_MY_COMMENT;
+
+import balancetalk.comment.domain.Comment;
+import balancetalk.comment.domain.CommentRepository;
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.member.domain.Member;
+import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.ApiMember;
+import balancetalk.report.domain.Report;
+import balancetalk.report.domain.ReportRepository;
+import balancetalk.report.dto.ReportDto.CreateReportRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReportCommentService {
+
+    private final CommentRepository commentRepository;
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createCommentReport(@Valid CreateReportRequest createReportRequest, ApiMember apiMember,
+                                    Long commentId, Long talkPickId) {
+
+        Member reporter = apiMember.toMember(memberRepository);
+
+        // 댓글과 톡픽 검증
+        Comment comment = validateCommentByTalkPick(commentId, talkPickId);
+        Member reported = comment.getMember();
+
+        // 본인의 댓글을 신고할 수 없음 예외 처리
+        if (reporter.equals(reported)) {
+            throw new BalanceTalkException(REPORT_MY_COMMENT);
+        }
+
+        Report report = createReportRequest.toEntity(reporter, reported, commentId, comment.getContent());
+
+        reportRepository.save(report);
+    }
+
+    private Comment validateCommentByTalkPick(Long commentId, Long talkPickId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_COMMENT));
+
+        if (!comment.getTalkPick().getId().equals(talkPickId)) {
+            throw new BalanceTalkException(NOT_FOUND_COMMENT_AT_THAT_TALK_PICK);
+        }
+
+        return comment;
+    }
+}

--- a/src/main/java/balancetalk/report/domain/Report.java
+++ b/src/main/java/balancetalk/report/domain/Report.java
@@ -30,6 +30,7 @@ public class Report extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
+    @NotNull
     private ReportType reportType;
 
     @NotNull

--- a/src/main/java/balancetalk/report/domain/Report.java
+++ b/src/main/java/balancetalk/report/domain/Report.java
@@ -30,6 +30,9 @@ public class Report extends BaseTimeEntity {
     @NotBlank
     private String reason;
 
+    @NotBlank
+    private String reportedContent;
+
     @ManyToOne
     @JoinColumn(name = "reporter_id")
     private Member reporter;

--- a/src/main/java/balancetalk/report/domain/Report.java
+++ b/src/main/java/balancetalk/report/domain/Report.java
@@ -1,0 +1,40 @@
+package balancetalk.report.domain;
+
+import balancetalk.comment.domain.Comment;
+import balancetalk.global.common.BaseTimeEntity;
+import balancetalk.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String reason;
+
+    @ManyToOne
+    @JoinColumn(name = "reporter_id")
+    private Member reporter;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}

--- a/src/main/java/balancetalk/report/domain/Report.java
+++ b/src/main/java/balancetalk/report/domain/Report.java
@@ -1,15 +1,17 @@
 package balancetalk.report.domain;
 
-import balancetalk.comment.domain.Comment;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +29,12 @@ public class Report extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(value = EnumType.STRING)
+    private ReportType reportType;
+
+    @NotNull
+    private Long resourceId;
+
     @NotBlank
     private String reason;
 
@@ -38,6 +46,7 @@ public class Report extends BaseTimeEntity {
     private Member reporter;
 
     @ManyToOne
-    @JoinColumn(name = "comment_id")
-    private Comment comment;
+    @JoinColumn(name = "reported_id")
+    private Member reported;
+
 }

--- a/src/main/java/balancetalk/report/domain/ReportRepository.java
+++ b/src/main/java/balancetalk/report/domain/ReportRepository.java
@@ -1,0 +1,6 @@
+package balancetalk.report.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/balancetalk/report/domain/ReportType.java
+++ b/src/main/java/balancetalk/report/domain/ReportType.java
@@ -1,0 +1,5 @@
+package balancetalk.report.domain;
+
+public enum ReportType {
+    COMMENT
+}

--- a/src/main/java/balancetalk/report/dto/ReportDto.java
+++ b/src/main/java/balancetalk/report/dto/ReportDto.java
@@ -1,0 +1,38 @@
+package balancetalk.report.dto;
+
+import balancetalk.member.domain.Member;
+import balancetalk.report.domain.Report;
+import balancetalk.report.domain.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class ReportDto {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "신고 생성 요청")
+    public static class CreateReportRequest {
+
+        @Schema(description = "신고된 컨텐츠 타입", example = "COMMENT")
+        private ReportType reportType;
+
+        @Schema(description = "신고 사유", example = "저에게 욕설을 했습니다.")
+        private String reason;
+
+        public Report toEntity(Member reporter, Member reported, Long resourceId, String content) {
+            return Report.builder()
+                    .reportType(reportType)
+                    .resourceId(resourceId)
+                    .reason(reason)
+                    .reporter(reporter)
+                    .reported(reported)
+                    .reportedContent(content)
+                    .build();
+        }
+    }
+
+    // TODO : 추후 어드민 페이지 구현시 Response 작성
+}

--- a/src/main/java/balancetalk/report/presentation/ReportController.java
+++ b/src/main/java/balancetalk/report/presentation/ReportController.java
@@ -1,0 +1,37 @@
+package balancetalk.report.presentation;
+
+import balancetalk.comment.dto.CommentDto;
+import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.dto.ApiMember;
+import balancetalk.report.application.ReportCommentService;
+import balancetalk.report.dto.ReportDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static balancetalk.report.dto.ReportDto.CreateReportRequest;
+
+@RestController
+@RequestMapping("/reports")
+@RequiredArgsConstructor
+@Tag(name = "report", description = "신고 API")
+public class ReportController {
+
+    private final ReportCommentService reportCommentService;
+
+    @PostMapping("/talks/{talkPickId}/comments/{commentId}")
+    @Operation(summary = "댓글 신고", description = "comment-Id에 해당하는 댓글을 신고한다.")
+    public void createCommentReport(@PathVariable Long talkPickId, @PathVariable Long commentId,
+                                    @Valid @RequestBody CreateReportRequest createCommentRequest,
+                                    @AuthPrincipal ApiMember apiMember) {
+
+        reportCommentService.createCommentReport(createCommentRequest, apiMember, commentId, talkPickId);
+    }
+
+}

--- a/src/main/java/balancetalk/report/presentation/ReportController.java
+++ b/src/main/java/balancetalk/report/presentation/ReportController.java
@@ -6,6 +6,7 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.report.application.ReportCommentService;
 import balancetalk.report.dto.ReportDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class ReportController {
     @Operation(summary = "댓글 신고", description = "comment-Id에 해당하는 댓글을 신고한다.")
     public void createCommentReport(@PathVariable Long talkPickId, @PathVariable Long commentId,
                                     @Valid @RequestBody CreateReportRequest createCommentRequest,
-                                    @AuthPrincipal ApiMember apiMember) {
+                                    @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
 
         reportCommentService.createCommentReport(createCommentRequest, apiMember, commentId, talkPickId);
     }


### PR DESCRIPTION
## 💡 작업 내용
- [ ] 댓글 신고 구현
- [ ] ERD 업데이트
- [ ] 기본 예외 처리

## 💡 자세한 설명
### postman 테스트 완료
<img width="1208" alt="스크린샷 2024-07-21 오후 3 56 02" src="https://github.com/user-attachments/assets/8578bdd0-4501-44b8-b17a-e0ca24c0412b">

### 댓글 신고 구현
엔티티, 서비스, 리포지토리, dto, 컨트롤러까지 신고 기능을 위한 기본적인 클래스들을 작성했습니다.
<img width="451" alt="스크린샷 2024-07-21 오후 3 56 23" src="https://github.com/user-attachments/assets/f15d9662-85d1-464c-ac99-d4eefa423f69">

추후에 게시글에도 신고 기능이 구현 예정되어 있기에, 댓글 좋아요 기능처럼 `resourceId`와 `ReportType`을 사용해 엔티티를 구현했습니다.

`reason`은 신고 사유 필드로, 기능명세서 업데이트로 인해 다음 Issue에서 유저가 직접 값을 입력하는 것이 아닌 정해진 세팅값들을 선택(enum) 할 수 있도록 업데이트 할 예정입니다.

### ERD 업데이트
<img width="556" alt="스크린샷 2024-07-21 오후 3 58 49" src="https://github.com/user-attachments/assets/20b63f86-cac9-4ab3-bdff-be324ddb939a">

위와 같이 ERD를 업데이트 했습니다.

### 기본 예외 처리
댓글과 톡픽 존재 여부를 검증하고, 본인의 댓글을 신고할 수 없도록 예외처리를 구현했습니다.

다음 Issue에서 중복 신고 불가 등의 기능명세서의 예외들을 추가로 구현할 예정입니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
1. 엔티티와 연관 관계가 바르게 작성되었을까요?

## 🚩 후속 작업 (선택)
1. 추가 예외 처리
2. 기능명세서에 따른 신고 사유 enum화


## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #413 
