### PR TITLE
톡픽 본문 요약 기능에 재요청 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
 	// SpringAI
 	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+
+	// Retry
+	implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/balancetalk/BalanceTalkApplication.java
+++ b/src/main/java/balancetalk/BalanceTalkApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server URL")})
 @EnableJpaAuditing
 @EnableCaching
+@EnableRetry
 @SpringBootApplication
 public class BalanceTalkApplication {
 

--- a/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
+++ b/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
@@ -8,6 +8,8 @@ import balancetalk.talkpick.domain.Summary;
 import balancetalk.talkpick.domain.TalkPick;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ public class SummaryContentService {
     private final MemberRepository memberRepository;
     private final ChatClient chatClient;
 
+    @Retryable(backoff = @Backoff(delay = 1000))
     @Transactional
     public void summaryContent(long talkPickId, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);


### PR DESCRIPTION
## 💡 작업 내용
- [x] Spring Retry 의존성 및 관련 설정 추가
- [x] 톡픽 본문 요약 기능에 재요청 로직 추가

## 💡 자세한 설명
톡픽 본문 요약 메서드에 `@Retryable` 어노테이션을 추가함으로써, 예외가 발생했을 때 최대 3회까지 재수행되도록 구현했습니다.

## 📗 참고 자료
https://hvho.github.io/2021-12-05/spring-retry

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #556 
