### PR TITLE
마이페이지 컨텐츠 반환 시 DTO에 마이페이지 등록 날짜 포함 구현 완료

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -187,12 +187,16 @@ public class GameDto {
         @Schema(description = "선택지 B 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/1157461e-a685-42fd-837e-7ed490894ca6_unnamed.png")
         private String optionBImg;
 
+        @Schema(description = "최종 수정일(마이페이지 등록 날짜)")
+        private LocalDateTime editedAt;
+
         public static GameMyPageResponse from(Game game) { // TODO : 클라이언트에게 어떤 정보를 제공할지 추후 기능명세서 업데이트 후 결정
             return GameMyPageResponse.builder()
                     .id(game.getId())
                     .title(game.getTitle())
 //                    .optionAImg(game.getOptionAImg())
 //                    .optionBImg(game.getOptionBImg())
+                    .editedAt(game.getEditedAt())
                     .build();
         }
 
@@ -203,6 +207,7 @@ public class GameDto {
 //                    .optionAImg(game.getOptionAImg())
 //                    .optionBImg(game.getOptionBImg())
                     .voteOption(vote.getVoteOption())
+                    .editedAt(game.getEditedAt())
                     .build();
         }
     }

--- a/src/main/java/balancetalk/member/presentation/MyPageController.java
+++ b/src/main/java/balancetalk/member/presentation/MyPageController.java
@@ -67,7 +67,7 @@ public class MyPageController {
 
     @GetMapping("/games/bookmarks")
     @Operation(summary = "북마크한 밸런스 게임 목록 조회", description = "로그인한 회원이 북마크한 밸런스 게임 목록을 조회한다.")
-    public Page<GameMyPageResponse  > findAllBookmarkedGames(
+    public Page<GameMyPageResponse> findAllBookmarkedGames(
             @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
             @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
 

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -220,6 +220,9 @@ public class TalkPickDto {
         @Schema(description = "댓글 개수", example = "2")
         private long commentCount;
 
+        @Schema(description = "최종 수정일(마이페이지 등록 날짜)")
+        private LocalDateTime editedAt;
+
         /*
         @Schema(description = "선택지 A 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
         private String optionAImg;
@@ -233,6 +236,7 @@ public class TalkPickDto {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
+                    .editedAt(talkPick.getEditedAt())
                     .build();
         }
 
@@ -241,6 +245,7 @@ public class TalkPickDto {
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
                     .voteOption(vote.getVoteOption())
+                    .editedAt(talkPick.getEditedAt())
                     .build();
         }
 
@@ -249,6 +254,7 @@ public class TalkPickDto {
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
                     .commentContent(comment.getContent())
+                    .editedAt(talkPick.getEditedAt())
                     .build();
         }
 
@@ -258,6 +264,7 @@ public class TalkPickDto {
                     .title(talkPick.getTitle())
                     .bookmarks(talkPick.getBookmarks())
                     .commentCount(!talkPick.getComments().isEmpty() ? talkPick.getComments().size() : 0)
+                    .editedAt(talkPick.getEditedAt())
                     .build();
         }
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 마이페이지 톡픽 응답 시 편집 날짜 반환
- [x] 마이페이지 밸런스 게임 응답 시 편집 날짜 반환

## 💡 자세한 설명
각 DTO에서 편집 날짜를 반환하도록 구현했습니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #524
