### PR TITLE
임시 저장했던 톡픽 등록 시 파일 타입을 TALK_PICK으로 변경

### DIFF
--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -5,7 +5,7 @@ import balancetalk.file.domain.FileType;
 import java.util.List;
 
 public interface FileRepositoryCustom {
-    void updateResourceIdByStoredNames(Long resourceId, List<String> storedNames);
+    void updateResourceIdAndTypeByStoredNames(Long resourceId, FileType fileType, List<String> storedNames);
 
     List<String> findImgUrlsByResourceIdAndFileType(Long resourceId, FileType fileType);
 

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -15,13 +15,13 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public void updateResourceIdByStoredNames(Long resourceId, List<String> storedNames) {
+    public void updateResourceIdAndTypeByStoredNames(Long resourceId, FileType fileType, List<String> storedNames) {
         if (storedNames == null) {
             return;
         }
 
         queryFactory.update(file)
-                .set(file.resourceId, resourceId)
+                .set(List.of(file.resourceId, file.fileType), List.of(resourceId, fileType))
                 .where(file.storedName.in(storedNames))
                 .execute();
     }

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -35,7 +35,7 @@ public class TalkPickService {
     public void createTalkPick(CreateOrUpdateTalkPickRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         TalkPick savedTalkPick = talkPickRepository.save(request.toEntity(member));
-        fileRepository.updateResourceIdByStoredNames(savedTalkPick.getId(), request.getStoredNames());
+        fileRepository.updateResourceIdAndTypeByStoredNames(savedTalkPick.getId(), FileType.TALK_PICK, request.getStoredNames());
     }
 
     @Transactional
@@ -74,7 +74,7 @@ public class TalkPickService {
         Member member = apiMember.toMember(memberRepository);
         TalkPick talkPick = member.getTalkPickById(talkPickId);
         talkPick.update(request.toEntity(member));
-        fileRepository.updateResourceIdByStoredNames(talkPickId, request.getStoredNames());
+        fileRepository.updateResourceIdAndTypeByStoredNames(talkPickId, FileType.TALK_PICK, request.getStoredNames());
     }
 
     @Transactional

--- a/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
@@ -32,12 +32,12 @@ public class TempTalkPickService {
 
         if (member.hasTempTalkPick()) {
             Long prevTempTalkPickId = member.updateTempTalkPick(request.toEntity(member));
-            fileRepository.updateResourceIdByStoredNames(prevTempTalkPickId, request.getStoredNames());
+            fileRepository.updateResourceIdAndTypeByStoredNames(prevTempTalkPickId, TEMP_TALK_PICK, request.getStoredNames());
             return;
         }
 
         TempTalkPick savedTempTalkPick = tempTalkPickRepository.save(request.toEntity(member));
-        fileRepository.updateResourceIdByStoredNames(savedTempTalkPick.getId(), request.getStoredNames());
+        fileRepository.updateResourceIdAndTypeByStoredNames(savedTempTalkPick.getId(), TEMP_TALK_PICK, request.getStoredNames());
     }
 
     public FindTempTalkPickResponse findTempTalkPick(ApiMember apiMember) {

--- a/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
@@ -32,24 +32,35 @@ public class TempTalkPickService {
 
         if (member.hasTempTalkPick()) {
             Long prevTempTalkPickId = member.updateTempTalkPick(request.toEntity(member));
-            fileRepository.updateResourceIdAndTypeByStoredNames(prevTempTalkPickId, TEMP_TALK_PICK, request.getStoredNames());
+            updateFileResourceIdByStoredNames(prevTempTalkPickId, request.getStoredNames());
             return;
         }
 
         TempTalkPick savedTempTalkPick = tempTalkPickRepository.save(request.toEntity(member));
-        fileRepository.updateResourceIdAndTypeByStoredNames(savedTempTalkPick.getId(), TEMP_TALK_PICK, request.getStoredNames());
+        updateFileResourceIdByStoredNames(savedTempTalkPick.getId(), request.getStoredNames());
+    }
+
+    private void updateFileResourceIdByStoredNames(Long resourceId, List<String> storedNames) {
+        fileRepository.updateResourceIdAndTypeByStoredNames(resourceId, TEMP_TALK_PICK, storedNames);
     }
 
     public FindTempTalkPickResponse findTempTalkPick(ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
-        TempTalkPick tempTalkPick = tempTalkPickRepository.findByMember(member)
+        TempTalkPick tempTalkPick = getTempTalkPick(member);
+
+        return FindTempTalkPickResponse.from(tempTalkPick, getImgUrls(tempTalkPick), getStoredNames(tempTalkPick));
+    }
+
+    private TempTalkPick getTempTalkPick(Member member) {
+        return tempTalkPickRepository.findByMember(member)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_TEMP_TALK_PICK));
+    }
 
-        List<String> imgUrls =
-                fileRepository.findImgUrlsByResourceIdAndFileType(tempTalkPick.getId(), TEMP_TALK_PICK);
-        List<String> storedNames =
-                fileRepository.findStoredNamesByResourceIdAndFileType(tempTalkPick.getId(), TEMP_TALK_PICK);
+    private List<String> getImgUrls(TempTalkPick tempTalkPick) {
+        return fileRepository.findImgUrlsByResourceIdAndFileType(tempTalkPick.getId(), TEMP_TALK_PICK);
+    }
 
-        return FindTempTalkPickResponse.from(tempTalkPick, imgUrls, storedNames);
+    private List<String> getStoredNames(TempTalkPick tempTalkPick) {
+        return fileRepository.findStoredNamesByResourceIdAndFileType(tempTalkPick.getId(), TEMP_TALK_PICK);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 임시 저장했던 톡픽 등록 시 파일 타입을 TALK_PICK으로 변경
- [x] 메서드 분리

## 💡 자세한 설명
임시 저장했던 톡픽을 TalkPick 엔티티로 저장하는 로직에서, 연관된 파일의 타입이 TEMP_TALK_PICK 그대로 남아 있는 문제가 발생했습니다.

이를 해결하기 위해, 이미지 파일 정보 업데이트 로직을 다음과 같이 개선했습니다.
```java
@Override
public void updateResourceIdAndTypeByStoredNames(Long resourceId, FileType fileType, List<String> storedNames) {
    if (storedNames == null) {
        return;
    }

    queryFactory.update(file)
            .set(List.of(file.resourceId, file.fileType), List.of(resourceId, fileType))
            .where(file.storedName.in(storedNames))
            .execute();
}
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
