### PR TITLE
투표 생성 시 null 미허용으로 수정

### DIFF
--- a/src/main/java/balancetalk/vote/domain/Vote.java
+++ b/src/main/java/balancetalk/vote/domain/Vote.java
@@ -5,6 +5,7 @@ import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Entity
@@ -31,6 +32,7 @@ public class Vote extends BaseTimeEntity {
     private GameOption gameOption;
 
     @Enumerated(value = EnumType.STRING)
+    @NotNull
     private VoteOption voteOption;
 
     public boolean matchesTalkPick(TalkPick talkPick) {

--- a/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
+++ b/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
@@ -5,6 +5,7 @@ import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,7 @@ public class VoteTalkPickDto {
     public static class VoteRequest {
 
         @Schema(description = "투표할 선택지", example = "A")
+        @NotNull(message = "선택지 값은 필수입니다.")
         private VoteOption voteOption;
 
         public Vote toEntity(Member member, TalkPick talkPick) {


### PR DESCRIPTION
## 💡 작업 내용
- [x] VoteRequest의 선택지 필드에 @NotNull 추가

## 💡 자세한 설명
VoteRequest의 선택지 필드에 @NotNull 추가하여, null이 저장되는 것을 방지하도록 했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #547 
