### PR TITLE
이미지 업로드 기능 개선

### DIFF
--- a/src/main/java/balancetalk/file/application/FileService.java
+++ b/src/main/java/balancetalk/file/application/FileService.java
@@ -36,12 +36,12 @@ public class FileService {
     private String bucket;
 
     @Transactional
-    public String uploadImage(MultipartFile multipartFile, Long resourceId, FileType fileType) {
+    public String uploadImage(MultipartFile multipartFile, FileType fileType) {
         if (multipartFile.isEmpty()) {
             throw new BalanceTalkException(NOT_ATTACH_IMAGE);
         }
 
-        File file = fileProcessor.process(multipartFile, s3EndPoint + fileType.getUploadDir(), resourceId, fileType);
+        File file = fileProcessor.process(multipartFile, s3EndPoint + fileType.getUploadDir(), fileType);
 
         String s3Key = fileType.getUploadDir() + file.getStoredName();
 

--- a/src/main/java/balancetalk/file/domain/File.java
+++ b/src/main/java/balancetalk/file/domain/File.java
@@ -18,7 +18,6 @@ public class File {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
     private Long resourceId;
 
     @NotNull

--- a/src/main/java/balancetalk/file/domain/File.java
+++ b/src/main/java/balancetalk/file/domain/File.java
@@ -25,11 +25,9 @@ public class File {
     private Long size;
 
     @NotBlank
-    @Size(max = 50)
     private String uploadName;
 
     @NotBlank
-    @Size(max = 50)
     private String storedName;
 
     @NotBlank

--- a/src/main/java/balancetalk/file/domain/FileProcessor.java
+++ b/src/main/java/balancetalk/file/domain/FileProcessor.java
@@ -11,12 +11,12 @@ import java.util.UUID;
 @Component
 public class FileProcessor {
 
-    public File process(MultipartFile multipartFile, String path, long resourceId, FileType fileType) {
+    public File process(MultipartFile multipartFile, String path, FileType fileType) {
         String originalName = multipartFile.getOriginalFilename();
         String storedName = createRandomName(originalName);
         long size = multipartFile.getSize();
         FileFormat FileFormat = convertMimeTypeToFileFormat(multipartFile.getContentType());
-        return createFile(resourceId, originalName, storedName, FileFormat, path, fileType, size);
+        return createFile(originalName, storedName, FileFormat, path, fileType, size);
     }
 
     private String createRandomName(String originalName) {
@@ -30,15 +30,13 @@ public class FileProcessor {
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_SUPPORTED_FILE_FORMAT));
     }
 
-    private File createFile(long resourceId,
-                            String uploadName,
+    private File createFile(String uploadName,
                             String storedName,
                             FileFormat FileFormat,
                             String path,
                             FileType fileType,
                             long size) {
         return File.builder()
-                .resourceId(resourceId)
                 .uploadName(uploadName)
                 .storedName(storedName)
                 .fileFormat(FileFormat)

--- a/src/main/java/balancetalk/file/domain/FileType.java
+++ b/src/main/java/balancetalk/file/domain/FileType.java
@@ -1,17 +1,23 @@
 package balancetalk.file.domain;
 
 public enum FileType {
-    TALK_PICK("talk-pick/"),
-    GAME("balance-game/"),
-    MEMBER("member/");
+    TALK_PICK("talk-pick/", 10),
+    GAME("balance-game/", 1),
+    MEMBER("member/", 1);
 
     private final String uploadDir;
+    private final int maxCount;
 
-    FileType(String uploadDir) {
+    FileType(String uploadDir, int maxCount) {
         this.uploadDir = uploadDir;
+        this.maxCount = maxCount;
     }
 
     public String getUploadDir() {
         return uploadDir;
+    }
+
+    public int getMaxCount() {
+        return maxCount;
     }
 }

--- a/src/main/java/balancetalk/file/domain/MultipartFiles.java
+++ b/src/main/java/balancetalk/file/domain/MultipartFiles.java
@@ -1,7 +1,6 @@
 package balancetalk.file.domain;
 
 import balancetalk.global.exception.BalanceTalkException;
-import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -9,7 +8,6 @@ import java.util.List;
 import static balancetalk.global.exception.ErrorCode.EXCEEDED_IMAGES_SIZE;
 import static balancetalk.global.exception.ErrorCode.NOT_ATTACH_IMAGE;
 
-@Getter
 public record MultipartFiles(List<MultipartFile> multipartFiles, FileType fileType) {
 
     public MultipartFiles {

--- a/src/main/java/balancetalk/file/domain/MultipartFiles.java
+++ b/src/main/java/balancetalk/file/domain/MultipartFiles.java
@@ -1,0 +1,32 @@
+package balancetalk.file.domain;
+
+import balancetalk.global.exception.BalanceTalkException;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static balancetalk.global.exception.ErrorCode.EXCEEDED_IMAGES_SIZE;
+import static balancetalk.global.exception.ErrorCode.NOT_ATTACH_IMAGE;
+
+@Getter
+public record MultipartFiles(List<MultipartFile> multipartFiles, FileType fileType) {
+
+    public MultipartFiles {
+        if (multipartFiles == null || containsEmptyFile(multipartFiles)) {
+            throw new BalanceTalkException(NOT_ATTACH_IMAGE);
+        }
+        if (multipartFiles.size() > fileType.getMaxCount()) {
+            throw new BalanceTalkException(EXCEEDED_IMAGES_SIZE);
+        }
+    }
+
+    private boolean containsEmptyFile(List<MultipartFile> multipartFiles) {
+        return multipartFiles.stream().anyMatch(MultipartFile::isEmpty);
+    }
+
+    @Override
+    public List<MultipartFile> multipartFiles() {
+        return List.copyOf(multipartFiles);
+    }
+}

--- a/src/main/java/balancetalk/file/dto/UploadFileResponse.java
+++ b/src/main/java/balancetalk/file/dto/UploadFileResponse.java
@@ -1,0 +1,20 @@
+package balancetalk.file.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Schema(description = "이미지 파일 업로드 응답")
+@Data
+@AllArgsConstructor
+public class UploadFileResponse {
+
+    @Schema(description = "https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png",
+            example = "[" +
+                    "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
+                    "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
+                    "]")
+    private List<String> imgUrls;
+}

--- a/src/main/java/balancetalk/file/presentation/FileController.java
+++ b/src/main/java/balancetalk/file/presentation/FileController.java
@@ -2,6 +2,8 @@ package balancetalk.file.presentation;
 
 import balancetalk.file.application.FileService;
 import balancetalk.file.domain.FileType;
+import balancetalk.file.domain.MultipartFiles;
+import balancetalk.file.dto.UploadFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +24,8 @@ public class FileController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "이미지 파일 업로드", description = "이미지 파일을 업로드한 후 이미지 URL을 반환 받습니다.")
-    public String uploadImage(@RequestPart("file") MultipartFile file,
-                              @Parameter(description = "리소스 타입", example = "TALK_PICK") @RequestParam("type") FileType fileType) {
-        return fileService.uploadImage(file, fileType);
+    public UploadFileResponse uploadImage(@RequestPart("file") List<MultipartFile> multipartFiles,
+                                          @Parameter(description = "리소스 타입", example = "TALK_PICK") @RequestParam("type") FileType fileType) {
+        return fileService.uploadImages(new MultipartFiles(multipartFiles, fileType));
     }
 }

--- a/src/main/java/balancetalk/file/presentation/FileController.java
+++ b/src/main/java/balancetalk/file/presentation/FileController.java
@@ -21,8 +21,7 @@ public class FileController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "이미지 파일 업로드", description = "이미지 파일을 업로드한 후 이미지 URL을 반환 받습니다.")
     public String uploadImage(@RequestPart("file") MultipartFile file,
-                              @Parameter(description = "타겟 리소스의 ID") @RequestParam Long resourceId,
-                              @Parameter(description = "타겟 리소스의 타입") @RequestParam("type") FileType fileType) {
-        return fileService.uploadImage(file, resourceId, fileType);
+                              @Parameter(description = "리소스 타입", example = "TALK_PICK") @RequestParam("type") FileType fileType) {
+        return fileService.uploadImage(file, fileType);
     }
 }

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     NOT_INPUT_PARENT_COMMENT_ID(BAD_REQUEST, "원 댓글 ID가 입력되지 않았습니다."),
     INVALID_VOTE_OPTION(BAD_REQUEST, "존재하지 않는 선택지입니다."),
     NOT_ATTACH_IMAGE(BAD_REQUEST, "이미지를 첨부하지 않아 문제가 발생했습니다."),
-    EXCEEDED_IMAGES_SIZE(BAD_REQUEST, "첨부 가능한 이미지 개수는 10개 이하입니다."),
+    EXCEEDED_IMAGES_SIZE(BAD_REQUEST, "첨부 가능한 이미지 개수를 초과했습니다."),
     NOT_SUPPORTED_FILE_FORMAT(BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     REPORT_MY_COMMENT(BAD_REQUEST, "본인의 댓글을 신고할 수 없습니다"),
     INVALID_REPORT_REASON(BAD_REQUEST, "신고 사유가 올바르지 않습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     NOT_INPUT_PARENT_COMMENT_ID(BAD_REQUEST, "원 댓글 ID가 입력되지 않았습니다."),
     INVALID_VOTE_OPTION(BAD_REQUEST, "존재하지 않는 선택지입니다."),
     NOT_ATTACH_IMAGE(BAD_REQUEST, "이미지를 첨부하지 않아 문제가 발생했습니다."),
+    EXCEEDED_IMAGES_SIZE(BAD_REQUEST, "첨부 가능한 이미지 개수는 10개 이하입니다."),
     NOT_SUPPORTED_FILE_FORMAT(BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     REPORT_MY_COMMENT(BAD_REQUEST, "본인의 댓글을 신고할 수 없습니다"),
     INVALID_REPORT_REASON(BAD_REQUEST, "신고 사유가 올바르지 않습니다."),

--- a/src/test/java/balancetalk/file/domain/FileProcessorTest.java
+++ b/src/test/java/balancetalk/file/domain/FileProcessorTest.java
@@ -29,10 +29,9 @@ class FileProcessorTest {
                 new MockMultipartFile("mockFile", "강아지", "image/png", "content".getBytes());
 
         // when
-        File result = fileProcessor.process(multipartFile, "https://process.test/path/", 1L, TALK_PICK);
+        File result = fileProcessor.process(multipartFile, "https://process.test/path/", TALK_PICK);
 
         // then
-        assertThat(result.getResourceId()).isEqualTo(1L);
         assertThat(result.getFileType()).isEqualTo(TALK_PICK);
         assertThat(result.getFileFormat()).isEqualTo(PNG);
         assertThat(result.getPath()).isEqualTo("https://process.test/path/");
@@ -48,7 +47,7 @@ class FileProcessorTest {
 
         // when, then
         Assertions.assertThatThrownBy(() ->
-                        fileProcessor.process(multipartFile, "https://process.test/path/", 1L, TALK_PICK))
+                        fileProcessor.process(multipartFile, "https://process.test/path/", TALK_PICK))
                 .isInstanceOf(BalanceTalkException.class);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 이미지 업로드 시 리소스 ID를 전달하지 않도록 변경
- [x] 여러 이미지 파일을 업로드할 수 있도록 개선

## 💡 자세한 설명
### MultipartFiles 유효성 검증
```java
public UploadFileResponse uploadImage(@RequestPart("file") List<MultipartFile> multipartFiles,
                                      @Parameter(description = "리소스 타입", example = "TALK_PICK") @RequestParam("type") FileType fileType) {
    return fileService.uploadImages(new MultipartFiles(multipartFiles, fileType));

    ...
```

```java
public record MultipartFiles(List<MultipartFile> multipartFiles, FileType fileType) {

    public MultipartFiles {
        if (multipartFiles == null || containsEmptyFile(multipartFiles)) {
            throw new BalanceTalkException(NOT_ATTACH_IMAGE);
        }
        if (multipartFiles.size() > fileType.getMaxCount()) {
            throw new BalanceTalkException(EXCEEDED_IMAGES_SIZE);
        }
    }

    private boolean containsEmptyFile(List<MultipartFile> multipartFiles) {
        return multipartFiles.stream().anyMatch(MultipartFile::isEmpty);
    }

    ...
```

기존에는 파일 관련 유효성 검증을 서비스 계층에서 처리했지만, 검증할 내용이 증가함에 따라 그 책임을 MultipartFiles 클래스에 위임했습니다.
검증한 내용은 다음과 같습니다.
- null 체크 `multipartFiles == null`
- 비어 있는 파일 체크 `containsEmptyFile(multipartFiles)`
- 파일 개수 체크 `multipartFiles.size() > fileType.getMaxCount()`

### 여러 이미지 파일을 업로드할 수 있도록 개선
```java
@Transactional
public UploadFileResponse uploadImages(MultipartFiles multipartFiles) {
    FileType fileType = multipartFiles.fileType();

    List<String> s3Keys = new ArrayList<>();
    for (MultipartFile multipartFile : multipartFiles.multipartFiles()) {
        try {
            File file = fileProcessor.process(multipartFile, s3EndPoint + fileType.getUploadDir(), fileType);
            String s3Key = fileType.getUploadDir() + file.getStoredName();

            // S3에 이미지 파일 업로드
            s3ImageUploader.uploadImageToBucket(s3Client, bucket, s3Key, multipartFile);

            // DB에 메타 데이터 저장
            fileRepository.save(file);

            // 이미지 URL 반환
            s3Keys.add(s3Key);
        } catch (Exception e) {
            // DB에 메타 데이터 저장 중 예외가 발생하면 S3에 업로드된 이미지 제거 후 커스텀 예외로 변환
            for (String key : s3Keys) {
                s3ImageRemover.removeImageFromBucket(s3Client, bucket, key);
            }

            throw new BalanceTalkException(NOT_UPLOADED_IMAGE_FOR_DB_ERROR);
        }
    }

    List<String> imgUrls = s3Keys.stream()
                .map(key -> s3ImageUrlGetter.getImageUrl(s3Client, bucket, key))
                .toList();

    return new UploadFileResponse(imgUrls);
}
```

여러 이미지 파일을 업로드할 수 있는 만큼, 업로드 과정에서 문제가 발생하면 데이터 일관성 문제가 발생할 수 있습니다.

예를 들어, 파일 A와 B를 성공적으로 업로드한 후 C를 업로드하는 과정에서 어떤 예외가 발생한다면, 트랜잭션 롤백으로 인해 A와 B까지 DB에 저장되지 않습니다. 하지만 S3의 경우 트랜잭션이 적용되지 않아 A와 B가 저장되지 않습니다. 즉, 파일 A와 B는 DB에는 없지만 S3에는 존재하는 문제가 발생합니다.

이를 해결하기 위해, try-catch 문을 이용하여 중간에 예외 발생 시 이전에 저장한 이미지 파일을 모두 S3에서 제거하도록 했습니다.

위와 같이 구현 후 테스트해본 결과 DB와 S3의 데이터 일관성 문제가 발생하지 않는 것을 확인하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #504 
