### PR TITLE
톡픽 투표 테이블 분리

### DIFF
--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -14,6 +14,8 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import balancetalk.talkpick.dto.TalkPickDto.TalkPickMyPageResponse;
+import balancetalk.vote.domain.TalkPickVote;
+import balancetalk.vote.domain.TalkPickVoteRepository;
 import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +34,7 @@ public class MyPageService {
     private final MemberRepository memberRepository;
     private final TalkPickRepository talkPickRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final TalkPickVoteRepository talkPickVoteRepository;
     private final VoteRepository voteRepository;
     private final CommentRepository commentRepository;
     private final GameRepository gameRepository;
@@ -48,7 +52,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllVotedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Vote> votes = voteRepository.findAllByMemberIdAndTalkPickDesc(member.getId());
+        List<TalkPickVote> votes = talkPickVoteRepository.findAllByMemberIdAndTalkPickDesc(member.getId());
 
         List<TalkPickMyPageResponse> responses = votes.stream()
                 .map(vote -> TalkPickMyPageResponse.from(vote.getTalkPick(), vote))

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -9,6 +9,7 @@ import balancetalk.global.exception.ErrorCode;
 import balancetalk.like.domain.Like;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TempTalkPick;
+import balancetalk.vote.domain.TalkPickVote;
 import balancetalk.vote.domain.Vote;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -51,6 +52,9 @@ public class Member extends BaseTimeEntity {
     private String profileImgUrl;
 
     @OneToMany(mappedBy = "member")
+    private List<TalkPickVote> talkPickVotes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
     private List<Vote> votes = new ArrayList<>();
 
     @OneToMany(mappedBy = "member")
@@ -85,14 +89,14 @@ public class Member extends BaseTimeEntity {
                 .anyMatch(bookmark -> bookmark.matches(resourceId, bookmarkType) && bookmark.isActive());
     }
 
-    public Optional<Vote> getVoteOnTalkPick(TalkPick talkPick) {
-        return this.votes.stream()
+    public Optional<TalkPickVote> getVoteOnTalkPick(TalkPick talkPick) {
+        return this.talkPickVotes.stream()
                 .filter(vote -> vote.matchesTalkPick(talkPick))
                 .findAny();
     }
 
     public boolean hasVotedTalkPick(TalkPick talkPick) {
-        return votes.stream()
+        return talkPickVotes.stream()
                 .anyMatch(vote -> vote.matchesTalkPick(talkPick));
     }
 

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -9,7 +9,7 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
-import balancetalk.vote.domain.Vote;
+import balancetalk.vote.domain.TalkPickVote;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,7 +52,7 @@ public class TalkPickService {
 
         Member member = guestOrApiMember.toMember(memberRepository);
         boolean hasBookmarked = member.hasBookmarked(talkPickId, TALK_PICK);
-        Optional<Vote> myVote = member.getVoteOnTalkPick(talkPick);
+        Optional<TalkPickVote> myVote = member.getVoteOnTalkPick(talkPick);
 
         if (myVote.isEmpty()) {
             return TalkPickDetailResponse.from(talkPick, imgUrls, hasBookmarked, null);

--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -3,7 +3,7 @@ package balancetalk.talkpick.domain;
 import balancetalk.comment.domain.Comment;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
-import balancetalk.vote.domain.Vote;
+import balancetalk.vote.domain.TalkPickVote;
 import balancetalk.vote.domain.VoteOption;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -68,7 +68,7 @@ public class TalkPick extends BaseTimeEntity {
     private ViewStatus viewStatus = ViewStatus.NORMAL;
 
     @OneToMany(mappedBy = "talkPick")
-    private List<Vote> votes = new ArrayList<>();
+    private List<TalkPickVote> votes = new ArrayList<>();
 
     @OneToMany(mappedBy = "talkPick")
     private List<Comment> comments = new ArrayList<>();

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static balancetalk.talkpick.domain.QTalkPick.talkPick;
 import static balancetalk.talkpick.dto.TalkPickDto.TalkPickResponse;
 import static balancetalk.talkpick.dto.TodayTalkPickDto.TodayTalkPickResponse;
-import static balancetalk.vote.domain.QVote.vote;
+import static balancetalk.vote.domain.QTalkPickVote.talkPickVote;
 
 @RequiredArgsConstructor
 public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
@@ -34,9 +34,9 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
                         talkPick.id, talkPick.title, talkPick.optionA, talkPick.optionB
                 ))
                 .from(talkPick)
-                .leftJoin(talkPick.votes, vote)
+                .leftJoin(talkPick.votes, talkPickVote)
                 .groupBy(talkPick.id)
-                .orderBy(talkPick.views.desc(), vote.count().desc(), talkPick.createdAt.desc())
+                .orderBy(talkPick.views.desc(), talkPickVote.count().desc(), talkPick.createdAt.desc())
                 .limit(1)
                 .fetchOne();
     }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -3,7 +3,7 @@ package balancetalk.talkpick.dto;
 import balancetalk.comment.domain.Comment;
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
-import balancetalk.vote.domain.Vote;
+import balancetalk.vote.domain.TalkPickVote;
 import balancetalk.vote.domain.VoteOption;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.querydsl.core.annotations.QueryProjection;
@@ -240,7 +240,7 @@ public class TalkPickDto {
                     .build();
         }
 
-        public static TalkPickMyPageResponse from(TalkPick talkPick, Vote vote) {
+        public static TalkPickMyPageResponse from(TalkPick talkPick, TalkPickVote vote) {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -8,8 +8,8 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickReader;
-import balancetalk.vote.domain.Vote;
-import balancetalk.vote.domain.VoteRepository;
+import balancetalk.vote.domain.TalkPickVote;
+import balancetalk.vote.domain.TalkPickVoteRepository;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +22,8 @@ import java.util.Optional;
 public class VoteTalkPickService {
 
     private final TalkPickReader talkPickReader;
-    private final VoteRepository voteRepository;
+    private final TalkPickVoteRepository voteRepository;
+    private final TalkPickVoteRepository talkPickVoteRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -47,7 +48,7 @@ public class VoteTalkPickService {
         TalkPick talkPick = talkPickReader.readById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 
-        Optional<Vote> vote = member.getVoteOnTalkPick(talkPick);
+        Optional<TalkPickVote> vote = member.getVoteOnTalkPick(talkPick);
         if (vote.isEmpty()) {
             throw new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE);
         }
@@ -60,11 +61,11 @@ public class VoteTalkPickService {
         TalkPick talkPick = talkPickReader.readById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 
-        Optional<Vote> vote = member.getVoteOnTalkPick(talkPick);
+        Optional<TalkPickVote> vote = member.getVoteOnTalkPick(talkPick);
         if (vote.isEmpty()) {
             throw new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE);
         }
 
-        voteRepository.delete(vote.get());
+        talkPickVoteRepository.delete(vote.get());
     }
 }

--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -15,15 +15,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class VoteTalkPickService {
 
     private final TalkPickReader talkPickReader;
     private final TalkPickVoteRepository voteRepository;
-    private final TalkPickVoteRepository talkPickVoteRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -48,12 +45,10 @@ public class VoteTalkPickService {
         TalkPick talkPick = talkPickReader.readById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 
-        Optional<TalkPickVote> vote = member.getVoteOnTalkPick(talkPick);
-        if (vote.isEmpty()) {
-            throw new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE);
-        }
+        TalkPickVote vote = member.getVoteOnTalkPick(talkPick)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE));
 
-        vote.get().updateVoteOption(request.getVoteOption());
+        vote.updateVoteOption(request.getVoteOption());
     }
 
     @Transactional
@@ -61,11 +56,9 @@ public class VoteTalkPickService {
         TalkPick talkPick = talkPickReader.readById(talkPickId);
         Member member = apiMember.toMember(memberRepository);
 
-        Optional<TalkPickVote> vote = member.getVoteOnTalkPick(talkPick);
-        if (vote.isEmpty()) {
-            throw new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE);
-        }
+        TalkPickVote vote = member.getVoteOnTalkPick(talkPick)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_VOTE));
 
