### PR TITLE
톡픽 목록 조회 기능에 페이징 기본 옵션 추가

### DIFF
--- a/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
@@ -9,9 +9,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import static balancetalk.talkpick.dto.TalkPickDto.*;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,20 +30,23 @@ public class TalkPickController {
 
     @Operation(summary = "톡픽 상세 조회", description = "톡픽 상세 페이지를 조회합니다.")
     @GetMapping("/{talkPickId}")
-    public TalkPickDetailResponse findTalkPickDetail(@PathVariable final Long talkPickId,
-                                                     @Parameter(hidden = true) @AuthPrincipal final GuestOrApiMember guestOrApiMember) {
+    public TalkPickDetailResponse findTalkPickDetail(
+            @PathVariable final Long talkPickId,
+            @Parameter(hidden = true) @AuthPrincipal final GuestOrApiMember guestOrApiMember) {
         return talkPickService.findById(talkPickId, guestOrApiMember);
     }
 
     @Operation(summary = "톡픽 목록 조회", description = "톡픽 목록을 조회합니다.")
     @GetMapping
-    public Page<TalkPickResponse> findPagedTalkPicks(Pageable pageable) {
+    public Page<TalkPickResponse> findPagedTalkPicks(
+            @PageableDefault(size = 20, sort = "createdAt", direction = DESC) Pageable pageable) {
         return talkPickService.findPaged(pageable);
     }
 
     @Operation(summary = "톡픽 수정", description = "톡픽을 수정합니다.")
     @PutMapping("/{talkPickId}")
-    public void updateTalkPick(@PathVariable final Long talkPickId, @RequestBody final CreateTalkPickRequest request) {
+    public void updateTalkPick(@PathVariable final Long talkPickId,
+                               @RequestBody final CreateTalkPickRequest request) {
     }
 
     @Operation(summary = "톡픽 삭제", description = "톡픽을 삭제합니다.")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 목록 조회 기능에 페이징 기본 옵션 추가

## 💡 자세한 설명
URL에 페이징 관련 파라미터 지정하지 않을 경우, 기본적으로 다음과 같은 페이징 옵션이 추가됩니다.
- 페이지 내 데이터 개수: 20
- 정렬 기준: 톡픽 생성일
- 정렬 방식: 내림차순

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #464 
