### PR TITLE
톡픽 상세 조회 API의 응답에서 수정일을 생성일로 변경

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -104,4 +104,8 @@ public class TalkPick extends BaseTimeEntity {
     public boolean matchesId(long id) {
         return this.id == id;
     }
+
+    public boolean isEdited() {
+        return editedAt != null;
+    }
 }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -130,8 +130,8 @@ public class TalkPickDto {
         @Schema(description = "작성자 닉네임", example = "hj30")
         private String writer;
 
-        @Schema(description = "최근 수정일", example = "2024-08-04")
-        private LocalDate editedAt;
+        @Schema(description = "작성일", example = "2024-08-04")
+        private LocalDate createdAt;
 
         @Schema(description = "수정 여부", example = "true")
         private Boolean isUpdated;
@@ -151,8 +151,8 @@ public class TalkPickDto {
                     .myBookmark(myBookmark)
                     .votedOption(votedOption)
                     .writer(entity.getWriterNickname())
-                    .editedAt(entity.getEditedAt().toLocalDate())
-                    .isUpdated(entity.getEditedAt().isAfter(entity.getCreatedAt()))
+                    .createdAt(entity.getCreatedAt().toLocalDate())
+                    .isUpdated(entity.isEdited())
                     .build();
         }
     }

--- a/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
+++ b/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
@@ -52,7 +52,7 @@ class TalkPickServiceTest {
         when(talkPick.getViews()).thenReturn(152L);
         when(talkPick.getWriterNickname()).thenReturn("writer");
         when(talkPick.getCreatedAt()).thenReturn(LocalDateTime.now());
-        when(talkPick.getEditedAt()).thenReturn(LocalDateTime.now());
+        when(talkPick.isEdited()).thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 상세 조회 API의 응답에서 수정일을 생성일로 변경

## 💡 자세한 설명
변경된 요구사항에 따라 톡픽 상세 조회 API의 응답에서 수정일을 생성일로 변경했습니다.
그리고 톡픽 편집 여부 판단 로직을 다음과 같이 변경했습니다.

```java
public boolean isEdited() {
    return editedAt != null;
}
```

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #492 
