### PR TITLE
카페인 캐시를 사용하여 리프레시 토큰 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	// caffeine cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/balancetalk/BalanceTalkApplication.java
+++ b/src/main/java/balancetalk/BalanceTalkApplication.java
@@ -4,10 +4,12 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server URL")})
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class BalanceTalkApplication {
 

--- a/src/main/java/balancetalk/global/caffeine/CacheConfig.java
+++ b/src/main/java/balancetalk/global/caffeine/CacheConfig.java
@@ -1,0 +1,34 @@
+package balancetalk.global.caffeine;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(cache.getCacheName(), Caffeine.newBuilder().recordStats()
+                                .expireAfterWrite(cache.getExpiredAfterWrite(), TimeUnit.SECONDS)
+                                .maximumSize(cache.getMaximumSize())
+                                .build()
+                        )
+                ).collect(Collectors.toUnmodifiableList());
+        cacheManager.setCaches(caches);
+        return cacheManager;
+    }
+}

--- a/src/main/java/balancetalk/global/caffeine/CacheType.java
+++ b/src/main/java/balancetalk/global/caffeine/CacheType.java
@@ -1,0 +1,19 @@
+package balancetalk.global.caffeine;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+
+    RefreshToken("refreshToken", 604800000, 10000);
+
+    private String cacheName;
+    private int expiredAfterWrite;
+    private int maximumSize;
+
+    CacheType(String cacheName, int expiredAfterWrite, int maximumSize) {
+        this.cacheName = cacheName;
+        this.expiredAfterWrite = expiredAfterWrite;
+        this.maximumSize = maximumSize;
+    }
+}

--- a/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/balancetalk/global/jwt/JwtAuthenticationFilter.java
@@ -19,12 +19,15 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
+
         try {
             if (token != null && jwtTokenProvider.validateToken(token)) {
                 Authentication auth = jwtTokenProvider.getAuthenticationByToken(token);
                 SecurityContextHolder.getContext().setAuthentication(auth);
+                chain.doFilter(request, response);
             }
         } catch (Exception e) {
             log.error("error={}", e.getMessage());

--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+
 import static balancetalk.global.jwt.JwtTokenProvider.createAccessCookie;
 import static balancetalk.global.jwt.JwtTokenProvider.createCookie;
 
@@ -28,7 +29,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final MemberRepository memberRepository;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
 
         // Oauth2User
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
@@ -42,7 +44,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         Member member = memberRepository.findByUsername(username);
         String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
-        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication, member.getId());
 
         response.addCookie(createCookie(refreshToken));
         response.addCookie(createAccessCookie(accessToken));

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -63,18 +63,7 @@ public class MemberService {
         String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication, member.getId());
 
-        log.info(CacheType.RefreshToken.getCacheName());
         cacheManager.getCache(CacheType.RefreshToken.getCacheName()).put(member.getId(), refreshToken);
-
-        for (String cacheName : cacheManager.getCacheNames()) {
-            CaffeineCache caffeineCache = (CaffeineCache) cacheManager.getCache(cacheName);
-
-            Cache<Object, Object> cache = caffeineCache.getNativeCache();
-            log.info("Cache Name: {}", cacheName);
-            cache.asMap().forEach((key, value) -> {
-                log.info("key: {} - value: {}", key, value != null ? value.toString() : "null");
-            });
-        }
 
         Cookie cookie = jwtTokenProvider.createCookie(refreshToken);
         response.addCookie(cookie);


### PR DESCRIPTION
## 💡 작업 내용
- [ ] 로그아웃 로직 수정
- [ ] 카페인 캐시 설정 구성
- [ ] 로그인 시 캐시에 `key-value` 형태로 토큰 담는 기능 구현

## 💡 자세한 설명

`CacheConfig` 클래스를 통해서 캐시 설정을 구성하고, `CacheType`에서는 Enum 형태로 캐시 종류를 관리합니다.

<img width="700" alt="스크린샷 2024-08-06 오후 5 13 28" src="https://github.com/user-attachments/assets/66a1a7e7-c4c9-4117-b406-35ca5f5c65bc">

* cacheName: 이름
* expiredAfterWrite: 해당 값이 바뀐 뒤 특정 시간이 지나면 삭제되도록 설정. 리프레시 토큰의 경우 7일을 기준으로 설정했습니다.
* maximumSize: 캐시 크기
---

<img width="1012" alt="스크린샷 2024-08-06 오후 4 58 03" src="https://github.com/user-attachments/assets/ce077499-ddad-4a0d-8b31-c42d53565334">

로그인에 성공한 경우, 이런식으로 key - memberId, value - refreshToken 형태로 저장됩니다.

로그아웃의 경우, 로그인이 되어있는 지 여부만 체크하고 프론트 쪽에서 작업을 수행하면 될 것 같습니다.

<img width="731" alt="스크린샷 2024-08-06 오후 6 01 52" src="https://github.com/user-attachments/assets/493a1485-8779-463e-be96-76fdd79f8d73">


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

이메일 발송, 임시 비밀번호 발송 기능도 레디스가 아닌 캐시로 관리 예정

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #458 
