### PR TITLE
오늘의 톡픽 조회 쿼리 개선

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -33,9 +33,8 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
                 .select(new QTodayTalkPickDto_TodayTalkPickResponse(
                         talkPick.id, talkPick.title, talkPick.optionA, talkPick.optionB
                 ))
-                .from(vote)
-                .join(vote.talkPick, talkPick)
-                .where(talkPick.id.eq(vote.talkPick.id))
+                .from(talkPick)
+                .leftJoin(talkPick.votes, vote)
                 .groupBy(talkPick.id)
                 .orderBy(talkPick.views.desc(), vote.count().desc(), talkPick.createdAt.desc())
                 .limit(1)


### PR DESCRIPTION
## 💡 작업 내용
- [x] 오늘의 톡픽 조회 쿼리 개선

## 💡 자세한 설명
기존 <<오늘의 톡픽 조회 API>>의 쿼리는 다음과 같이 작성되어 있습니다.

```sql
select t.id, t.title, t.option_a, t.option_b 
from vote v join talk_pick t on v.talk_pick_id = t.id
group by t.id
order by t.views desc, count(v.id) desc, t.created_at desc
limit 1;
```
이 쿼리에서는 inner join을 사용하여, vote 테이블에 데이터가 없으면 어떤 데이터도 조회되지 않는다는 문제가 존재했습니다.
(아래 그림을 보면 더 쉽게 이해할 수 있습니다)

<img width="484" alt="image" src="https://github.com/user-attachments/assets/70438575-35f9-4f06-814c-76055a8baa06">

inner join으로 조회할 경우 겹치는 영역에 존재하는 데이터만 가져오기 때문에, vote 데이터가 없으면 어떤 데이터도 존재하지 않는 것입니다.
반면에, left join으로 조회할 경우 talk_pick 전체를 가져오므로, vote 데이터가 없더라도 데이터가 존재하게 됩니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #531 
