### PR TITLE
단일 회원 조회 시 추가 데이터 반환 구현 완료

### DIFF
--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -136,4 +136,12 @@ public class Member extends BaseTimeEntity {
     public Long updateTempTalkPick(TempTalkPick newTempTalkPick) {
         return tempTalkPick.update(newTempTalkPick);
     }
+
+    public int getPostsCount() {
+        return talkPicks.size() + games.size();
+    }
+
+    public int getBookmarkedPostsCount() {
+        return bookmarks.size();
+    }
 }

--- a/src/main/java/balancetalk/member/dto/MemberDto.java
+++ b/src/main/java/balancetalk/member/dto/MemberDto.java
@@ -89,9 +89,12 @@ public class MemberDto {
         @Schema(description = "가입일", example = "2024-02-16 13:37:17.391706")
         private LocalDateTime createdAt;
 
-//    @Schema(description = "작성한 게시글 수", example = "11")
-//    private int postsCount;
-//
+        @Schema(description = "작성한 게시글 수", example = "23")
+        private int postsCount;
+
+        @Schema(description = "저장한 게시글 수", example = "21")
+        private int bookmarkedPostsCount;
+
 //    @Schema(description = "작성한 게시글의 받은 추천 수", example = "119")
 //    private int totalPostLike;
 //
@@ -106,6 +109,8 @@ public class MemberDto {
             return MemberResponse.builder()
                     .id(member.getId())
                     .nickname(member.getNickname())
+                    .postsCount(member.getPostsCount())
+                    .bookmarkedPostsCount(member.getBookmarkedPostsCount())
 //                .createdAt(member.getCreatedAt())
 //                .postsCount(member.getPostCount())
 //                .totalPostLike(member.getPostLikes())


### PR DESCRIPTION
## 💡 작업 내용
- [ ] 해당 회원이 작성한 글 개수 반환 구현
- [ ] 해당 회원이 저장한 글 개수 반환 구현

## 💡 자세한 설명
멤버 클래스에 글 개수를 반환하는 각각의 메서드를 구현하고, 이를 DTO에서 사용하도록 수정했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #525
