### PR TITLE
SSE 적용 실시간 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-web-services'
 	testImplementation 'org.projectlombok:lombok:1.18.26'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -71,7 +72,6 @@ dependencies {
 
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -93,7 +93,8 @@ public enum ErrorCode {
     // 500
     REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),
     FAIL_SEND_EMAIL(INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다."),
-    NOT_UPLOADED_IMAGE_FOR_DB_ERROR(INTERNAL_SERVER_ERROR, "이미지 정보를 저장하던 중 문제가 생겨 업로드에 실패했습니다.");
+    NOT_UPLOADED_IMAGE_FOR_DB_ERROR(INTERNAL_SERVER_ERROR, "이미지 정보를 저장하던 중 문제가 생겨 업로드에 실패했습니다."),
+    SEND_NOTIFICATION_FAIL(INTERNAL_SERVER_ERROR, "알림 전송에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/balancetalk/global/notification/application/NotificationService.java
+++ b/src/main/java/balancetalk/global/notification/application/NotificationService.java
@@ -1,0 +1,72 @@
+package balancetalk.global.notification.application;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.notification.domain.Notification;
+import balancetalk.global.notification.domain.NotificationRepository;
+import balancetalk.member.domain.Member;
+import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.ApiMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static balancetalk.global.exception.ErrorCode.SEND_NOTIFICATION_FAIL;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final MemberRepository memberRepository;
+    private final NotificationRepository notificationRepository;
+    private final Map<Long, SseEmitter> memberEmitters = new ConcurrentHashMap<>();
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    public SseEmitter createEmitter(ApiMember apiMember) {
+        Long memberId = apiMember.toMember(memberRepository).getId();
+
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        memberEmitters.put(memberId, emitter);
+
+        // 연결 종료 / 만료 / 에러 발생 시 emitter 제거
+        emitter.onCompletion(() -> memberEmitters.remove(memberId, emitter));
+        emitter.onTimeout(() -> memberEmitters.remove(memberId, emitter));
+        emitter.onError((e) -> memberEmitters.remove(memberId, emitter));
+
+        return emitter;
+    }
+
+    @Transactional
+    public void sendNotification(Member member, String message) {
+        Notification notification = Notification.builder()
+                .member(member)
+                .message(message)
+                .isRead(false)
+                .build();
+
+        notificationRepository.save(notification);
+
+        sendRealTimeNotification(notification);
+    }
+
+    private void sendRealTimeNotification(Notification notification) {
+
+        SseEmitter emitter = memberEmitters.get(notification.getMember().getId());
+
+        if (emitter != null) {
+            executorService.execute(() -> {
+                try {
+                    emitter.send(SseEmitter.event().name("notification").data(notification.getMessage()));
+                } catch (Exception e) {
+                    throw new BalanceTalkException(SEND_NOTIFICATION_FAIL);
+                }
+            });
+
+        }
+    }
+}

--- a/src/main/java/balancetalk/global/notification/domain/Notification.java
+++ b/src/main/java/balancetalk/global/notification/domain/Notification.java
@@ -1,0 +1,26 @@
+package balancetalk.global.notification.domain;
+
+import balancetalk.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String message;
+
+    private boolean isRead;
+
+}

--- a/src/main/java/balancetalk/global/notification/domain/Notification.java
+++ b/src/main/java/balancetalk/global/notification/domain/Notification.java
@@ -1,7 +1,9 @@
 package balancetalk.global.notification.domain;
 
+import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Entity
@@ -9,7 +11,7 @@ import lombok.*;
 @Getter
 @RequiredArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Notification {
+public class Notification extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,6 +21,7 @@ public class Notification {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @NotBlank
     private String message;
 
     private boolean isRead;

--- a/src/main/java/balancetalk/global/notification/domain/NotificationRepository.java
+++ b/src/main/java/balancetalk/global/notification/domain/NotificationRepository.java
@@ -1,0 +1,6 @@
+package balancetalk.global.notification.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/balancetalk/global/notification/presentation/NotificationController.java
+++ b/src/main/java/balancetalk/global/notification/presentation/NotificationController.java
@@ -1,0 +1,23 @@
+package balancetalk.global.notification.presentation;
+
+import balancetalk.global.notification.application.NotificationService;
+import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.dto.ApiMember;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/notifications")
+    @Operation(summary = "알림 스트리밍", description = "로그인한 사용자의 알림을 실시간으로 스트리밍합니다.")
+    public SseEmitter streamNotifications(@AuthPrincipal ApiMember apiMember) {
+        return notificationService.createEmitter(apiMember);
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 알림 엔티티 작성
- [x] 알림 컨트롤러 작성
- [x] 알림 리포지토리 작성
- [x] 알림 서비스 작성
- [x] ERD 업데이트

## 💡 자세한 설명
SSE(Server-Sent Events) 를 적용한 실시간 알림 기능을 구현했습니다. SSE는 간단히 말하자면, 서버에서 특정 이벤트가 일어나면 연결이 맺어져 있는 동안 클라이언트에게 실시간으로 동작을 전송해줍니다.

![image](https://github.com/user-attachments/assets/f5077b5f-d2d0-4fb8-bdfd-655fc94b2e20)
[출처](https://stonehee99.tistory.com/30)
원래는 웹소켓을 이용하여 구현하려 했으나, 알림 기능은 서버->클라이언트 단방향 통신이고, 구현의 간단함으로 인해 SSE 방식을 채택했습니다.

## 코드 설명
### `createEmitter()` 메서드
```java
public SseEmitter createEmitter(ApiMember apiMember) {
        Long memberId = apiMember.toMember(memberRepository).getId();

        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
        memberEmitters.put(memberId, emitter);

        // 연결 종료 / 만료 / 에러 발생 시 emitter 제거
        emitter.onCompletion(() -> memberEmitters.remove(memberId, emitter));
        emitter.onTimeout(() -> memberEmitters.remove(memberId, emitter));
        emitter.onError((e) -> memberEmitters.remove(memberId, emitter));

        return emitter;
    }

```
`SseEmitter` : Spring에서 제공하는 클래스로, 서버가 클라이언트에 실시간 데이터를 전송할 수 있게 합니다.
`SseEmitter(Long.MAX_VALUE)` : 타임아웃 없이 연결을 유지하도록 설정합니다.
`memberEmitters` 에 저장:
사용자 ID와 SSE 연결 객체를 `ConcurrentHashMap`에 저장합니다. 이를 통해 특정 사용자에게 알림을 보낼 수 있습니다.
(`ConcurrentHashMap` 사용 이유 : 스레드 안전성)

`onCompletion` : 연결이 정상적으로 종료되었을 때 호출됩니다.
`onTimeout` : 연결이 타임아웃되었을 때 호출됩니다.
`onError` : 연결에 오류가 발생했을 때 호출됩니다.
각 이벤트 발생 시, 해당 사용자의 SSE 연결 객체를 `memberEmitters`에서 제거합니다.

### `sendRealTimeNotification()` 메서드
```java
private void sendRealTimeNotification(Notification notification) {

    SseEmitter emitter = memberEmitters.get(notification.getMember().getId());

    if (emitter != null) {
        executorService.execute(() -> {
            try {
                emitter.send(SseEmitter.event().name("notification").data(notification.getMessage()));
            } catch (Exception e) {
                throw new BalanceTalkException(SEND_NOTIFICATION_FAIL);
            }
        });
    }
```
`MemberEmitters.get(notification.getMember().getId())` : 알림을 받을 사용자의 SSE 연결 객체를 가져옵니다.
`executorService.execute` : 알림 전송 작업을 비동기로 실행합니다. 이를 통해 메인 스레드의 부하를 줄이고, 실시간 성능을 향상시킵니다.
`emitter.send` : SSE를 통해 클라이언트에 알림 메시지를 전송합니다. `*SseEmitter.event().name("notification").data(notification.getMessage())*` 를 사용하여 이벤트 이름과 전달할 데이터를 설정합니다.


## ERD 업데이트
![image](https://github.com/user-attachments/assets/6c0dfe44-ab39-40a5-acc0-e0f312d5e2fc)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
1. 답글 알림 구현
2. 톡픽 알림 구현
3. 투표 알림 구현
4. 알림 관련 프론트와 논의

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #436 
