### PR TITLE
톡픽 상세 조회 API 응답에 이미지 URL 추가

### DIFF
--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface FileRepositoryCustom {
     void updateResourceIdByStoredNames(long resourceId, List<String> storedNames);
+
+    List<String> findImgUrlsByResourceIdAndFileType(Long talkPickId, FileType fileType);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -1,5 +1,7 @@
 package balancetalk.file.domain.repository;
 
+import balancetalk.file.domain.File;
+import balancetalk.file.domain.FileType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -18,5 +20,16 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
                 .set(file.resourceId, resourceId)
                 .where(file.storedName.in(storedNames))
                 .execute();
+    }
+
+    @Override
+    public List<String> findImgUrlsByResourceIdAndFileType(Long resourceId, FileType fileType) {
+        List<File> images = queryFactory.selectFrom(file)
+                .where(file.fileType.eq(fileType), file.resourceId.eq(resourceId))
+                .fetch();
+
+        return images.stream()
+                .map(image -> "%s%s".formatted(image.getPath(), image.getStoredName()))
+                .toList();
     }
 }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -100,6 +100,13 @@ public class TalkPickDto {
         @Schema(description = "출처 URL", example = "https://github.com/CHZZK-Study/Balance-Talk-Backend/issues/506")
         private String sourceUrl;
 
+        @Schema(description = "톡픽 작성 시 첨부한 이미지 URL 목록",
+                example = "[" +
+                        "\"9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png\",\n" +
+                        "\"fdcbd97b-f9be-45d1-b855-43f3fd17d5a6_6d588490-d5d4-4e47-b5d0-957e6ed4830b_prom.jpeg\"" +
+                        "]")
+        private List<String> imgUrls;
+
         @Schema(description = "선택지 A 투표수", example = "12")
         private long votesCountOfOptionA;
 
@@ -127,7 +134,10 @@ public class TalkPickDto {
         @Schema(description = "수정 여부", example = "true")
         private Boolean isUpdated;
 
-        public static TalkPickDetailResponse from(TalkPick entity, boolean myBookmark, VoteOption votedOption) {
+        public static TalkPickDetailResponse from(TalkPick entity,
+                                                  List<String> imgUrls,
+                                                  boolean myBookmark,
+                                                  VoteOption votedOption) {
             return TalkPickDetailResponse.builder()
                     .id(entity.getId())
                     .title(entity.getTitle())
@@ -136,6 +146,7 @@ public class TalkPickDto {
                     .optionA(entity.getOptionA())
                     .optionB(entity.getOptionB())
                     .sourceUrl(entity.getSourceUrl())
+                    .imgUrls(imgUrls)
                     .votesCountOfOptionA(entity.votesCountOf(A))
                     .votesCountOfOptionB(entity.votesCountOf(B))
                     .views(entity.getViews())

--- a/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
+++ b/src/test/java/balancetalk/talkpick/application/TalkPickServiceTest.java
@@ -1,5 +1,6 @@
 package balancetalk.talkpick.application;
 
+import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.member.domain.Member;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.domain.Summary;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static balancetalk.vote.domain.VoteOption.A;
@@ -30,6 +32,9 @@ class TalkPickServiceTest {
 
     @Mock
     TalkPickRepository talkPickRepository;
+
+    @Mock
+    FileRepository fileRepository;
 
     TalkPick talkPick;
     GuestOrApiMember guestOrApiMember;
@@ -75,6 +80,7 @@ class TalkPickServiceTest {
         // given
         when(talkPickRepository.findById(1L)).thenReturn(Optional.ofNullable(talkPick));
         when(guestOrApiMember.isGuest()).thenReturn(true);
+        when(fileRepository.findImgUrlsByResourceIdAndFileType(any(), any())).thenReturn(List.of());
 
         // when
         TalkPickDetailResponse result = talkPickService.findById(1L, guestOrApiMember);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 상세 조회 API 응답에 이미지 URL 추가

## 💡 자세한 설명
톡픽 상세 조회 API 응답에 이미지 URL 목록을 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #512 
