### PR TITLE
[톡픽 작성&수정] 요청 바디에 타 웹사이트 출처와 이미지 URL 배열 추가

### DIFF
--- a/src/main/java/balancetalk/file/application/FileService.java
+++ b/src/main/java/balancetalk/file/application/FileService.java
@@ -1,6 +1,7 @@
 package balancetalk.file.application;
 
 import balancetalk.file.domain.*;
+import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.file.domain.s3.S3ImageRemover;
 import balancetalk.file.domain.s3.S3ImageUploader;
 import balancetalk.file.domain.s3.S3ImageUrlGetter;

--- a/src/main/java/balancetalk/file/application/FileService.java
+++ b/src/main/java/balancetalk/file/application/FileService.java
@@ -42,6 +42,7 @@ public class FileService {
         FileType fileType = multipartFiles.fileType();
 
         List<String> s3Keys = new ArrayList<>();
+        List<String> storedNames = new ArrayList<>();
         for (MultipartFile multipartFile : multipartFiles.multipartFiles()) {
             try {
                 File file = fileProcessor.process(multipartFile, s3EndPoint + fileType.getUploadDir(), fileType);
@@ -53,8 +54,9 @@ public class FileService {
                 // DB에 메타 데이터 저장
                 fileRepository.save(file);
 
-                // 이미지 URL 반환
+                // 이미지 URL 및 고유 이름 저장
                 s3Keys.add(s3Key);
+                storedNames.add(file.getStoredName());
             } catch (Exception e) {
                 // DB에 메타 데이터 저장 중 예외가 발생하면 S3에 업로드된 이미지 제거 후 커스텀 예외로 변환
                 for (String key : s3Keys) {
@@ -69,6 +71,6 @@ public class FileService {
                 .map(key -> s3ImageUrlGetter.getImageUrl(s3Client, bucket, key))
                 .toList();
 
-        return new UploadFileResponse(imgUrls);
+        return new UploadFileResponse(imgUrls, storedNames);
     }
 }

--- a/src/main/java/balancetalk/file/domain/FileRepository.java
+++ b/src/main/java/balancetalk/file/domain/FileRepository.java
@@ -1,8 +1,0 @@
-package balancetalk.file.domain;
-
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface FileRepository extends JpaRepository<File, Long> {
-    Optional<File> findByStoredName(String storedName);
-}

--- a/src/main/java/balancetalk/file/domain/repository/FileRepository.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepository.java
@@ -1,0 +1,7 @@
+package balancetalk.file.domain.repository;
+
+import balancetalk.file.domain.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long>, FileRepositoryCustom {
+}

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -1,0 +1,9 @@
+package balancetalk.file.domain.repository;
+
+import balancetalk.file.domain.FileType;
+
+import java.util.List;
+
+public interface FileRepositoryCustom {
+    void updateResourceIdByStoredNames(long resourceId, List<String> storedNames);
+}

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -1,0 +1,22 @@
+package balancetalk.file.domain.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static balancetalk.file.domain.QFile.file;
+
+@RequiredArgsConstructor
+public class FileRepositoryImpl implements FileRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void updateResourceIdByStoredNames(long resourceId, List<String> storedNames) {
+        queryFactory.update(file)
+                .set(file.resourceId, resourceId)
+                .where(file.storedName.in(storedNames))
+                .execute();
+    }
+}

--- a/src/main/java/balancetalk/file/dto/UploadFileResponse.java
+++ b/src/main/java/balancetalk/file/dto/UploadFileResponse.java
@@ -11,10 +11,17 @@ import java.util.List;
 @AllArgsConstructor
 public class UploadFileResponse {
 
-    @Schema(description = "https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png",
+    @Schema(description = "업로드한 이미지 URL 목록",
             example = "[" +
                     "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
                     "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
                     "]")
     private List<String> imgUrls;
+
+    @Schema(description = "업로드한 이미지 고유 이름 목록",
+            example = "[" +
+                    "\"9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
+                    "\"fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
+                    "]")
+    private List<String> storedNames;
 }

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -1,5 +1,6 @@
 package balancetalk.talkpick.application;
 
+import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
@@ -27,11 +28,13 @@ public class TalkPickService {
 
     private final MemberRepository memberRepository;
     private final TalkPickRepository talkPickRepository;
+    private final FileRepository fileRepository;
 
     @Transactional
     public void createTalkPick(CreateOrUpdateTalkPickRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
-        talkPickRepository.save(request.toEntity(member));
+        TalkPick savedTalkPick = talkPickRepository.save(request.toEntity(member));
+        fileRepository.updateResourceIdByStoredNames(savedTalkPick.getId(), request.getStoredNames());
     }
 
     @Transactional
@@ -68,6 +71,7 @@ public class TalkPickService {
         Member member = apiMember.toMember(memberRepository);
         TalkPick talkPick = member.getTalkPickById(talkPickId);
         talkPick.edit(request.getTitle(), request.getContent(), request.getOptionA(), request.getOptionB());
+        fileRepository.updateResourceIdByStoredNames(talkPickId, request.getStoredNames());
     }
 
     @Transactional

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -29,7 +29,7 @@ public class TalkPickService {
     private final TalkPickRepository talkPickRepository;
 
     @Transactional
-    public void createTalkPick(CreateTalkPickRequest request, ApiMember apiMember) {
+    public void createTalkPick(CreateOrUpdateTalkPickRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         talkPickRepository.save(request.toEntity(member));
     }
@@ -64,7 +64,7 @@ public class TalkPickService {
     }
 
     @Transactional
-    public void updateTalkPick(Long talkPickId, UpdateTalkPickRequest request, ApiMember apiMember) {
+    public void updateTalkPick(Long talkPickId, CreateOrUpdateTalkPickRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         TalkPick talkPick = member.getTalkPickById(talkPickId);
         talkPick.edit(request.getTitle(), request.getContent(), request.getOptionA(), request.getOptionB());

--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -52,6 +52,8 @@ public class TalkPick extends BaseTimeEntity {
     @Column(name = "option_b")
     private String optionB;
 
+    private String sourceUrl;
+
     @PositiveOrZero
     @ColumnDefault("0")
     private Long views;

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -1,7 +1,7 @@
 package balancetalk.talkpick.dto;
 
-import balancetalk.member.domain.Member;
 import balancetalk.comment.domain.Comment;
+import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteOption;
@@ -16,6 +16,7 @@ import lombok.Data;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static balancetalk.talkpick.domain.ViewStatus.NORMAL;
 import static balancetalk.vote.domain.VoteOption.A;
@@ -23,10 +24,10 @@ import static balancetalk.vote.domain.VoteOption.B;
 
 public class TalkPickDto {
 
-    @Schema(description = "톡픽 생성 요청")
+    @Schema(description = "톡픽 생성/수정 요청")
     @Data
     @AllArgsConstructor
-    public static class CreateTalkPickRequest {
+    public static class CreateOrUpdateTalkPickRequest {
 
         @Schema(description = "제목", example = "제목")
         @NotBlank(message = "제목은 공백을 허용하지 않습니다.")
@@ -46,6 +47,15 @@ public class TalkPickDto {
         @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
         @Size(max = 10, message = "선택지 이름은 10자 이하여야 합니다.")
         private String optionB;
+
+        @Schema(description = "출처 URL", example = "https://github.com/CHZZK-Study/Balance-Talk-Backend/issues/506")
+        private String sourceUrl;
+
+        @Schema(description = "첨부한 이미지 URL이 담긴 배열", example = "[" +
+                "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
+                "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
+                "]")
+        private List<String> imgUrls;
 
         public TalkPick toEntity(Member member) {
             return TalkPick.builder()
@@ -54,36 +64,12 @@ public class TalkPickDto {
                     .content(content)
                     .optionA(optionA)
                     .optionB(optionB)
+                    .sourceUrl(sourceUrl)
                     .views(0L)
                     .bookmarks(0L)
                     .viewStatus(NORMAL)
                     .build();
         }
-    }
-
-    @Schema(description = "톡픽 수정 요청")
-    @Data
-    @AllArgsConstructor
-    public static class UpdateTalkPickRequest {
-
-        @Schema(description = "제목", example = "제목")
-        @NotBlank(message = "제목은 공백을 허용하지 않습니다.")
-        @Size(max = 50, message = "제목은 50자 이하여야 합니다.")
-        private String title;
-
-        @Schema(description = "본문 내용", example = "본문 내용")
-        @NotBlank(message = "본문 내용은 공백을 허용하지 않습니다.")
-        private String content;
-
-        @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
-        @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
-        @Size(max = 10, message = "선택지 이름은 10자 이하여야 합니다.")
-        private String optionA;
-
-        @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
-        @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
-        @Size(max = 10, message = "선택지 이름은 10자 이하여야 합니다.")
-        private String optionB;
     }
 
     @Schema(description = "톡픽 상세 조회 응답")
@@ -108,6 +94,9 @@ public class TalkPickDto {
 
         @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
         private String optionB;
+
+        @Schema(description = "출처 URL", example = "https://github.com/CHZZK-Study/Balance-Talk-Backend/issues/506")
+        private String sourceUrl;
 
         @Schema(description = "선택지 A 투표수", example = "12")
         private long votesCountOfOptionA;
@@ -144,6 +133,7 @@ public class TalkPickDto {
                     .summary(new SummaryDto(entity.getSummary()))
                     .optionA(entity.getOptionA())
                     .optionB(entity.getOptionB())
+                    .sourceUrl(entity.getSourceUrl())
                     .votesCountOfOptionA(entity.votesCountOf(A))
                     .votesCountOfOptionB(entity.votesCountOf(B))
                     .views(entity.getViews())
@@ -240,7 +230,7 @@ public class TalkPickDto {
                     .voteOption(vote.getVoteOption())
                     .build();
         }
-      
+
         public static TalkPickMyPageResponse from(TalkPick talkPick, Comment comment) {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -51,11 +51,12 @@ public class TalkPickDto {
         @Schema(description = "출처 URL", example = "https://github.com/CHZZK-Study/Balance-Talk-Backend/issues/506")
         private String sourceUrl;
 
-        @Schema(description = "첨부한 이미지 URL이 담긴 배열", example = "[" +
-                "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
-                "\"https://picko-image.s3.ap-northeast-2.amazonaws.com/talk-pick/fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
-                "]")
-        private List<String> imgUrls;
+        @Schema(description = "첨부한 이미지 고유 이름 목록",
+                example = "[" +
+                        "\"9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
+                        "\"fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
+                        "]")
+        private List<String> storedNames;
 
         public TalkPick toEntity(Member member) {
             return TalkPick.builder()

--- a/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
@@ -28,7 +28,7 @@ public class TalkPickController {
 
     @Operation(summary = "톡픽 생성", description = "톡픽을 생성합니다.")
     @PostMapping
-    public void createTalkPick(@RequestBody final CreateTalkPickRequest request,
+    public void createTalkPick(@RequestBody final CreateOrUpdateTalkPickRequest request,
                                @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
         talkPickService.createTalkPick(request, apiMember);
     }
@@ -51,7 +51,7 @@ public class TalkPickController {
     @Operation(summary = "톡픽 수정", description = "톡픽을 수정합니다.")
     @PutMapping("/{talkPickId}")
     public void updateTalkPick(@PathVariable final Long talkPickId,
-                               @RequestBody final UpdateTalkPickRequest request,
+                               @RequestBody final CreateOrUpdateTalkPickRequest request,
                                @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
         talkPickService.updateTalkPick(talkPickId, request, apiMember);
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 엔티티 및 dto에 출처 url 필드 추가
- [x] 파일 업로드 API 응답에 이미지 고유 이름 필드 추가
- [x] 톡픽 생성/수정 시 이미지 resourceId 변경 로직 추가

## 💡 자세한 설명
톡픽 작성/수정 API 요청 바디에 출처와 이미지 정보를 담아서 전달하도록 개선했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #506 
