### PR TITLE
밸런스 게임 최신순, 인기순 조회 로직 구현

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -21,10 +21,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -33,7 +30,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
-    private static final int GAME_SIZE = 16;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
     private final GameTopicRepository gameTopicRepository;
@@ -68,13 +64,11 @@ public class GameService {
         return GameDetailResponse.from(game, hasBookmarked, myVote.get().getVoteOption());
     }
 
-    public Page<GameResponse> findLatestGames(int page) {
-        Pageable pageable = PageRequest.of(page, GAME_SIZE, Sort.by(Direction.DESC, "createdAt"));
+    public Page<GameResponse> findLatestGames(Pageable pageable) {
         return gameRepository.findAllByOrderByCreatedAtDesc(pageable);
     }
 
-    public Page<GameResponse> findBestGames(int page) {
-        Pageable pageable = PageRequest.of(page, GAME_SIZE, Sort.by(Direction.DESC, "views"));
+    public Page<GameResponse> findBestGames(Pageable pageable) {
         return gameRepository.findAllByOrderByViewsDesc(pageable);
     }
 

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -73,6 +73,11 @@ public class GameService {
         return gameRepository.findAllByOrderByCreatedAtDesc(pageable);
     }
 
+    public Page<GameResponse> findGamesOrderByViews(int page) {
+        Pageable pageable = PageRequest.of(page, GAME_SIZE, Sort.by(Direction.DESC, "views"));
+        return gameRepository.findAllByOrderByViewsDesc(pageable);
+    }
+
     public void createGameTopic(CreateGameTopicRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         GameTopic gameTopic = request.toEntity();

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -8,6 +8,7 @@ import balancetalk.game.domain.repository.GameTopicRepository;
 import balancetalk.game.dto.GameDto.CreateGameRequest;
 import balancetalk.game.dto.GameDto.CreateGameTopicRequest;
 import balancetalk.game.dto.GameDto.GameDetailResponse;
+import balancetalk.game.dto.GameDto.GameResponse;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
@@ -19,6 +20,11 @@ import jakarta.transaction.Transactional;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -27,6 +33,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
+    private static final int GAME_SIZE = 16;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
     private final GameTopicRepository gameTopicRepository;
@@ -59,6 +66,11 @@ public class GameService {
         }
 
         return GameDetailResponse.from(game, hasBookmarked, myVote.get().getVoteOption());
+    }
+
+    public Page<GameResponse> findLatestGames(int page) {
+        Pageable pageable = PageRequest.of(page, GAME_SIZE, Sort.by(Direction.DESC, "createdAt"));
+        return gameRepository.findAllByOrderByCreatedAtDesc(pageable);
     }
 
     public void createGameTopic(CreateGameTopicRequest request, ApiMember apiMember) {

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -73,7 +73,7 @@ public class GameService {
         return gameRepository.findAllByOrderByCreatedAtDesc(pageable);
     }
 
-    public Page<GameResponse> findGamesOrderByViews(int page) {
+    public Page<GameResponse> findBestGames(int page) {
         Pageable pageable = PageRequest.of(page, GAME_SIZE, Sort.by(Direction.DESC, "views"));
         return gameRepository.findAllByOrderByViewsDesc(pageable);
     }

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -1,7 +1,12 @@
 package balancetalk.game.domain.repository;
 
 import balancetalk.game.domain.Game;
+import balancetalk.game.dto.GameDto.GameResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
+
+    Page<GameResponse> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GameRepository extends JpaRepository<Game, Long> {
 
     Page<GameResponse> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<GameResponse> findAllByOrderByViewsDesc(Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -64,12 +64,4 @@ public class GameController {
     public Page<GameResponse> findBestPosts(int page) {
         return gameService.findGamesOrderByViews(page);
     }
-
-    @GetMapping("/new")
-    @Operation(summary = "새로운 밸런스 게임 조회", description = "새로 업로드 된 밸런스 게임 목록들을 조회합니다.")
-    public List<GameResponse> findNewPosts() {
-        GameResponse GameResponse1 = new GameResponse(1L, "제목1", "O", "X");
-        GameResponse GameResponse2 = new GameResponse(2L, "제목2", "X", "O");
-        return Arrays.asList(GameResponse1, GameResponse2);
-    }
 }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -11,11 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
-import java.util.Arrays;
-import java.util.List;
 import static balancetalk.game.dto.GameDto.*;
 
 @Slf4j
@@ -55,13 +53,17 @@ public class GameController {
 
     @GetMapping("/latest")
     @Operation(summary = "최신순으로 밸런스 게임 조회", description = "최신순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public Page<GameResponse> findLatestGames(int page) {
-        return gameService.findLatestGames(page);
+    public Page<GameResponse> findLatestGames(@RequestParam(value = "page", defaultValue = "0") int page,
+                                              @RequestParam(value = "size", defaultValue = "16") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return gameService.findLatestGames(pageable);
     }
 
     @GetMapping("/best")
     @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public Page<GameResponse> findBestGames(int page) {
-        return gameService.findBestGames(page);
+    public Page<GameResponse> findBestGames(@RequestParam(value = "page", defaultValue = "0") int page,
+                                            @RequestParam(value = "size", defaultValue = "16") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return gameService.findBestGames(pageable);
     }
 }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -62,6 +62,6 @@ public class GameController {
     @GetMapping("/best")
     @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
     public Page<GameResponse> findBestGames(int page) {
-        return gameService.findGamesOrderByViews(page);
+        return gameService.findBestGames(page);
     }
 }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -60,12 +60,9 @@ public class GameController {
     }
 
     @GetMapping("/best")
-    @Operation(summary = "인기 밸런스 게임 조회", description = "인기 있는 밸런스 게임 목록을 조회합니다.")
-    public Page<GameResponse> findBestPosts(Pageable pageable) {
-        GameResponse GameResponse1 = new GameResponse(1L, "제목1", "O", "X");
-        GameResponse GameResponse2 = new GameResponse(2L, "제목2", "X", "O");
-        List<GameResponse> GameDetailResponses = Arrays.asList(GameResponse1, GameResponse2);
-        return new PageImpl<>(GameDetailResponses, pageable, 1);
+    @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
+    public Page<GameResponse> findBestPosts(int page) {
+        return gameService.findGamesOrderByViews(page);
     }
 
     @GetMapping("/new")

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -2,6 +2,7 @@ package balancetalk.game.presentation;
 
 import balancetalk.game.application.GameService;
 import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.application.MemberService;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,7 @@ import static balancetalk.game.dto.GameDto.*;
 public class GameController {
 
     private final GameService gameService;
+    private final MemberService memberService;
 
     @PostMapping
     @Operation(summary = "밸런스 게임 생성", description = "밸런스 게임을 생성합니다.")
@@ -48,6 +50,13 @@ public class GameController {
     @DeleteMapping("/{gameId}")
     @Operation(summary = "밸런스 게임 삭제", description = "밸런스 게임을 삭제합니다.")
     public void deleteGame(@PathVariable final Long gameId) {
+
+    }
+
+    @GetMapping("/latest")
+    @Operation(summary = "최신순으로 밸런스 게임 조회", description = "최신순으로 정렬된 16개의 게임 목록을 리턴합니다.")
+    public Page<GameResponse> findLatestGames(int page) {
+        return gameService.findLatestGames(page);
     }
 
     @GetMapping("/best")

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -61,7 +61,7 @@ public class GameController {
 
     @GetMapping("/best")
     @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public Page<GameResponse> findBestPosts(int page) {
+    public Page<GameResponse> findBestGames(int page) {
         return gameService.findGamesOrderByViews(page);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 밸런스 게임 최신순으로 조회하는 API 구현
- [x] 밸런스 게임 인기순으로 조회하는 API 구현

## 💡 자세한 설명

인기순으로 정렬하는 기능은 초기 단계에서는 좋아요 갯수가 아닌 조회수로 정렬해서 보여주도록 구현했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #432 
