### PR TITLE
알림 기능 전달 데이터 JSON 으로 추가 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -220,6 +220,7 @@ public class CommentService {
     private void sendReplyNotification(Comment parentComment) {
         long replyCount = parentComment.getReplies().size();
         Member parentCommentAuthor = parentComment.getMember();
+        TalkPick talkPick = parentComment.getTalkPick();
         String replyCountKey = "REPLY_" + replyCount;
         String firstReplyKey = "FIRST_REPLY";
         Map<String, Boolean> notificationHistory = parentComment.getNotificationHistory();
@@ -230,7 +231,8 @@ public class CommentService {
 
         // 첫 답글 알림
         if ((isFirstReplyFromOther && !parentComment.getIsNotifiedForFirstReply()) && !notificationHistory.getOrDefault(firstReplyKey, false)) {
-            notificationService.sendNotification(parentComment.getMember(), FIRST_COMMENT_REPLY.getMessage());
+            notificationService.sendTalkPickNotification(parentCommentAuthor,talkPick,
+                    "톡픽", FIRST_COMMENT_REPLY.getMessage());
             parentComment.setIsNotifiedForFirstReplyTrue();
             notificationHistory.put(firstReplyKey, true);
             parentComment.setNotificationHistory(notificationHistory);
@@ -238,7 +240,8 @@ public class CommentService {
         } else if ((replyCount == FIRST_COUNT_OF_REPLY_NOTIFICATION ||
                 replyCount == SECOND_COUNT_OF_REPLY_NOTIFICATION || replyCount == THIRD_COUNT_OF_REPLY_NOTIFICATION) &&
                 !notificationHistory.getOrDefault(replyCountKey, false)) {
-            notificationService.sendNotification(parentComment.getMember(), COMMENT_REPLY.format(replyCount));
+            notificationService.sendTalkPickNotification(parentCommentAuthor, talkPick, "톡픽",
+                    COMMENT_REPLY.format(replyCount));
             notificationHistory.put(replyCountKey, true);
             parentComment.setNotificationHistory(notificationHistory);
         }

--- a/src/main/java/balancetalk/global/notification/application/NotificationService.java
+++ b/src/main/java/balancetalk/global/notification/application/NotificationService.java
@@ -3,10 +3,15 @@ package balancetalk.global.notification.application;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.notification.domain.Notification;
 import balancetalk.global.notification.domain.NotificationRepository;
+import balancetalk.global.notification.dto.NotificationDto.NotificationRequest;
+import balancetalk.global.notification.dto.NotificationDto.NotificationResponse;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
+import balancetalk.talkpick.domain.TalkPick;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -19,6 +24,7 @@ import java.util.concurrent.Executors;
 import static balancetalk.global.exception.ErrorCode.SEND_NOTIFICATION_FAIL;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class NotificationService {
 
@@ -26,6 +32,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final Map<Long, SseEmitter> memberEmitters = new ConcurrentHashMap<>();
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ObjectMapper objectMapper;
 
     public SseEmitter createEmitter(ApiMember apiMember) {
         Long memberId = apiMember.toMember(memberRepository).getId();
@@ -42,12 +49,9 @@ public class NotificationService {
     }
 
     @Transactional
-    public void sendNotification(Member member, String message) {
-        Notification notification = Notification.builder()
-                .member(member)
-                .message(message)
-                .isRead(false)
-                .build();
+    public void sendTalkPickNotification(Member member, TalkPick talkPick, String title, String message) { //TODO 여기 dto 클래스로 분리하고, 형식에 맞게 여러개
+        // 만든 다음 service 레이어에서 사용
+        Notification notification = NotificationRequest.toEntity(member, talkPick, title, message);
 
         notificationRepository.save(notification);
 
@@ -61,12 +65,13 @@ public class NotificationService {
         if (emitter != null) {
             executorService.execute(() -> {
                 try {
-                    emitter.send(SseEmitter.event().name("notification").data(notification.getMessage()));
+                    NotificationResponse response = NotificationResponse.fromEntity(notification);
+                    String jsonMessage = objectMapper.writeValueAsString(response);
+                    emitter.send(SseEmitter.event().name("notification").data(jsonMessage));
                 } catch (Exception e) {
                     throw new BalanceTalkException(SEND_NOTIFICATION_FAIL);
                 }
             });
-
         }
     }
 }

--- a/src/main/java/balancetalk/global/notification/domain/Notification.java
+++ b/src/main/java/balancetalk/global/notification/domain/Notification.java
@@ -22,6 +22,12 @@ public class Notification extends BaseTimeEntity {
     private Member member;
 
     @NotBlank
+    private String title;
+
+    @NotBlank
+    private String resourceTitle;
+
+    @NotBlank
     private String message;
 
     private boolean isRead;

--- a/src/main/java/balancetalk/global/notification/dto/NotificationDto.java
+++ b/src/main/java/balancetalk/global/notification/dto/NotificationDto.java
@@ -1,0 +1,65 @@
+package balancetalk.global.notification.dto;
+
+import balancetalk.global.notification.domain.Notification;
+import balancetalk.member.domain.Member;
+import balancetalk.talkpick.domain.TalkPick;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class NotificationDto {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "톡픽 알림 생성 요청")
+    public static class NotificationRequest {
+
+        @Schema(description = "알림 제목", example = "톡픽")
+        private String title;
+
+        @Schema(description = "알림 상세 메시지", example = "작성한 댓글이 하트 10개를 달성했어요.")
+        private String message;
+
+        public static Notification toEntity(Member member, TalkPick talkPick, String title, String message) {
+            return Notification.builder()
+                    .member(member)
+                    .title(title)
+                    .resourceTitle(talkPick.getTitle())
+                    .message(message)
+                    .isRead(false)
+                    .build();
+        }
+    }
+
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "톡픽 알림 응답 요청")
+    public static class NotificationResponse {
+
+        @Schema(description = "알림 제목", example = "톡픽")
+        private String title;
+
+        @Schema(description = "알림 발생 날짜")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "톡픽 제목", example = "이별 사유 이게 말이 돼?")
+        private String talkPickTitle;
+
+        @Schema(description = "알림 상세 메시지", example = "작성한 댓글이 하트 10개를 달성했어요.")
+        private String message;
+
+        public static NotificationResponse fromEntity(Notification notification) {
+            return NotificationResponse.builder()
+                    .title(notification.getTitle())
+                    .createdAt(notification.getCreatedAt())
+                    .talkPickTitle(notification.getResourceTitle())
+                    .message(notification.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/balancetalk/like/application/CommentLikeService.java
+++ b/src/main/java/balancetalk/like/application/CommentLikeService.java
@@ -11,6 +11,7 @@ import balancetalk.like.dto.LikeDto;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
+import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -114,6 +115,8 @@ public class CommentLikeService {
 
     private void sendLikeNotification(Comment comment) {
         long likeCount = likeRepository.countByResourceIdAndLikeType(comment.getId(), LikeType.COMMENT);
+        Member member = comment.getMember();
+        TalkPick talkPick = comment.getTalkPick();
         String likeCountKey = "LIKE_" + likeCount;
         Map<String, Boolean> notificationHistory = comment.getNotificationHistory();
 
@@ -121,7 +124,8 @@ public class CommentLikeService {
                 likeCount == SECOND_COUNT_OF_LIKE_NOTIFICATION ||
                 likeCount == THIRD_COUNT_OF_LIKE_NOTIFICATION) && !notificationHistory.getOrDefault(likeCountKey, false)) {
 
-            notificationService.sendNotification(comment.getMember(), COMMENT_LIKE.format(likeCount));
+            notificationService.sendTalkPickNotification(member, talkPick, "톡픽",
+                    COMMENT_LIKE.format(likeCount));
             notificationHistory.put(likeCountKey, true);
             comment.setNotificationHistory(notificationHistory);
         }


### PR DESCRIPTION
## 💡 작업 내용
- [ ] `Jackson JSR-310 모듈` 의존성 추가
- [ ] 알림 DTO 작성
- [ ] 기존 알림 기능에 DTO 적용

## 💡 자세한 설명
### postman 테스트 완료
<img width="1080" alt="스크린샷 2024-08-27 오후 10 23 37" src="https://github.com/user-attachments/assets/c56a9732-3571-4505-97aa-26de331e9583">

### `Jackson JSR-310 모듈` 의존성 추가
기존의 Jackson 라이브러리는 `LocalDateTime` 등을 날짜 및 시간 클래스를 직렬화 할 수 없기에, 이를 가능하게 하는 `JSR-310` 모듈을 추가했습니다.

### 알림 DTO 작성
단순히 한 줄 메시지를 알림으로 반환하는 것이 아닌, `알림 제목`, `알림 발생 날짜`, `리소스 제목(여기선 톡픽 제목)`, `알림 상세 메시지` 등 여러개의 정보를 클라이언트가 사용할 수 있게 반환해야 하므로, JSON 형식으로 데이터를 전달하기 위해 DTO 클래스를 작성했습니다.
추후 각 상황에 맞는 요청, 응답 `static class` 들을 추가 구현 할 예정입니다.

### 기존 알림 기능에 DTO 적용
기존에 구현되어 있는 `첫 답글`, `댓글 좋아요 개수` 알림 기능에 DTO 적용 후 변경 사항을 반영했습니다.
참고로, **하드코딩** 되어 있는 부분들이 있는데, 이 부분도 추후 여러 알림 상황을 구현하면서 처리 할 예정입니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
1. 하드코딩 제거
2. 상황별 알림 기능 구현
3. 100단위, 1,000 단위 이벤트 발생 시 경우 추가 구현

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #451
