### PR TITLE
회원 조회 방식을 email이 아닌 id로 변경

### DIFF
--- a/src/main/java/balancetalk/global/jwt/ApiMemberArgumentResolver.java
+++ b/src/main/java/balancetalk/global/jwt/ApiMemberArgumentResolver.java
@@ -6,7 +6,6 @@ import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -14,7 +13,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ApiMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -39,8 +37,7 @@ public class ApiMemberArgumentResolver implements HandlerMethodArgumentResolver 
 
         String token = jwtTokenProvider.resolveToken(request);
         jwtTokenProvider.validateToken(token);
-        String email = jwtTokenProvider.getPayload(token);
-
-        return new ApiMember(email);
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        return new ApiMember(memberId);
     }
 }

--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -103,8 +103,8 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthenticationByToken(String token) {
-        String userPrincipal = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody().getSubject();
-        CustomUserDetails customUserDetails = myUserDetailService.loadUserByUsername(userPrincipal);
+        Long memberId = getMemberId(token);
+        CustomUserDetails customUserDetails = myUserDetailService.loadByMemberId(memberId);
         return new UsernamePasswordAuthenticationToken(customUserDetails, "", customUserDetails.getAuthorities());
     }
 
@@ -168,5 +168,10 @@ public class JwtTokenProvider {
             return customUserDetails.getMemberId();
         }
         return null;
+    }
+
+    private Long getMemberId(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+        return claims.get("memberId", Long.class);
     }
 }

--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -170,7 +170,7 @@ public class JwtTokenProvider {
         return null;
     }
 
-    private Long getMemberId(String token) {
+    public Long getMemberId(String token) {
         Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
         return claims.get("memberId", Long.class);
     }

--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -8,18 +8,18 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-
 import static balancetalk.global.jwt.JwtTokenProvider.createAccessCookie;
 import static balancetalk.global.jwt.JwtTokenProvider.createCookie;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -44,9 +44,22 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
+        member.updateNickname(hideNickname(member.getNickname()));
+        memberRepository.save(member); // FIXME: 저장 쿼리를 하나 더 날리는데 비효율적인 방법 -> 개선할 수 있나?
 
         response.addCookie(createCookie(refreshToken));
         response.addCookie(createAccessCookie(accessToken));
         response.sendRedirect("http://localhost:3000/");
+    }
+
+    private String hideNickname(String nickname) {
+        StringBuilder sb = new StringBuilder(nickname);
+        for (int i = 3; i < nickname.length(); i++) {
+            if (nickname.charAt(i) == '@') {
+                break;
+            }
+            sb.setCharAt(i, '*');
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -44,22 +44,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
-        member.updateNickname(hideNickname(member.getNickname()));
-        memberRepository.save(member); // FIXME: 저장 쿼리를 하나 더 날리는데 비효율적인 방법 -> 개선할 수 있나?
-
         response.addCookie(createCookie(refreshToken));
         response.addCookie(createAccessCookie(accessToken));
         response.sendRedirect("http://localhost:3000/");
     }
 
-    private String hideNickname(String nickname) {
-        StringBuilder sb = new StringBuilder(nickname);
-        for (int i = 3; i < nickname.length(); i++) {
-            if (nickname.charAt(i) == '@') {
-                break;
-            }
-            sb.setCharAt(i, '*');
-        }
-        return sb.toString();
-    }
 }

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -47,7 +47,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (findMember == null) {
             String encodedPassword = passwordEncoder().encode(OAUTH2_PASSWORD);
             Oauth2Dto oauth2Dto = Oauth2Dto.builder()
-                    .name(oauth2Response.getEmail())
+                    .name(hideNickname(oauth2Response.getEmail()))
                     .email(oauth2Response.getEmail())
                     .username(username)
                     .role(Role.USER)
@@ -56,7 +56,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             Member newMember = oauth2Dto.toEntity();
             memberRepository.save(newMember);
-            newMember.updateNickname(hideNickname(newMember.getNickname()));
             return new CustomOAuth2User(oauth2Dto);
         }
 

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -56,6 +56,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             Member newMember = oauth2Dto.toEntity();
             memberRepository.save(newMember);
