### PR TITLE
마이페이지 - 밸런스 게임 조회 기능 구현 및 톡픽 조회 일부 기능 수정

### DIFF
--- a/src/main/java/balancetalk/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/comment/domain/Comment.java
@@ -17,6 +17,7 @@ import lombok.*;
 import org.springframework.lang.Nullable;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -78,8 +79,11 @@ public class Comment extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String notificationHistory;
 
+    private LocalDateTime editedAt;
+
     public void updateContent(String content) {
         this.content = content;
+        this.editedAt = LocalDateTime.now();
     }
 
     public void setIsBest(boolean isBest) {

--- a/src/main/java/balancetalk/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/comment/domain/CommentRepository.java
@@ -1,7 +1,6 @@
 package balancetalk.comment.domain;
 
 import balancetalk.like.domain.LikeType;
-import balancetalk.talkpick.domain.TalkPick;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,5 +22,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.talkPick IS NOT NULL " +
             "AND c.editedAt IN (SELECT MAX(c2.editedAt) FROM Comment c2 WHERE c2.member.id = :memberId GROUP BY c2.talkPick.id) " +
             "ORDER BY c.editedAt DESC")
-    List<Comment> findAllByMemberIdDesc(@Param("memberId") Long memberId);
+    List<Comment> findAllLatestCommentsByMemberIdAndOrderByDesc(@Param("memberId") Long memberId);
 }

--- a/src/main/java/balancetalk/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/comment/domain/CommentRepository.java
@@ -21,7 +21,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                                                                      @Param("likeType") LikeType likeType);
 
     @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.talkPick IS NOT NULL " +