-        talkPickVoteRepository.delete(vote.get());
+        voteRepository.delete(vote);
     }
 }

--- a/src/main/java/balancetalk/vote/domain/TalkPickVote.java
+++ b/src/main/java/balancetalk/vote/domain/TalkPickVote.java
@@ -1,8 +1,8 @@
 package balancetalk.vote.domain;
 
-import balancetalk.game.domain.GameOption;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.member.domain.Member;
+import balancetalk.talkpick.domain.TalkPick;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -12,7 +12,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Vote extends BaseTimeEntity {
+public class TalkPickVote extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,26 +23,22 @@ public class Vote extends BaseTimeEntity {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "game_option_id")
-    private GameOption gameOption;
+    @JoinColumn(name = "talk_pick_id")
+    private TalkPick talkPick;
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
     private VoteOption voteOption;
 
-    public boolean matchesGameOption(GameOption gameOption) {
-        return this.gameOption.equals(gameOption);
-    }
-
-    public void updateVoteOption(VoteOption newVoteOption) {
-        this.voteOption = newVoteOption;
-    }
-
-    public void updateGameOption(GameOption gameOption) {
-        this.gameOption = gameOption;
+    public boolean matchesTalkPick(TalkPick talkPick) {
+        return this.talkPick.equals(talkPick);
     }
 
     public boolean isVoteOptionEquals(VoteOption voteOption) {
         return this.voteOption.equals(voteOption);
+    }
+
+    public void updateVoteOption(VoteOption newVoteOption) {
+        this.voteOption = newVoteOption;
     }
 }

--- a/src/main/java/balancetalk/vote/domain/TalkPickVoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/TalkPickVoteRepository.java
@@ -1,0 +1,12 @@
+package balancetalk.vote.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface TalkPickVoteRepository extends JpaRepository<TalkPickVote, Long> {
+
+    @Query("SELECT v FROM TalkPickVote v WHERE v.member.id = :memberId AND v.talkPick IS NOT NULL ORDER BY v.lastModifiedAt DESC")
+    List<TalkPickVote> findAllByMemberIdAndTalkPickDesc(Long memberId);
+}

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -7,9 +7,6 @@ import java.util.List;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
-    @Query("SELECT v FROM Vote v WHERE v.member.id = :memberId AND v.talkPick IS NOT NULL ORDER BY v.lastModifiedAt DESC")
-    List<Vote> findAllByMemberIdAndTalkPickDesc(Long memberId);
-
     @Query("SELECT v FROM Vote v WHERE v.member.id = :memberId AND v.gameOption IS NOT NULL ORDER BY v.lastModifiedAt DESC")
     List<Vote> findAllByMemberIdAndGameDesc(Long memberId);
 }

