### PR TITLE
로그 추적기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+
+	all { // log4j2와 중복으로 인해 logback 의존성 제거
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
 }
 
 repositories {
@@ -50,6 +54,10 @@ dependencies {
 	// caffeine cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.github.ben-manes.caffeine:caffeine'
+
+	// log4j2
+	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/balancetalk/global/utils/LoggingAspect.java
+++ b/src/main/java/balancetalk/global/utils/LoggingAspect.java
@@ -1,0 +1,58 @@
+package balancetalk.global.utils;
+
+import balancetalk.member.dto.ApiMember;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @Pointcut("execution(* *..*Controller.*(..))")
+    public void pointcut() {} // pointcut signature
+
+    @Around("pointcut()")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                .getRequest();
+        HttpServletResponse response = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getResponse();
+
+        String userIp = request.getRemoteAddr();
+        String method = request.getMethod();
+        String requestURI = request.getRequestURI();
+        Object[] args = joinPoint.getArgs();
+
+        Long memberId = Arrays.stream(args)
+                .filter(arg -> arg instanceof ApiMember)
+                .map(arg -> (ApiMember) arg)
+                .map(ApiMember::getMemberId)
+                .findFirst()
+                .orElse(null);
+        int status = response.getStatus();
+        if (memberId == null) {
+            log.info("[REQUEST] {} GUEST {} {} args={}", userIp, method, requestURI, args);
+        }
+        else {
+            log.info("[REQUEST] {} memberId={} {} {} args={}", userIp, memberId, method, requestURI, args);
+        }
+
+        try {
+            Object proceed = joinPoint.proceed();
+            log.info("[RESPONSE] {} {}", status, proceed);
+            return proceed;
+        } catch (Exception e) {
+            log.error("[RESPONSE] {} {} {}", status, e.getMessage(), e.getStackTrace());
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/logs/log4j2-dev.yml
+++ b/src/main/resources/logs/log4j2-dev.yml
@@ -37,8 +37,8 @@ Configuration:
       level: info
       AppenderRef:
         ref: RollingFile_Appender
-    AsyncLogger:
-      name: asyncLogger
+    Logger:
+      name: com.pick-o
       additivity: false
       level: info
       includeLocation: false

--- a/src/main/resources/logs/log4j2-dev.yml
+++ b/src/main/resources/logs/log4j2-dev.yml
@@ -1,0 +1,46 @@
+Configuration:
+  name: Logger-dev
+  status: info
+
+  Properties:
+    Property:
+      name: log-path
+      value: "logs"
+
+  Appenders:
+    RollingFile:
+      name: RollingFile_Appender
+      fileName: ${log-path}/logfile.log
+      filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
+      PatternLayout:
+        pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+      immediateFlush: false   # async 방식으로 버퍼를 통해 로그 남기기
+
+      Policies:
+        SizeBasedTriggeringPolicy:
+          size: "10 MB"
+        TimeBasedTriggeringPolicy:
+          Interval: 1   # 하루마다 rollover 발생
+          modulate: true
+
+      DefaultRollOverStrategy:
+        max: 10
+        Delete:
+          basePath: "${log-dir}"
+          maxDepth: "1"   # 디렉토리 깊이
+          IfLastModified:
+            age: "P7D"   # 파일을 7일동안 보관
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: RollingFile_Appender
+    AsyncLogger:
+      name: asyncLogger
+      additivity: false
+      level: info
+      includeLocation: false
+      AppenderRef:
+        ref: RollingFile_Appender

--- a/src/main/resources/logs/log4j2-local.yml
+++ b/src/main/resources/logs/log4j2-local.yml
@@ -1,0 +1,28 @@
+Configutation:
+  name: Logger-local
+  status: debug
+
+  Properties:
+    Property:
+      name: log-path
+      value: "logs"
+
+  Appenders:
+    Console:
+      name: Console_Appender
+      target: SYSTEM_OUT
+      PatternLayout:
+        pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        - ref: Console_Appender
+    Logger:
+      - name: com.pick-o
+        additivity: false
+        level: debug
+        AppenderRef:
+          - ref: Console_Appender


### PR DESCRIPTION
## 💡 작업 내용
- [x] AOP를 사용하여 비회원/회원일 때 요청, 응답, 에러 상황 기록
- [x] 로깅 전략으로 Log4j2 사용
- [x] yml파일 생성

## 💡 자세한 설명

### 비회원일 떄 요청을 보낸 경우
![스크린샷 2024-08-15 오전 12 16 15](https://github.com/user-attachments/assets/fae80a8f-5376-4af1-8e51-ab570759ca95)


### 회원일 떄 요청을 보낸 경우
![스크린샷 2024-08-15 오전 12 17 03](https://github.com/user-attachments/assets/2fefe4d1-cff7-4697-844e-558a47cb34d4)

### 정상 응답
![스크린샷 2024-08-15 오전 12 40 53](https://github.com/user-attachments/assets/357bcbee-f18f-42cd-b5a0-fe187e593665)


### 에러 상황 시 응답값
![스크린샷 2024-08-15 오전 12 16 40](https://github.com/user-attachments/assets/f7319ad0-0261-4c50-b5e1-37c626392668)



![스크린샷 2024-08-15 오전 12 31 41](https://github.com/user-attachments/assets/b67a3929-9524-417d-8d8b-b0090a750257)

![스크린샷 2024-08-15 오전 12 30 59](https://github.com/user-attachments/assets/8f9f2b89-e478-4d74-b01e-27df85013961)

Log4j2 설정 파일을 사용하여 로컬에서 실행한 경우, `DEBUG`까지 출력하도록 구현했습니다.

개발환경의 경우, 아직 db 서버가 연결되지 않았기 때문에 임시 주석처리 해뒀습니다.

## 📗 참고 자료 (선택)

https://kth990303.tistory.com/369

https://velog.io/@byeongju/Log4j2-AsyncLogger%EC%99%80-%ED%95%A8%EA%BB%98-%ED%95%98%EB%8A%94-Logging-%ED%99%98%EA%B2%BD-%EA%B5%AC%EC%B6%95

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #502 