### PR TITLE
jwt deprecated 로직 개선

### DIFF
--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -5,9 +5,11 @@ import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.application.MyUserDetailService;
 import balancetalk.member.domain.CustomUserDetails;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,9 +23,6 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    @Value("${spring.jwt.secret}")
-    private String secretKey;
-
     @Value("${spring.jwt.token.access-expiration-time}")
     private long accessExpirationTime;
 
@@ -31,6 +30,8 @@ public class JwtTokenProvider {
     private long refreshExpirationTime;
 
     private final MyUserDetailService myUserDetailService;
+
+    private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
 
     /**
      * Access 토큰 생성
@@ -47,7 +48,7 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)
-                .signWith(SignatureAlgorithm.HS512, secretKey) // TODO: secretKey를 미리 암호화?
+                .signWith(secretKey)
                 .compact();
     }
 
@@ -66,7 +67,7 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)
-                .signWith(SignatureAlgorithm.HS512, secretKey)
+                .signWith(secretKey)
                 .compact();
         // redis에 refresh token 저장
 //        redisService.setValues(authentication.getName(), refreshToken, Duration.ofMillis(refreshExpirationTime));


### PR DESCRIPTION
## 💡 작업 내용
- [x] jwt 관련 로직 수정
- [x] yml 파일 최신화


## 💡 자세한 설명
기존에 임의의 문자열을 인코딩해서 `secretKey`로 사용을 했었는데, 그 방식은 안전하지 않아서 사용이 중단되었다고 합니다.

따라서, secretFor라는 메서드를 사용해서 자체적으로 인코딩하도록 개선했습니다.

![스크린샷 2024-08-27 오전 12 18 10](https://github.com/user-attachments/assets/83b42147-3573-4130-af76-c65a60ac44fe)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #532 
