### PR TITLE
회원 이미지 관련 작업

### DIFF
--- a/src/main/java/balancetalk/file/domain/FileRepository.java
+++ b/src/main/java/balancetalk/file/domain/FileRepository.java
@@ -1,11 +1,8 @@
 package balancetalk.file.domain;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<File, Long> {
     Optional<File> findByStoredName(String storedName);
-
-    List<File> findAllByStoredNameIn(List<String> storedNames);
 }

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -1,9 +1,6 @@
 package balancetalk.game.application;
 
 import static balancetalk.bookmark.domain.BookmarkType.GAME;
-
-import balancetalk.file.domain.File;
-import balancetalk.file.domain.FileRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameTopic;
 import balancetalk.game.domain.repository.GameRepository;
@@ -20,7 +17,6 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.domain.Vote;
 import jakarta.transaction.Transactional;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,8 +30,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
-    private static final int GAME_IMAGE_SIZE = 2;
-    private final FileRepository fileRepository;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
     private final GameTopicRepository gameTopicRepository;
@@ -48,10 +42,6 @@ public class GameService {
 
         Game game = request.toEntity(gameTopic, member);
 
-        List<File> gameFiles = fileRepository.findAllByStoredNameIn(game.getImages());
-        if (gameFiles.size() < GAME_IMAGE_SIZE) {
-            throw new BalanceTalkException(ErrorCode.NOT_FOUND_FILE);
-        }
         gameRepository.save(game);
     }
 

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -1,6 +1,5 @@
 package balancetalk.member.application;
 
-import balancetalk.file.domain.FileRepository;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.jwt.JwtTokenProvider;
@@ -21,10 +20,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.stream.Collectors;
-
 import static balancetalk.global.exception.ErrorCode.ALREADY_REGISTERED_EMAIL;
 import static balancetalk.global.exception.ErrorCode.ALREADY_REGISTERED_NICKNAME;
 

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -36,7 +36,6 @@ public class MemberService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
-    private final FileRepository fileRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisService redisService;
 
@@ -48,11 +47,6 @@ public class MemberService {
             throw new BalanceTalkException(ALREADY_REGISTERED_NICKNAME);
         }
         joinRequest.setPassword(passwordEncoder.encode(joinRequest.getPassword()));
-//        File profilePhoto = null;
-        if (joinRequest.getProfilePhoto() != null && !joinRequest.getProfilePhoto().isEmpty()) {
-//            profilePhoto = fileRepository.findByStoredName(joinRequest.getProfilePhoto())
-//                    .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE));
-        }
         Member member = joinRequest.toEntity();
         return memberRepository.save(member).getId();
     }

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -97,13 +97,10 @@ public class MemberService {
         member.updatePassword(passwordEncoder.encode(newPassword));
     }
 
-//    public void updateImage(String storedFileName, TokenDto tokenDto) {
-//        Member member = memberRepository.findByEmail(tokenDto.getEmail())
-//                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_MEMBER));
-//        File file = fileRepository.findByStoredName(storedFileName)
-//                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE));
-//        member.updateImage(file);
-//    }
+    public void updateImage(final String profileImgUrl, ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        member.updateImgUrl(profileImgUrl);
+    }
 
     public void delete(final LoginRequest loginRequest, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -70,6 +70,10 @@ public class Member extends BaseTimeEntity {
         this.password = password;
     }
 
+    public void updateImgUrl(String profileImgUrl) {
+        this.profileImgUrl = profileImgUrl;
+    }
+
     public boolean hasBookmarked(Long resourceId, BookmarkType bookmarkType) {
         return this.bookmarks.stream()
                 .anyMatch(bookmark -> bookmark.matches(resourceId, bookmarkType));

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -45,6 +45,8 @@ public class Member extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
+    private String profileImgUrl;
+
     @OneToMany(mappedBy = "member")
     private List<Vote> votes = new ArrayList<>();
 

--- a/src/main/java/balancetalk/member/dto/MemberDto.java
+++ b/src/main/java/balancetalk/member/dto/MemberDto.java
@@ -37,8 +37,8 @@ public class MemberDto {
         @Schema(description = "회원 권한", example = "USER")
         private Role role;
 
-        @Schema(description = "회원 프로필 사진", example = "4df23447-2355-45h2-8783-7f6gd2ceb848_프로필사진.jpg")
-        private String profilePhoto;
+        @Schema(description = "회원 프로필 url", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/member/511ca5c7-4367-40d1-ab18-3a8f0f4332a7_unnamed.png")
+        private String profileImgUrl;
 
         public Member toEntity() {
             return Member.builder()
@@ -46,6 +46,7 @@ public class MemberDto {
                     .email(email)
                     .password(password)
                     .role(Role.USER)
+                    .profileImgUrl(profileImgUrl)
                     .build();
         }
     }
@@ -82,7 +83,7 @@ public class MemberDto {
         @Schema(description = "회원 닉네임", example = "닉네임")
         private String nickname;
 
-        @Schema(description = "회원 프로필 URL", example = "https://balance-talk-static-files.s3.ap-northeast-2.amazonaws.com/balance-talk-images/balance-option/a723b360-f42f-4dc9-be69-72904b6861d9_강아지.jpeg")
+        @Schema(description = "회원 프로필 URL", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/member/511ca5c7-4367-40d1-ab18-3a8f0f4332a7_unnamed.pn")
         private String profileImageUrl;
 
         @Schema(description = "가입일", example = "2024-02-16 13:37:17.391706")

--- a/src/main/java/balancetalk/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/member/presentation/MemberController.java
@@ -76,12 +76,12 @@ public class MemberController {
         memberService.updatePassword(newPassword, apiMember);
     }
 
-//    @ResponseStatus(HttpStatus.OK)
-//    @PutMapping(value = "/image", consumes = "text/plain")
-//    @Operation(summary = "회원 이미지 변경", description = "회원 프로필 이미지를 변경한다.")
-//    public void updateImage(@RequestBody String storedFileName, @AuthPrincipal TokenDto tokenDto) {
-//        memberService.updateImage(storedFileName, tokenDto);
-//    }
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping(value = "/image", consumes = "text/plain")
+    @Operation(summary = "회원 이미지 변경", description = "회원 프로필 이미지를 변경한다.")
+    public void updateImage(@RequestBody String profileImgUrl, @AuthPrincipal ApiMember apiMember) {
+        memberService.updateImage(profileImgUrl, apiMember);
+    }
 
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping


### PR DESCRIPTION
## 💡 작업 내용
- [x] 회원 가입 시 이미지도 같이 전달
- [x] 회원 이미지 업데이트 구현
- [x] 기존 밸런스 게임 생성 시 storedName이 아닌 이미지를 전달하도록 수정

## 💡 자세한 설명

기존에 밸런스 게임을 생성할 때 File DB를 조회 한 후  `storedName`을 보내주는 식으로 구현을 했었는데 이미지 파일을 보내주도록 변경했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #440 