-            "AND c.lastModifiedAt IN (SELECT MAX(c2.lastModifiedAt) FROM Comment c2 WHERE c2.member.id = :memberId GROUP BY c2.talkPick.id) " +
-            "ORDER BY c.lastModifiedAt DESC")
+            "AND c.editedAt IN (SELECT MAX(c2.editedAt) FROM Comment c2 WHERE c2.member.id = :memberId GROUP BY c2.talkPick.id) " +
+            "ORDER BY c.editedAt DESC")
     List<Comment> findAllByMemberIdDesc(@Param("memberId") Long memberId);
 }

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -39,6 +39,7 @@ public class CommentDto {
                     .viewStatus(ViewStatus.NORMAL)
                     .reportedCount(0)
                     .isNotifiedForFirstReply(false)
+                    .editedAt(LocalDateTime.now())
                     .build();
         }
 

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -9,6 +9,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,6 +49,8 @@ public class Game extends BaseTimeEntity {
 
     private String optionBImg;
 
+    private LocalDateTime editedAt;
+
     @PositiveOrZero
     private long views = 0L;
 
@@ -61,5 +65,12 @@ public class Game extends BaseTimeEntity {
         return votes.stream()
                 .filter(vote -> vote.isVoteOptionEquals(voteOption))
                 .count();
+    }
+
+    public void edit() { // 밸런스 게임 수정 시 호출
+        // this.title = title;
+        // this.optionA = optionA;
+        // this.optionB = optionB;
+        this.editedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -79,6 +79,7 @@ public class Game extends BaseTimeEntity {
         // this.optionA = optionA;
         // this.optionB = optionB;
         this.editedAt = LocalDateTime.now();
+    }
 
     public void increaseBookmarks() {
         this.bookmarks++;

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -2,6 +2,8 @@ package balancetalk.game.domain.repository;
 
 import balancetalk.game.domain.Game;
 import java.util.List;
+
+import balancetalk.talkpick.domain.TalkPick;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,5 +26,7 @@ public interface GameRepository extends JpaRepository<Game, Long> {
             ") " +
             "ORDER BY g.views DESC, g.createdAt DESC")
     List<Game> findGamesByViews(@Param("topicName") String topicName, Pageable pageable);
+
+    List<Game> findAllByMemberIdOrderByEditedAtDesc(Long memberId);
 
 }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -5,6 +5,7 @@ import static balancetalk.vote.domain.VoteOption.*;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameTopic;
 import balancetalk.member.domain.Member;
+import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteOption;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -170,10 +171,21 @@ public class GameDto {
         @Schema(description = "밸런스 게임 제목", example = "제목")
         private String title;
 
+        @Schema(description = "투표한 선택지", example = "A")
+        private VoteOption voteOption;
+
         public static GameMyPageResponse from(Game game) {
             return GameMyPageResponse.builder()
                     .id(game.getId())
                     .title(game.getTitle())
+                    .build();
+        }
+
+        public static GameMyPageResponse from(Game game, Vote vote) {
+            return GameMyPageResponse.builder()
+                    .id(game.getId())
+                    .title(game.getTitle())
+                    .voteOption(vote.getVoteOption())
                     .build();
         }
     }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -14,6 +14,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 public class GameDto {
 
     @Data
@@ -49,6 +51,7 @@ public class GameDto {
                     .optionBImg(optionBImg)
                     .gameTopic(topic)
                     .member(member)
+                    .editedAt(LocalDateTime.now())
                     .build();
         }
     }
@@ -174,10 +177,18 @@ public class GameDto {
         @Schema(description = "투표한 선택지", example = "A")
         private VoteOption voteOption;
 
-        public static GameMyPageResponse from(Game game) {
+        @Schema(description = "선택지 A 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
+        private String optionAImg;
+
+        @Schema(description = "선택지 B 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/1157461e-a685-42fd-837e-7ed490894ca6_unnamed.png")
+        private String optionBImg;
+
+        public static GameMyPageResponse from(Game game) { // TODO : 클라이언트에게 어떤 정보를 제공할지 추후 기능명세서 업데이트 후 결정
             return GameMyPageResponse.builder()
                     .id(game.getId())
                     .title(game.getTitle())
+                    .optionAImg(game.getOptionAImg())
+                    .optionBImg(game.getOptionBImg())
                     .build();
         }
 
@@ -185,6 +196,8 @@ public class GameDto {
             return GameMyPageResponse.builder()
                     .id(game.getId())
                     .title(game.getTitle())
+                    .optionAImg(game.getOptionAImg())
+                    .optionBImg(game.getOptionBImg())
                     .voteOption(vote.getVoteOption())
                     .build();
         }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -6,6 +6,7 @@ import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameTopic;
 import balancetalk.member.domain.Member;
 import balancetalk.vote.domain.VoteOption;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -155,4 +156,26 @@ public class GameDto {
                     .build();
         }
     }
+
+    @Schema(description = "마이페이지 밸런스 게임 응답")
+    @Data
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class GameMyPageResponse {
+
+        @Schema(description = "밸런스 게임 ID", example = "1")
+        private long id;
+
+        @Schema(description = "밸런스 게임 제목", example = "제목")
+        private String title;
+
+        public static GameMyPageResponse from(Game game) {
+            return GameMyPageResponse.builder()
+                    .id(game.getId())
+                    .title(game.getTitle())
+                    .build();
+        }
+    }
+
 }

--- a/src/main/java/balancetalk/global/notification/presentation/NotificationController.java
+++ b/src/main/java/balancetalk/global/notification/presentation/NotificationController.java
@@ -4,6 +4,7 @@ import balancetalk.global.notification.application.NotificationService;
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,6 +12,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "notification", description = "알림 API")
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -59,7 +59,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllCommentedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Comment> comments = commentRepository.findAllByMemberIdDesc(member.getId());
+        List<Comment> comments = commentRepository.findAllLatestCommentsByMemberIdAndOrderByDesc(member.getId());
 
         List<TalkPickMyPageResponse> responses = comments.stream()
                 .map(comment -> TalkPickMyPageResponse.from(comment.getTalkPick(), comment))

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -5,6 +5,7 @@ import balancetalk.bookmark.domain.BookmarkRepository;
 import balancetalk.bookmark.domain.BookmarkType;
 import balancetalk.comment.domain.Comment;
 import balancetalk.comment.domain.CommentRepository;
+import balancetalk.game.domain.Game;
 import balancetalk.game.domain.repository.GameRepository;
 import balancetalk.game.dto.GameDto.GameMyPageResponse;
 import balancetalk.member.domain.Member;
@@ -95,6 +96,17 @@ public class MyPageService {
 
         List<GameMyPageResponse> responses = votes.stream()
                 .map(vote -> GameMyPageResponse.from(vote.getGame(), vote))
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(responses, pageable, responses.size());
+    }
+
+    public Page<GameMyPageResponse> findAllGamesByMember(ApiMember apiMember, Pageable pageable) {
+        Member member = apiMember.toMember(memberRepository);
+        List<Game> games = gameRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId());
+
+        List<GameMyPageResponse> responses = games.stream()
+                .map(GameMyPageResponse::from)
                 .collect(Collectors.toList());
 
         return new PageImpl<>(responses, pageable, responses.size());

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -5,6 +5,8 @@ import balancetalk.bookmark.domain.BookmarkRepository;
 import balancetalk.bookmark.domain.BookmarkType;
 import balancetalk.comment.domain.Comment;
 import balancetalk.comment.domain.CommentRepository;
+import balancetalk.game.domain.repository.GameRepository;
+import balancetalk.game.dto.GameDto.GameMyPageResponse;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
@@ -30,6 +32,7 @@ public class MyPageService {
     private final BookmarkRepository bookmarkRepository;
     private final VoteRepository voteRepository;
     private final CommentRepository commentRepository;
+    private final GameRepository gameRepository;
 
     public Page<TalkPickMyPageResponse> findAllBookmarkedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
@@ -70,6 +73,17 @@ public class MyPageService {
 
         List<TalkPickMyPageResponse> responses = talkPicks.stream()
                 .map(TalkPickMyPageResponse::fromMyTalkPick)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(responses, pageable, responses.size());
+    }
+
+    public Page<GameMyPageResponse> findAllBookmarkedGames(ApiMember apiMember, Pageable pageable) {
+        Member member = apiMember.toMember(memberRepository);
+        List<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.GAME);
+
+        List<GameMyPageResponse> responses = bookmarks.stream()
+                .map(bookmark -> GameMyPageResponse.from(gameRepository.findById(bookmark.getResourceId()).get()))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(responses, pageable, responses.size());

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -66,7 +66,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllTalkPicksByMember(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<TalkPick> talkPicks = talkPickRepository.findAllByMemberIdOrderByLastModifiedAtDesc(member.getId());
+        List<TalkPick> talkPicks = talkPickRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId());
 
         List<TalkPickMyPageResponse> responses = talkPicks.stream()
                 .map(TalkPickMyPageResponse::fromMyTalkPick)

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -47,7 +47,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllVotedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Vote> votes = voteRepository.findAllByMemberIdDesc(member.getId());
+        List<Vote> votes = voteRepository.findAllByMemberIdAndTalkPickDesc(member.getId());
 
         List<TalkPickMyPageResponse> responses = votes.stream()
                 .map(vote -> TalkPickMyPageResponse.from(vote.getTalkPick(), vote))
@@ -84,6 +84,17 @@ public class MyPageService {
 
         List<GameMyPageResponse> responses = bookmarks.stream()
                 .map(bookmark -> GameMyPageResponse.from(gameRepository.findById(bookmark.getResourceId()).get()))
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(responses, pageable, responses.size());
+    }
+
+    public Page<GameMyPageResponse> findAllVotedGames(ApiMember apiMember, Pageable pageable) {
+        Member member = apiMember.toMember(memberRepository);
+        List<Vote> votes = voteRepository.findAllByMemberIdAndGameDesc(member.getId());
+
+        List<GameMyPageResponse> responses = votes.stream()
+                .map(vote -> GameMyPageResponse.from(vote.getGame(), vote))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(responses, pageable, responses.size());

--- a/src/main/java/balancetalk/member/presentation/MyPageController.java
+++ b/src/main/java/balancetalk/member/presentation/MyPageController.java
@@ -1,5 +1,6 @@
 package balancetalk.member.presentation;
 
+import balancetalk.game.dto.GameDto;
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.application.MyPageService;
 import balancetalk.member.dto.ApiMember;
@@ -11,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -63,5 +63,15 @@ public class MyPageController {
 
         Pageable pageable = PageRequest.of(page, size);
         return myPageService.findAllTalkPicksByMember(apiMember, pageable);
+    }
+
+    @GetMapping("/games/bookmarks")
+    @Operation(summary = "북마크한 밸런스 게임 목록 조회", description = "로그인한 회원이 북마크한 밸런스 게임 목록을 조회한다.")
+    public Page<GameDto.GameMyPageResponse  > findAllBookmarkedGames(
+            @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
+            @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        return myPageService.findAllBookmarkedGames(apiMember, pageable);
     }
 }

--- a/src/main/java/balancetalk/member/presentation/MyPageController.java
+++ b/src/main/java/balancetalk/member/presentation/MyPageController.java
@@ -1,6 +1,6 @@
 package balancetalk.member.presentation;
 
-import balancetalk.game.dto.GameDto;
+import balancetalk.game.dto.GameDto.GameMyPageResponse;
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.application.MyPageService;
 import balancetalk.member.dto.ApiMember;
@@ -67,11 +67,21 @@ public class MyPageController {
 
     @GetMapping("/games/bookmarks")
     @Operation(summary = "북마크한 밸런스 게임 목록 조회", description = "로그인한 회원이 북마크한 밸런스 게임 목록을 조회한다.")
-    public Page<GameDto.GameMyPageResponse  > findAllBookmarkedGames(
+    public Page<GameMyPageResponse  > findAllBookmarkedGames(
             @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
             @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
 
         Pageable pageable = PageRequest.of(page, size);
         return myPageService.findAllBookmarkedGames(apiMember, pageable);
+    }
+
+    @GetMapping("/games/votes")
+    @Operation(summary = "투표한 밸런스 게임 목록 조회", description = "로그인한 회원이 투표한 밸런스 게임 목록을 조회한다.")
+    public Page<GameMyPageResponse> findAllVotedGames(
+            @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
+            @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        return myPageService.findAllVotedGames(apiMember, pageable);
     }
 }

--- a/src/main/java/balancetalk/member/presentation/MyPageController.java
+++ b/src/main/java/balancetalk/member/presentation/MyPageController.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/my-page")
-@Tag(name = "my-page", description = "마이페이지 API")
+@RequestMapping("/my")
+@Tag(name = "my", description = "마이페이지 API")
 public class MyPageController {
 
     private final MyPageService myPageService;

--- a/src/main/java/balancetalk/member/presentation/MyPageController.java
+++ b/src/main/java/balancetalk/member/presentation/MyPageController.java
@@ -84,4 +84,14 @@ public class MyPageController {
         Pageable pageable = PageRequest.of(page, size);
         return myPageService.findAllVotedGames(apiMember, pageable);
     }
+
+    @GetMapping("/games/my")
+    @Operation(summary = "내가 작성한 밸런스 게임 목록 조회", description = "로그인한 회원이 작성한 밸런스 게임 목록을 조회한다.")
+    public Page<GameMyPageResponse> findAllMyGames(
+            @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
+            @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        return myPageService.findAllGamesByMember(apiMember, pageable);
+    }
 }

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface TalkPickRepository extends JpaRepository<TalkPick, Long>, TalkPickRepositoryCustom {
 
-    List<TalkPick> findAllByMemberIdOrderByLastModifiedAtDesc(Long memberId);
+    List<TalkPick> findAllByMemberIdOrderByEditedAtDesc(Long memberId);
 }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -57,6 +57,7 @@ public class TalkPickDto {
                     .views(0L)
                     .bookmarks(0L)
                     .viewStatus(NORMAL)
+                    .editedAt(LocalDateTime.now())
                     .build();
         }
     }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -200,7 +200,7 @@ public class TalkPickDto {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class TalkPickMyPageResponse {
 
-        @Schema(description = "톡픽 ID", example = "톡픽 ID")
+        @Schema(description = "톡픽 ID", example = "1")
         private long id;
 
         @Schema(description = "제목", example = "톡픽 제목")

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -8,5 +8,8 @@ import java.util.List;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     @Query("SELECT v FROM Vote v WHERE v.member.id = :memberId AND v.talkPick IS NOT NULL ORDER BY v.lastModifiedAt DESC")
-    List<Vote> findAllByMemberIdDesc(Long memberId);
+    List<Vote> findAllByMemberIdAndTalkPickDesc(Long memberId);
+
+    @Query("SELECT v FROM Vote v WHERE v.member.id = :memberId AND v.game IS NOT NULL ORDER BY v.lastModifiedAt DESC")
+    List<Vote> findAllByMemberIdAndGameDesc(Long memberId);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 생성 시 편집일 초기값 설정
- [x] 톡픽 검색 기준 편집일로 변경
- [x] 내가 댓글 단 톡픽 조회 시 편집일 기준 조회로 변경
- [x] 내가 북마크한 밸런스 게임 조회 기능 구현
- [x] 내가 투표한 밸런스 게임 조회 기능 구현
- [x] 내가 작성한 밸런스 조회 기능 구현

## 💡 자세한 설명
### postman 테스트 완료

## 톡픽 생성 시 편집일 초기값 설정
톡픽 생성 시에 `editedAt` 값을 정해주지 않으면, 마이페이지에서 톡픽 조회 시 `editedAt` 기준으로 내림차순이 불가하기 때문에, `TalkPickDto` 에서 톡픽 생성 요청 시 초기값을 설정하도록 구현했습니다.

## 내가 댓글 단 톡픽 조회 시 편집일 기준 조회로 변경
'내가 작성한 톡픽 조회' 와 마찬가지로, 본인의 댓글에 답글이 달리거나, 좋아요를 받는 상황에서도 `lastModifiedAt` 값이 변경 되기 때문에, 이를 구분하기 위한 `editedAt` 필드를 추가하고, 이 값을 기준으로 댓글 단 톡픽을 조회하도록 구현했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
1. 톡픽 이미지 업로드 기능 구현 완료 후, 마이페이지에서 톡픽 조회 시 선택지 이미지 반환
2. 밸런스 게임 기능 명세서 & 피그마가 미완인 상태라, 마이페이지에서 밸런스 게임 조회 시 어떤 값을 클라이언트에 전달해줘야 하는지 불분명한 상황. 추후 기능 명세서 업데이트 시 추가 구현 예정

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #490 #491
