### PR TITLE
밸런스 게임 생성 시 누락된 북마크, 조회수 값 추가

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -48,6 +48,8 @@ public class GameDto {
                     .gameTopic(gameTopic)
                     .gameOptions(gameOptions.stream().map(GameOptionDto::toEntity).collect(Collectors.toUnmodifiableList()))
                     .member(member)
+                    .bookmarks(0L)
+                    .views(0L)
                     .editedAt(LocalDateTime.now())
                     .build();
         }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 북마크, 조회수 값 추가
- [x] 배포된 서버에서 로그인 한 사용자가 밸런스 게임에 투표 시 500 에러

## 💡 자세한 설명

밸런스게임 구조를 바꾸면서 생성할 때 `bookmarks`, `views`값을 누락해서 값이 null로 들어오게 되어 API 호출 시에 NPE에러가 발생했습니다. 

500 에러는, 연관 관계를 바꾸면서 생긴 오류인데, 기존에 Vote 테이블이 Game을 가르키고 있던 것을 Game_Option으로 연관 관계를 다시 맺어주었습니다.

![스크린샷 2024-08-28 오전 2 49 06](https://github.com/user-attachments/assets/7f35a0bb-23fb-4dd7-930e-dc871d719f74)

![스크린샷 2024-08-28 오전 2 51 25](https://github.com/user-attachments/assets/324b753b-23fa-44c7-9e05-e32ee2b8d68a)



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #537 