### PR TITLE
톡픽 상세조회 API의 응답 중 수정일을 lastModifiedAt이 아닌 editedAt으로 변경

### DIFF
--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -152,7 +152,7 @@ public class TalkPickDto {
                     .votedOption(votedOption)
                     .writer(entity.getWriterNickname())
                     .editedAt(entity.getEditedAt().toLocalDate())
-                    .isUpdated(entity.getLastModifiedAt().isAfter(entity.getCreatedAt()))
+                    .isUpdated(entity.getEditedAt().isAfter(entity.getCreatedAt()))
                     .build();
         }
     }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -131,7 +131,7 @@ public class TalkPickDto {
         private String writer;
 
         @Schema(description = "최근 수정일", example = "2024-08-04")
-        private LocalDate lastModifiedAt;
+        private LocalDate editedAt;
 
         @Schema(description = "수정 여부", example = "true")
         private Boolean isUpdated;
@@ -151,7 +151,7 @@ public class TalkPickDto {
                     .myBookmark(myBookmark)
                     .votedOption(votedOption)
                     .writer(entity.getWriterNickname())
-                    .lastModifiedAt(entity.getLastModifiedAt().toLocalDate())
+                    .editedAt(entity.getEditedAt().toLocalDate())
                     .isUpdated(entity.getLastModifiedAt().isAfter(entity.getCreatedAt()))
                     .build();
         }

--- a/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
+++ b/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
@@ -52,7 +52,7 @@ class TalkPickServiceTest {
         when(talkPick.getViews()).thenReturn(152L);
         when(talkPick.getWriterNickname()).thenReturn("writer");
         when(talkPick.getCreatedAt()).thenReturn(LocalDateTime.now());
-        when(talkPick.getLastModifiedAt()).thenReturn(LocalDateTime.now());
+        when(talkPick.getEditedAt()).thenReturn(LocalDateTime.now());
     }
 
     @Test


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 상세조회 API의 응답 중 수정일을 lastModifiedAt이 아닌 editedAt으로 변경

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #487 
