### PR TITLE
밸런스 게임 이미지 등록 구현

### DIFF
--- a/src/main/java/balancetalk/file/domain/FileRepository.java
+++ b/src/main/java/balancetalk/file/domain/FileRepository.java
@@ -1,8 +1,11 @@
 package balancetalk.file.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<File, Long> {
     Optional<File> findByStoredName(String storedName);
+
+    List<File> findAllByStoredNameIn(List<String> storedNames);
 }

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
+    private static final int GAME_IMAGE_SIZE = 2;
     private final FileRepository fileRepository;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
@@ -45,7 +46,7 @@ public class GameService {
         Game game = request.toEntity(gameTopic, member);
 
         List<File> gameFiles = fileRepository.findAllByStoredNameIn(game.getImages());
-        if (gameFiles.size() < 2) {
+        if (gameFiles.size() < GAME_IMAGE_SIZE) {
             throw new BalanceTalkException(ErrorCode.NOT_FOUND_FILE);
         }
         gameRepository.save(game);

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -1,6 +1,9 @@
 package balancetalk.game.application;
 
 import static balancetalk.bookmark.domain.BookmarkType.GAME;
+
+import balancetalk.file.domain.File;
+import balancetalk.file.domain.FileRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameTopic;
 import balancetalk.game.domain.repository.GameRepository;
@@ -16,6 +19,7 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.domain.Vote;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +31,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
+    private final FileRepository fileRepository;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
     private final GameTopicRepository gameTopicRepository;
@@ -38,6 +43,11 @@ public class GameService {
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_GAME_TOPIC));
 
         Game game = request.toEntity(gameTopic, member);
+
+        List<File> gameFiles = fileRepository.findAllByStoredNameIn(game.getImages());
+        if (gameFiles.size() < 2) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_FILE);
+        }
         gameRepository.save(game);
     }
 

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -56,4 +56,11 @@ public class Game extends BaseTimeEntity {
     public void increaseViews() {
         this.views++;
     }
+
+    public List<String> getImages() {
+        List<String> images = new ArrayList<>();
+        images.add(optionAImg);
+        images.add(optionBImg);
+        return images;
+    }
 }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -83,8 +83,14 @@ public class GameDto {
         @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
         private String optionA;
 
+        @Schema(description = "선택지 A 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
+        private String optionAImg;
+
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB;
+
+        @Schema(description = "선택지 B 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/1157461e-a685-42fd-837e-7ed490894ca6_unnamed.png")
+        private String optionBImg;
 
         @Schema(description = "조회수", example = "3")
         private long views;
@@ -103,7 +109,9 @@ public class GameDto {
                     .id(game.getId())
                     .title(game.getTitle())
                     .optionA(game.getOptionA())
+                    .optionAImg(game.getOptionAImg())
                     .optionB(game.getOptionB())
+                    .optionBImg(game.getOptionBImg())
                     .views(game.getViews())
                     .myBookmark(myBookmark)
                     .votedOption(votedOption)

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -24,8 +24,14 @@ public class GameDto {
         @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
         private String optionA;
 
+        @Schema(description = "선택지 A 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
+        private String optionAImg;
+
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB;
+
+        @Schema(description = "선택지 B 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/1157461e-a685-42fd-837e-7ed490894ca6_unnamed.png")
+        private String optionBImg;
 
         @Schema(description = "밸런스 게임 주제", example = "커플")
         private String gameTopic;
@@ -34,7 +40,9 @@ public class GameDto {
             return Game.builder()
                     .title(title)
                     .optionA(optionA)
+                    .optionAImg(optionAImg)
                     .optionB(optionB)
+                    .optionBImg(optionBImg)
                     .gameTopic(topic)
                     .member(member)
                     .build();


### PR DESCRIPTION
## 💡 작업 내용
- [x] 밸런스 게임 생성 시 이미지 파일이 포함되도록 구현
- [x] 상세 조회 시 파일 이름이 같이 조회되도록 변경

## 💡 자세한 설명

![스크린샷 2024-07-23 오전 12 54 51](https://github.com/user-attachments/assets/e68ee2af-88d5-48a1-8d33-f60c5fb7a750)

![스크린샷 2024-07-23 오전 12 54 55](https://github.com/user-attachments/assets/6125bc5e-764d-4aa6-acad-a3c340d005fb)

이미지 파일을 업로드 할 때 리스트 형태로 File DB에서 조회를 합니다.


![스크린샷 2024-07-23 오전 12 55 01](https://github.com/user-attachments/assets/355ead36-25f6-4eec-9964-e72a4467835c)

만약에 조회를 했을 때 리스트의 사이즈가 2보다 작다면, 둘 중 하나 혹은 두개의 이미지 이름이 DB에 존재하지 않는다는 뜻 이므로 에러를 던져 줍니다.


#### 사이즈가 1인 경우
![스크린샷 2024-07-23 오전 12 58 06](https://github.com/user-attachments/assets/759db3f1-0077-4a0f-acff-d8dfd59585d6)





## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #434 