--- a/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
+++ b/src/main/java/balancetalk/vote/dto/VoteTalkPickDto.java
@@ -2,6 +2,7 @@ package balancetalk.vote.dto;
 
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.vote.domain.TalkPickVote;
 import balancetalk.vote.domain.Vote;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,8 +23,8 @@ public class VoteTalkPickDto {
         @NotNull(message = "선택지 값은 필수입니다.")
         private VoteOption voteOption;
 
-        public Vote toEntity(Member member, TalkPick talkPick) {
-            return Vote.builder()
+        public TalkPickVote toEntity(Member member, TalkPick talkPick) {
+            return TalkPickVote.builder()
                     .member(member)
                     .talkPick(talkPick)
                     .voteOption(voteOption)

--- a/src/test/java/balancetalk/vote/application/VoteTalkPickServiceTest.java
+++ b/src/test/java/balancetalk/vote/application/VoteTalkPickServiceTest.java
@@ -6,7 +6,7 @@ import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickReader;
-import balancetalk.vote.domain.Vote;
+import balancetalk.vote.domain.TalkPickVote;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,8 +40,8 @@ class VoteTalkPickServiceTest {
     void createVote_Fail_ByAlreadyVote() {
         // given
         TalkPick talkPick = TalkPick.builder().id(1L).build();
-        Vote vote = Vote.builder().talkPick(talkPick).build();
-        Member member = Member.builder().votes(List.of(vote)).build();
+        TalkPickVote vote = TalkPickVote.builder().talkPick(talkPick).build();
+        Member member = Member.builder().talkPickVotes(List.of(vote)).build();
 
         when(talkPickReader.readById(any())).thenReturn(talkPick);
         when(guestOrApiMember.isGuest()).thenReturn(false);
@@ -57,7 +57,7 @@ class VoteTalkPickServiceTest {
     void updateVote_Fail_ByNotFoundVote() {
         // given
         TalkPick talkPick = TalkPick.builder().id(1L).build();
-        Member member = Member.builder().votes(List.of()).build();
+        Member member = Member.builder().talkPickVotes(List.of()).build();
 
         when(talkPickReader.readById(any())).thenReturn(talkPick);
         when(apiMember.toMember(any())).thenReturn(member);
@@ -72,7 +72,7 @@ class VoteTalkPickServiceTest {
     void deleteVote_Fail_ByNotFoundVote() {
         // given
         TalkPick talkPick = TalkPick.builder().id(1L).build();
-        Member member = Member.builder().votes(List.of()).build();
+        Member member = Member.builder().talkPickVotes(List.of()).build();
 
         when(talkPickReader.readById(any())).thenReturn(talkPick);
         when(apiMember.toMember(any())).thenReturn(member);

--- a/src/test/java/balancetalk/vote/domain/VoteTest.java
+++ b/src/test/java/balancetalk/vote/domain/VoteTest.java
@@ -14,7 +14,7 @@ class VoteTest {
     void matchesTalkPick_True() {
         // given
         TalkPick talkPick = TalkPick.builder().build();
-        Vote vote = Vote.builder().talkPick(talkPick).build();
+        TalkPickVote vote = TalkPickVote.builder().talkPick(talkPick).build();
 
         // when
         boolean result = vote.matchesTalkPick(talkPick);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 투표 엔티티 추가 및 그에 따른 코드 변경

## 💡 자세한 설명
기존의 투표 테이블을 톡픽과 밸런스 게임 각각의 투표 테이블 2개로 분리하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #551 
