### PR TITLE
이미 북마크한 톡픽에 더 이상 북마크할 수 없다는 예외 처리 추가

### DIFF
--- a/src/main/java/balancetalk/bookmark/application/BookmarkTalkPickService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkTalkPickService.java
@@ -34,6 +34,9 @@ public class BookmarkTalkPickService {
         if (member.isMyTalkPick(talkPick)) {
             throw new BalanceTalkException(CANNOT_BOOKMARK_MY_RESOURCE);
         }
+        if (member.hasBookmarked(talkPickId, TALK_PICK)) {
+            throw new BalanceTalkException(ALREADY_BOOKMARKED);
+        }
 
         member.getBookmarkOf(talkPickId, TALK_PICK)
                 .ifPresentOrElse(Bookmark::activate,

--- a/src/main/java/balancetalk/bookmark/application/BookmarkTalkPickService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkTalkPickService.java
@@ -8,7 +8,7 @@ import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.domain.TalkPick;
-import balancetalk.talkpick.domain.repository.TalkPickRepository;
+import balancetalk.talkpick.domain.TalkPickReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,17 +20,16 @@ import static balancetalk.global.exception.ErrorCode.*;
 @RequiredArgsConstructor
 public class BookmarkTalkPickService {
 
-    private final TalkPickRepository talkPickRepository;
+    private final TalkPickReader talkPickReader;
     private final MemberRepository memberRepository;
     private final BookmarkGenerator bookmarkGenerator;
     private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public void createBookmark(final long talkPickId, final ApiMember apiMember) {
-        TalkPick talkPick = talkPickRepository.findById(talkPickId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
-
+        TalkPick talkPick = talkPickReader.readById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
+
         if (member.isMyTalkPick(talkPick)) {
             throw new BalanceTalkException(CANNOT_BOOKMARK_MY_RESOURCE);
         }
@@ -41,22 +40,26 @@ public class BookmarkTalkPickService {
         member.getBookmarkOf(talkPickId, TALK_PICK)
                 .ifPresentOrElse(Bookmark::activate,
                         () -> bookmarkRepository.save(bookmarkGenerator.generate(talkPickId, TALK_PICK, member)));
-
         talkPick.increaseBookmarks();
     }
 
     @Transactional
     public void deleteBookmark(Long talkPickId, ApiMember apiMember) {
-        TalkPick talkPick = talkPickRepository.findById(talkPickId)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
-
+        TalkPick talkPick = talkPickReader.readById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 
         Bookmark bookmark = member.getBookmarkOf(talkPickId, TALK_PICK)
                 .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_BOOKMARK));
 
-        bookmark.deactivate();
+        if (isNotActivated(bookmark)) {
+            throw new BalanceTalkException(ALREADY_DELETED_BOOKMARK);
+        }
 
+        bookmark.deactivate();
         talkPick.decreaseBookmarks();
+    }
+
+    private boolean isNotActivated(Bookmark bookmark) {
+        return !bookmark.isActive();
     }
 }

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -14,7 +14,6 @@ public enum ErrorCode {
     MISMATCHED_BALANCE_OPTION(BAD_REQUEST, "투표한 선택지는 다른 게시글에 속해 있습니다."),
     EXPIRED_POST_DEADLINE(BAD_REQUEST, "투표가 이미 종료된 게시글입니다."),
     UNMODIFIABLE_VOTE(BAD_REQUEST, "투표 수정이 불가능한 게시글입니다."),
-    ALREADY_BOOKMARK(BAD_REQUEST, "이미 북마크한 게시글입니다."),
     INCORRECT_PASSWORD(BAD_REQUEST, "비밀번호가 잘못되었거나 요청 형식이 올바르지 않습니다"),
     MIME_TYPE_NULL(BAD_REQUEST, "MIME 타입이 null입니다."),
     FILE_UPLOAD_FAILED(BAD_REQUEST, "파일 업로드에 실패했습니다."),
@@ -34,6 +33,7 @@ public enum ErrorCode {
     INVALID_REPORT_REASON(BAD_REQUEST, "신고 사유가 올바르지 않습니다."),
     INVALID_REPORT_TYPE(BAD_REQUEST, "신고 타입이 올바르지 않습니다."),
     CANNOT_BOOKMARK_MY_RESOURCE(BAD_REQUEST, "본인이 생성한 자원에는 북마크가 불가능합니다."),
+    ALREADY_BOOKMARKED(BAD_REQUEST, "이미 북마크한 게시글입니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     INVALID_REPORT_TYPE(BAD_REQUEST, "신고 타입이 올바르지 않습니다."),
     CANNOT_BOOKMARK_MY_RESOURCE(BAD_REQUEST, "본인이 생성한 자원에는 북마크가 불가능합니다."),
     ALREADY_BOOKMARKED(BAD_REQUEST, "이미 북마크한 게시글입니다."),
+    ALREADY_DELETED_BOOKMARK(BAD_REQUEST, "이미 북마크가 취소된 상태입니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -108,7 +108,7 @@ public class Member extends BaseTimeEntity {
 
     public Optional<Bookmark> getBookmarkOf(long resourceId, BookmarkType type) {
         return bookmarks.stream()
-                .filter(bookmark -> bookmark.matches(resourceId, type))
+                .filter(bookmark -> bookmark.matches(resourceId, type) && bookmark.isActive())
                 .findFirst();
     }
 }

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -108,7 +108,7 @@ public class Member extends BaseTimeEntity {
 
     public Optional<Bookmark> getBookmarkOf(long resourceId, BookmarkType type) {
         return bookmarks.stream()
-                .filter(bookmark -> bookmark.matches(resourceId, type) && bookmark.isActive())
+                .filter(bookmark -> bookmark.matches(resourceId, type))
                 .findFirst();
     }
 }

--- a/src/test/java/balancetalk/bookmark/application/BookmarkTalkPickServiceTest.java
+++ b/src/test/java/balancetalk/bookmark/application/BookmarkTalkPickServiceTest.java
@@ -7,7 +7,7 @@ import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.domain.TalkPick;
-import balancetalk.talkpick.domain.repository.TalkPickRepository;
+import balancetalk.talkpick.domain.TalkPickReader;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ class BookmarkTalkPickServiceTest {
     BookmarkTalkPickService bookmarkTalkPickService;
 
     @Mock
-    TalkPickRepository talkPickRepository;
+    TalkPickReader talkPickReader;
 
     @Mock
     MemberRepository memberRepository;
@@ -56,7 +56,7 @@ class BookmarkTalkPickServiceTest {
         Bookmark bookmark = mock(Bookmark.class);
         TalkPick talkPick = mock(TalkPick.class);
 
-        when(talkPickRepository.findById(any())).thenReturn(Optional.ofNullable(talkPick));
+        when(talkPickReader.readById(any())).thenReturn(talkPick);
         when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
         when(bookmarkGenerator.generate(1L, TALK_PICK, member)).thenReturn(bookmark);
 
@@ -83,7 +83,7 @@ class BookmarkTalkPickServiceTest {
 
         TalkPick talkPick = mock(TalkPick.class);
 
-        when(talkPickRepository.findById(any())).thenReturn(Optional.ofNullable(talkPick));
+        when(talkPickReader.readById(any())).thenReturn(talkPick);
         when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
 
         // when
@@ -91,7 +91,6 @@ class BookmarkTalkPickServiceTest {
 
         // then
         Assertions.assertThat(bookmark.getActive()).isTrue();
-        verify(bookmarkRepository, never()).save(bookmark);
     }
 
     @Test
@@ -110,7 +109,7 @@ class BookmarkTalkPickServiceTest {
 
         TalkPick talkPick = mock(TalkPick.class);
 
-        when(talkPickRepository.findById(any())).thenReturn(Optional.ofNullable(talkPick));
+        when(talkPickReader.readById(any())).thenReturn(talkPick);
         when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
 
         // when


### PR DESCRIPTION
## 💡 작업 내용
- [x] 이미 북마크한 톡픽에 더 이상 북마크할 수 없다는 예외 처리 추가

## 💡 자세한 설명
이미 북마크한 톡픽에 더 이상 북마크할 수 없다는 예외 처리 로직을 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #477 