+            newMember.updateNickname(hideNickname(newMember.getNickname()));
             return new CustomOAuth2User(oauth2Dto);
         }
 
@@ -68,5 +69,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .build();
             return new CustomOAuth2User(oauth2Dto);
         }
+    }
+
+    private String hideNickname(String nickname) {
+        StringBuilder sb = new StringBuilder(nickname);
+        for (int i = 3; i < nickname.length(); i++) {
+            if (nickname.charAt(i) == '@') {
+                break;
+            }
+            sb.setCharAt(i, '*');
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,7 +1,6 @@
 package balancetalk.global.oauth2.service;
 
 import static balancetalk.global.config.SecurityConfig.*;
-
 import balancetalk.global.oauth2.dto.CustomOAuth2User;
 import balancetalk.global.oauth2.dto.GoogleResponse;
 import balancetalk.global.oauth2.dto.KakaoResponse;
@@ -47,9 +46,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         if (findMember == null) {
             String encodedPassword = passwordEncoder().encode(OAUTH2_PASSWORD);
-            String hideEmail = hideEmail(oauth2Response.getEmail());
             Oauth2Dto oauth2Dto = Oauth2Dto.builder()
-                    .name(hideEmail)
+                    .name(oauth2Response.getEmail())
                     .email(oauth2Response.getEmail())
                     .username(username)
                     .role(Role.USER)
@@ -58,7 +56,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             Member newMember = oauth2Dto.toEntity();
             memberRepository.save(newMember);
-
             return new CustomOAuth2User(oauth2Dto);
         }
 
@@ -71,16 +68,5 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .build();
             return new CustomOAuth2User(oauth2Dto);
         }
-    }
-
-    private String hideEmail(String email) {
-        StringBuilder sb = new StringBuilder(email);
-        for (int i = 3; i < email.length(); i++) {
-            if (email.charAt(i) == '@') {
-                break;
-            }
-            sb.setCharAt(i, '*');
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/balancetalk/member/application/MyUserDetailService.java
+++ b/src/main/java/balancetalk/member/application/MyUserDetailService.java
@@ -6,10 +6,12 @@ import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MyUserDetailService implements UserDetailsService {
@@ -17,8 +19,14 @@ public class MyUserDetailService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(email)
+    public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
+        return new CustomUserDetails(member);
+    }
+
+    public CustomUserDetails loadByMemberId(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
         return new CustomUserDetails(member);
     }

--- a/src/main/java/balancetalk/member/application/MyUserDetailService.java
+++ b/src/main/java/balancetalk/member/application/MyUserDetailService.java
@@ -17,8 +17,8 @@ public class MyUserDetailService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(username)
+    public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
         return new CustomUserDetails(member);
     }

--- a/src/main/java/balancetalk/member/dto/ApiMember.java
+++ b/src/main/java/balancetalk/member/dto/ApiMember.java
@@ -11,10 +11,10 @@ import lombok.Data;
 @AllArgsConstructor
 public class ApiMember {
 
-    private String email;
+    private Long memberId;
 
     public Member toMember(MemberRepository memberRepository) {
-        return memberRepository.findByEmail(email)
+        return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/balancetalk/member/dto/ApiMember.java
+++ b/src/main/java/balancetalk/member/dto/ApiMember.java
@@ -11,10 +11,10 @@ import lombok.Data;
 @AllArgsConstructor
 public class ApiMember {
 
-    private String username;
+    private String email;
 
     public Member toMember(MemberRepository memberRepository) {
-        return memberRepository.findByEmail(username)
+        return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 네이밍 수정
- [x] ApiMember에서 email이 아닌 memberId로 조회하도록 수정

## 💡 자세한 설명

계속해서 어디 로직은 회원 조회를 할 때 `email`로 하고, 어디는 `memberId`로 하니 통일성이 없고, 에러가 발생해도 디버깅하는데 오래걸렸습니다.

그래서, `memberId`를 통해서 조회하는 것으로 통일했습니다. 


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #438 
