### PR TITLE
밸런스 게임 최신순, 인기순 조회 수정

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -17,10 +17,12 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.domain.Vote;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +32,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
+    private static final int START_PAGE = 0;
+    private static final int END_PAGE = 16;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
     private final GameTopicRepository gameTopicRepository;
@@ -65,12 +69,22 @@ public class GameService {
         return GameDetailResponse.from(game, hasBookmarked, myVote.get().getVoteOption());
     }
 
-    public Page<GameResponse> findLatestGames(Pageable pageable) {
-        return gameRepository.findAllByOrderByCreatedAtDesc(pageable);
+    public List<GameResponse> findLatestGames(int gameTopicId) {
+        Pageable pageable = PageRequest.of(START_PAGE, END_PAGE);
+        List<Game> games = gameRepository.findGamesByCreated(gameTopicId, pageable);
+        return games.stream()
+                .map(game -> new GameResponse(game.getId(), game.getTitle(), game.getOptionA(), game.getOptionAImg(),
+                        game.getOptionB(), game.getOptionBImg()))
+                .collect(Collectors.toUnmodifiableList());
     }
 
-    public Page<GameResponse> findBestGames(Pageable pageable) {
-        return gameRepository.findAllByOrderByViewsDesc(pageable);
+    public List<GameResponse> findBestGames(int gameTopicId) {
+        Pageable pageable = PageRequest.of(START_PAGE, END_PAGE);
+        List<Game> games = gameRepository.findGamesByViews(gameTopicId, pageable);
+        return games.stream()
+                .map(game -> new GameResponse(game.getId(), game.getTitle(), game.getOptionA(), game.getOptionAImg(),
+                        game.getOptionB(), game.getOptionBImg()))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     public void createGameTopic(CreateGameTopicRequest request, ApiMember apiMember) {

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -1,14 +1,18 @@
 package balancetalk.game.domain.repository;
 
 import balancetalk.game.domain.Game;
-import balancetalk.game.dto.GameDto.GameResponse;
-import org.springframework.data.domain.Page;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
-    Page<GameResponse> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("SELECT g FROM Game g WHERE g.gameTopic.id = :gameTopicId ORDER BY g.createdAt DESC")
+    List<Game> findGamesByCreated(@Param("gameTopicId") int gameTopicId, Pageable pageable);
 
-    Page<GameResponse> findAllByOrderByViewsDesc(Pageable pageable);
+    @Query("SELECT g FROM Game g WHERE g.gameTopic.id = :gameTopicId ORDER BY g.views DESC")
+    List<Game> findGamesByViews(@Param("gameTopicId") int gameTopicId, Pageable pageable);
+
 }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -61,11 +61,14 @@ public class GameDto {
         @Schema(description = "밸런스 게임 제목", example = "제목")
         private String title;
 
-        @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
-        private String optionA;
+        @Schema(description = "선택지 A 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
+        private String optionAImg;
 
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB;
+
+        @Schema(description = "선택지 B 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/1157461e-a685-42fd-837e-7ed490894ca6_unnamed.png")
+        private String optionBImg;
     }
 
     @Data

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -64,6 +64,9 @@ public class GameDto {
         @Schema(description = "선택지 A 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
         private String optionAImg;
 
+        @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
+        private String optionA;
+
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB;
 

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -8,12 +8,11 @@ import balancetalk.member.dto.GuestOrApiMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
+
 import static balancetalk.game.dto.GameDto.*;
 
 @Slf4j
@@ -52,18 +51,14 @@ public class GameController {
     }
 
     @GetMapping("/latest")
-    @Operation(summary = "최신순으로 밸런스 게임 조회", description = "최신순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public Page<GameResponse> findLatestGames(@RequestParam(value = "page", defaultValue = "0") int page,
-                                              @RequestParam(value = "size", defaultValue = "16") int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return gameService.findLatestGames(pageable);
+    @Operation(summary = "최신순으로 밸런스 게임 조회", description = "최신순으로 정렬된 16개의 게임 목록을 카테고리 별로 리턴합니다.")
+    public List<GameResponse> findLatestGames(@RequestParam int gameTopicId) {
+        return gameService.findLatestGames(gameTopicId);
     }
 
     @GetMapping("/best")
-    @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public Page<GameResponse> findBestGames(@RequestParam(value = "page", defaultValue = "0") int page,
-                                            @RequestParam(value = "size", defaultValue = "16") int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return gameService.findBestGames(pageable);
+    @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 카테고리 별로 리턴합니다.")
+    public List<GameResponse> findBestGames(@RequestParam int gameTopicId) {
+        return gameService.findBestGames(gameTopicId);
     }
 }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -51,13 +51,13 @@ public class GameController {
     }
 
     @GetMapping("/latest")
-    @Operation(summary = "최신순으로 밸런스 게임 조회", description = "최신순으로 정렬된 16개의 게임 목록을 카테고리 별로 리턴합니다.")
+    @Operation(summary = "최신순으로 밸런스 게임 조회", description = "gameTopicId에 해당하면서 최신순으로 정렬된 16개의 게임 목록을 리턴합니다.")
     public List<GameResponse> findLatestGames(@RequestParam int gameTopicId) {
         return gameService.findLatestGames(gameTopicId);
     }
 
     @GetMapping("/best")
-    @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 카테고리 별로 리턴합니다.")
+    @Operation(summary = "인기순으로 밸런스 게임 조회", description = "gameTopicId에 해당하면서 인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
     public List<GameResponse> findBestGames(@RequestParam int gameTopicId) {
         return gameService.findBestGames(gameTopicId);
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 카테고리 별로 나눠주기 위해 jpql 수정
- [x] 기존 pagenation 파라미터 삭제

## 💡 자세한 설명

### gameTopicId가 2이고 최신순으로 조회한 경우
<img width="867" alt="스크린샷 2024-08-06 오후 9 24 09" src="https://github.com/user-attachments/assets/8bf3f33d-4b21-4509-ad1a-6109a7c3791b">

### gameTopicId가 1이고 인기순으로 조회한 경우
<img width="839" alt="스크린샷 2024-08-06 오후 9 24 39" src="https://github.com/user-attachments/assets/70d98f75-5e5b-435c-8b3d-8b7ef6eddef3">

포스트맨에서 테스트 돌려도 동일하게 결과를 가져오는 것을 확인했고, 16개 데이터를 초과한 경우엔 상위 16개만 리턴해주도록 구현했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #469 
