### PR TITLE
마이페이지 페이지네이션 size 적용되지 않는 에러 해결

### DIFF
--- a/src/main/java/balancetalk/bookmark/domain/BookmarkRepository.java
+++ b/src/main/java/balancetalk/bookmark/domain/BookmarkRepository.java
@@ -1,6 +1,8 @@
 package balancetalk.bookmark.domain;
 
 import balancetalk.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,7 @@ import java.util.List;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     @Query("SELECT b FROM Bookmark b WHERE b.member = :member AND b.bookmarkType = :bookmarkType AND b.active = true ORDER BY b.lastModifiedAt DESC")
-    List<Bookmark> findActivatedByMemberOrderByDesc(@Param("member") Member member, @Param("bookmarkType") BookmarkType bookmarkType);
+    Page<Bookmark> findActivatedByMemberOrderByDesc(@Param("member") Member member, @Param("bookmarkType") BookmarkType bookmarkType,
+                                                    Pageable pageable);
 
 }

--- a/src/main/java/balancetalk/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/comment/domain/CommentRepository.java
@@ -22,5 +22,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.talkPick IS NOT NULL " +
             "AND c.editedAt IN (SELECT MAX(c2.editedAt) FROM Comment c2 WHERE c2.member.id = :memberId GROUP BY c2.talkPick.id) " +
             "ORDER BY c.editedAt DESC")
-    List<Comment> findAllLatestCommentsByMemberIdAndOrderByDesc(@Param("memberId") Long memberId);
+    Page<Comment> findAllLatestCommentsByMemberIdAndOrderByDesc(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -3,7 +3,7 @@ package balancetalk.game.domain.repository;
 import balancetalk.game.domain.Game;
 import java.util.List;
 
-import balancetalk.talkpick.domain.TalkPick;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,6 +27,6 @@ public interface GameRepository extends JpaRepository<Game, Long> {
             "ORDER BY g.views DESC, g.createdAt DESC")
     List<Game> findGamesByViews(@Param("topicName") String topicName, Pageable pageable);
 
-    List<Game> findAllByMemberIdOrderByEditedAtDesc(Long memberId);
+    Page<Game> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
 
 }

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -41,7 +41,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllBookmarkedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.TALK_PICK);
+        Page<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.TALK_PICK, pageable);
 
         List<TalkPickMyPageResponse> responses = bookmarks.stream()
                 .map(bookmark -> { TalkPick talkPick = talkPickRepository.findById(bookmark.getResourceId()).get();
@@ -54,7 +54,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllVotedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<TalkPickVote> votes = talkPickVoteRepository.findAllByMemberIdAndTalkPickDesc(member.getId());
+        Page<TalkPickVote> votes = talkPickVoteRepository.findAllByMemberIdAndTalkPickDesc(member.getId(), pageable);
 
         List<TalkPickMyPageResponse> responses = votes.stream()
                 .map(vote -> TalkPickMyPageResponse.from(vote.getTalkPick(), vote))
@@ -65,7 +65,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllCommentedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Comment> comments = commentRepository.findAllLatestCommentsByMemberIdAndOrderByDesc(member.getId());
+        Page<Comment> comments = commentRepository.findAllLatestCommentsByMemberIdAndOrderByDesc(member.getId(), pageable);
 
         List<TalkPickMyPageResponse> responses = comments.stream()
                 .map(comment -> TalkPickMyPageResponse.from(comment.getTalkPick(), comment))
@@ -76,7 +76,7 @@ public class MyPageService {
 
     public Page<TalkPickMyPageResponse> findAllTalkPicksByMember(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<TalkPick> talkPicks = talkPickRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId());
+        Page<TalkPick> talkPicks = talkPickRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId(), pageable);
 
         List<TalkPickMyPageResponse> responses = talkPicks.stream()
                 .map(TalkPickMyPageResponse::fromMyTalkPick)
@@ -87,7 +87,7 @@ public class MyPageService {
 
     public Page<GameMyPageResponse> findAllBookmarkedGames(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.GAME);
+        Page<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.GAME, pageable);
 
         List<GameMyPageResponse> responses = bookmarks.stream()
                 .map(bookmark -> { Game game = gameRepository.findById(bookmark.getResourceId()).get();
@@ -100,7 +100,7 @@ public class MyPageService {
 
     public Page<GameMyPageResponse> findAllVotedGames(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Vote> votes = voteRepository.findAllByMemberIdAndGameDesc(member.getId());
+        Page<Vote> votes = voteRepository.findAllByMemberIdAndGameDesc(member.getId(), pageable);
 
         List<GameMyPageResponse> responses = votes.stream()
                 .map(vote -> GameMyPageResponse.from(vote.getGameOption().getGame(), vote))
@@ -111,7 +111,7 @@ public class MyPageService {
 
     public Page<GameMyPageResponse> findAllGamesByMember(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        List<Game> games = gameRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId());
+        Page<Game> games = gameRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId(), pageable);
 
         List<GameMyPageResponse> responses = games.stream()
                 .map(GameMyPageResponse::from)

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
@@ -1,10 +1,12 @@
 package balancetalk.talkpick.domain.repository;
 
 import balancetalk.talkpick.domain.TalkPick;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TalkPickRepository extends JpaRepository<TalkPick, Long>, TalkPickRepositoryCustom {
 
-    List<TalkPick> findAllByMemberIdOrderByEditedAtDesc(Long memberId);
+    Page<TalkPick> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/balancetalk/vote/domain/TalkPickVoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/TalkPickVoteRepository.java
@@ -1,5 +1,7 @@
 package balancetalk.vote.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -8,5 +10,5 @@ import java.util.List;
 public interface TalkPickVoteRepository extends JpaRepository<TalkPickVote, Long> {
 
     @Query("SELECT v FROM TalkPickVote v WHERE v.member.id = :memberId AND v.talkPick IS NOT NULL ORDER BY v.lastModifiedAt DESC")
-    List<TalkPickVote> findAllByMemberIdAndTalkPickDesc(Long memberId);
+    Page<TalkPickVote> findAllByMemberIdAndTalkPickDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -1,5 +1,7 @@
 package balancetalk.vote.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -8,5 +10,5 @@ import java.util.List;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     @Query("SELECT v FROM Vote v WHERE v.member.id = :memberId AND v.gameOption IS NOT NULL ORDER BY v.lastModifiedAt DESC")
-    List<Vote> findAllByMemberIdAndGameDesc(Long memberId);
+    Page<Vote> findAllByMemberIdAndGameDesc(Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 리포지토리 메서드들을 `Page<>` 타입으로 변경 및 적용

## 💡 자세한 설명
기존 마이페이지 조회 리포지토리 메서드들이 `List<>` 타입이라서 페이지네이션의 `size`의 `defaultValue(6)` 값이 적용이 안 되는 에러가 발생했었습니다. 리포지토리 메서드들을 `Page<>` 으로 변경해줌으로서 에러를 해결했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #558
