### PR TITLE
톡픽 본문 요약 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -80,6 +82,10 @@ dependencies {
 
 	// jackson
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+
+	// SpringAI
+	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 }
 
 tasks.named('test') {

--- a/src/main/java/balancetalk/global/config/OpenaiConfig.java
+++ b/src/main/java/balancetalk/global/config/OpenaiConfig.java
@@ -1,0 +1,14 @@
+package balancetalk.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenaiConfig {
+
+    @Bean
+    public ChatClient chatClient(ChatClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -101,7 +101,8 @@ public enum ErrorCode {
     NOT_UPLOADED_IMAGE_FOR_DB_ERROR(INTERNAL_SERVER_ERROR, "이미지 정보를 저장하던 중 문제가 생겨 업로드에 실패했습니다."),
     SEND_NOTIFICATION_FAIL(INTERNAL_SERVER_ERROR, "알림 전송에 실패했습니다."),
     FAIL_PARSE_NOTIFICATION_HISTORY(INTERNAL_SERVER_ERROR, "알림 내역 파싱에 실패했습니다."),
-    FAIL_SERIALIZE_NOTIFICATION_HISTORY(INTERNAL_SERVER_ERROR, "알림 내역 직렬화에 실패했습니다.");
+    FAIL_SERIALIZE_NOTIFICATION_HISTORY(INTERNAL_SERVER_ERROR, "알림 내역 직렬화에 실패했습니다."),
+    SUMMARY_SIZE_IS_OVER(INTERNAL_SERVER_ERROR, "요약 내용의 길이가 적정 기준을 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
+++ b/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
@@ -24,7 +24,8 @@ public class SummaryContentService {
 
         Summary summary = chatClient.prompt()
                 .system("- 당신의 역할은 사용자가 입력한 문장을 3줄로 요약하는 것입니다.\n" +
-                        "- 각 문장을 firstLine, secondLine, thirdLine 키에 담아주세요.")
+                        "- 각 문장을 firstLine, secondLine, thirdLine 키에 담아주세요.\n" +
+                        "- 각 문장의 최대 글자수는 공백 포함 120자 이내입니다.")
                 .user(talkPick.getContent())
                 .call()
                 .entity(Summary.class);

--- a/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
+++ b/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
@@ -1,5 +1,6 @@
 package balancetalk.talkpick.application;
 
+import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static balancetalk.global.exception.ErrorCode.SUMMARY_SIZE_IS_OVER;
 
 @Service
 @RequiredArgsConstructor
@@ -25,11 +28,14 @@ public class SummaryContentService {
         Summary summary = chatClient.prompt()
                 .system("- 당신의 역할은 사용자가 입력한 문장을 3줄로 요약하는 것입니다.\n" +
                         "- 각 문장을 firstLine, secondLine, thirdLine 키에 담아주세요.\n" +
-                        "- 각 문장의 최대 글자수는 공백 포함 120자 이내입니다.")
+                        "- 각 문장 값의 크기는 120 이상으로 해주세요.")
                 .user(talkPick.getContent())
                 .call()
                 .entity(Summary.class);
 
+        if (summary.isOverSize()) {
+            throw new BalanceTalkException(SUMMARY_SIZE_IS_OVER);
+        }
         talkPick.updateSummary(summary);
     }
 }

--- a/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
+++ b/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
@@ -1,0 +1,34 @@
+package balancetalk.talkpick.application;
+
+import balancetalk.member.domain.Member;
+import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.dto.ApiMember;
+import balancetalk.talkpick.domain.Summary;
+import balancetalk.talkpick.domain.TalkPick;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SummaryContentService {
+
+    private final MemberRepository memberRepository;
+    private final ChatClient chatClient;
+
+    @Transactional
+    public void summaryContent(long talkPickId, ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        TalkPick talkPick = member.getTalkPickById(talkPickId);
+
+        Summary summary = chatClient.prompt()
+                .system("- 당신의 역할은 사용자가 입력한 문장을 3줄로 요약하는 것입니다.\n" +
+                        "- 각 문장을 firstLine, secondLine, thirdLine 키에 담아주세요.")
+                .user(talkPick.getContent())
+                .call()
+                .entity(Summary.class);
+
+        talkPick.updateSummary(summary);
+    }
+}

--- a/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
+++ b/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
@@ -28,7 +28,7 @@ public class SummaryContentService {
         Summary summary = chatClient.prompt()
                 .system("- 당신의 역할은 사용자가 입력한 문장을 3줄로 요약하는 것입니다.\n" +
                         "- 각 문장을 firstLine, secondLine, thirdLine 키에 담아주세요.\n" +
-                        "- 각 문장 값의 크기는 120 이상으로 해주세요.")
+                        "- 각 문장의 글자수는 120 이내로 해주세요.")
                 .user(talkPick.getContent())
                 .call()
                 .entity(Summary.class);

--- a/src/main/java/balancetalk/talkpick/domain/Summary.java
+++ b/src/main/java/balancetalk/talkpick/domain/Summary.java
@@ -1,15 +1,19 @@
 package balancetalk.talkpick.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
 public class Summary {
 
-    String summaryFirstLine;
-    String summarySecondLine;
-    String summaryThirdLine;
+    @Column(name = "summary_first_line")
+    String firstLine;
+
+    @Column(name = "summary_second_line")
+    String secondLine;
+
+    @Column(name = "summary_third_line")
+    String thirdLine;
 }

--- a/src/main/java/balancetalk/talkpick/domain/Summary.java
+++ b/src/main/java/balancetalk/talkpick/domain/Summary.java
@@ -9,15 +9,21 @@ import lombok.Getter;
 @Getter
 public class Summary {
 
-    @Size(max = 120)
+    private static final int MAX_SIZE = 120;
+
+    @Size(max = MAX_SIZE)
     @Column(name = "summary_first_line")
     String firstLine;
 
-    @Size(max = 120)
+    @Size(max = MAX_SIZE)
     @Column(name = "summary_second_line")
     String secondLine;
 
-    @Size(max = 120)
+    @Size(max = MAX_SIZE)
     @Column(name = "summary_third_line")
     String thirdLine;
+
+    public boolean isOverSize() {
+        return firstLine.length() > MAX_SIZE || secondLine.length() > MAX_SIZE || thirdLine.length() > MAX_SIZE;
+    }
 }

--- a/src/main/java/balancetalk/talkpick/domain/Summary.java
+++ b/src/main/java/balancetalk/talkpick/domain/Summary.java
@@ -2,18 +2,22 @@ package balancetalk.talkpick.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Embeddable
 @Getter
 public class Summary {
 
+    @Size(max = 120)
     @Column(name = "summary_first_line")
     String firstLine;
 
+    @Size(max = 120)
     @Column(name = "summary_second_line")
     String secondLine;
 
+    @Size(max = 120)
     @Column(name = "summary_third_line")
     String thirdLine;
 }

--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -39,7 +39,7 @@ public class TalkPick extends BaseTimeEntity {
     private Summary summary;
 
     @NotBlank
-    @Column(columnDefinition = "LONGTEXT")
+    @Size(max = 2000)
     private String content;
 
     @NotBlank
@@ -110,5 +110,9 @@ public class TalkPick extends BaseTimeEntity {
 
     public boolean isEdited() {
         return editedAt != null;
+    }
+
+    public void updateSummary(Summary newSummary) {
+        this.summary = newSummary;
     }
 }

--- a/src/main/java/balancetalk/talkpick/dto/SummaryResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SummaryResponse.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Schema(description = "톡픽 3줄 요약")
 @Data
-public class SummaryDto {
+public class SummaryResponse {
 
     @Schema(description = "요약 1번째 줄", example = "요약 1번째 줄 내용")
     private String summaryFirstLine;
@@ -17,9 +17,9 @@ public class SummaryDto {
     @Schema(description = "요약 3번째 줄", example = "요약 3번째 줄 내용")
     private String summaryThirdLine;
 
-    public SummaryDto(Summary summary) {
-        this.summaryFirstLine = summary.getSummaryFirstLine();
-        this.summarySecondLine = summary.getSummarySecondLine();
-        this.summaryThirdLine = summary.getSummaryThirdLine();
+    public SummaryResponse(Summary summary) {
+        this.summaryFirstLine = summary.getFirstLine();
+        this.summarySecondLine = summary.getSecondLine();
+        this.summaryThirdLine = summary.getThirdLine();
     }
 }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -89,7 +89,7 @@ public class TalkPickDto {
         @Schema(description = "본문 내용", example = "톡픽 본문 내용")
         private String content;
 
-        private SummaryDto summary;
+        private SummaryResponse summary;
 
         @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
         private String optionA;
@@ -142,7 +142,7 @@ public class TalkPickDto {
                     .id(entity.getId())
                     .title(entity.getTitle())
                     .content(entity.getContent())
-                    .summary(new SummaryDto(entity.getSummary()))
+                    .summary(new SummaryResponse(entity.getSummary()))
                     .optionA(entity.getOptionA())
                     .optionB(entity.getOptionB())
                     .sourceUrl(entity.getSourceUrl())

--- a/src/main/java/balancetalk/talkpick/presentation/SummaryContentController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SummaryContentController.java
@@ -1,0 +1,25 @@
+package balancetalk.talkpick.presentation;
+
+import balancetalk.global.utils.AuthPrincipal;
+import balancetalk.member.dto.ApiMember;
+import balancetalk.talkpick.application.SummaryContentService;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/talks/{talkPickId}/summary")
+@RequiredArgsConstructor
+public class SummaryContentController {
+
+    private final SummaryContentService summaryContentService;
+
+    @PostMapping
+    public void summaryContent(@PathVariable final Long talkPickId,
+                               @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        summaryContentService.summaryContent(talkPickId, apiMember);
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] SpringAI 의존성 추가
- [x] openai api-key 추가
- [x] 톡픽 본문 요약 기능 구현
- [x] 요약된 문장 최대 글자수 제한
- [x] 요약 내용의 길이가 적정 기준을 초과한 경우 예외 처리

## 💡 자세한 설명
SpringAI를 통해 OpenAI의 chatGPT4o API를 연결하여, 톡픽 본문 요약 기능을 구현했습니다.

## 📗 참고 자료
https://spring.io/projects/spring-ai
https://figure.kim/post/spring-ai

## 🚩 후속 작업
### retry 구현
현재 구현한 요약 기능의 경우, 어떤 이유로 요약에 실패했을 때 예외만 던집니다.
하지만 요약에 실패했을 때 자동으로 재요청해야 하므로, retry 라이브러리를 이용해 구현할 예정입니다.

### 시스템 메시지
시스템 메시지를 하드코딩하여 구현했습니다. 이를 DB에서 관리하도록 개선할 예정입니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #521 
