### PR TITLE
게시글 상세 조회 시 작성자, 작성일 추가

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -11,6 +11,7 @@ import balancetalk.game.domain.repository.GameTagRepository;
 import balancetalk.game.dto.GameDto.CreateGameMainTagRequest;
 import balancetalk.game.dto.GameDto.CreateGameRequest;
 import balancetalk.game.dto.GameDto.GameDetailResponse;
+import balancetalk.game.dto.GameDto.GamePopularResponse;
 import balancetalk.game.dto.GameDto.GameResponse;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
@@ -36,6 +37,7 @@ public class GameService {
 
     private static final int START_PAGE = 0;
     private static final int END_PAGE = 16;
+    private static final String popularTag = "인기";
     private final GameReader gameReader;
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
@@ -93,20 +95,20 @@ public class GameService {
                 }).toList();
     }
 
-    public List<GameResponse> findBestGames(final String topicName, GuestOrApiMember guestOrApiMember) {
+    public List<GamePopularResponse> findBestGames(final String topicName, GuestOrApiMember guestOrApiMember) {
         Pageable pageable = PageRequest.of(START_PAGE, END_PAGE);
         List<Game> games = gameRepository.findGamesByViews(topicName, pageable);
 
         if (guestOrApiMember.isGuest()) {
             return games.stream()
-                    .map(game -> GameResponse.fromEntity(game, null, false)).toList();
+                    .map(game -> GamePopularResponse.fromEntity(game, null, false, popularTag)).toList();
         }
 
         Member member = guestOrApiMember.toMember(memberRepository);
         return games.stream()
                 .map(game -> {
                     boolean bookmarked = member.hasBookmarked(game.getId(), GAME);
-                    return GameResponse.fromEntity(game, member, bookmarked);
+                    return GamePopularResponse.fromEntity(game, member, bookmarked, popularTag);
                 }).toList();
     }
 

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -84,6 +84,10 @@ public class Game extends BaseTimeEntity {
         return option.votesCount();
     }
 
+    public String getWriter() {
+        return this.member.getNickname();
+    }
+
     public void edit() { // 밸런스 게임 수정 시 호출
         // this.title = title;
         // this.optionA = optionA;

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -98,6 +98,46 @@ public class GameDto {
     @Data
     @Builder
     @AllArgsConstructor
+    @Schema(description = "밸런스 게임 인기순으로 조회했을 때 응답값")
+    public static class GamePopularResponse {
+
+        @Schema(description = "밸런스 게임 id", example = "1")
+        private Long id;
+
+        @Schema(description = "밸런스 게임 제목", example = "제목")
+        private String title;
+
+        @Schema(description = "게임 추가 설명", example = "추가 설명")
+        private String description;
+
+        private List<GameOptionDto> gameOptions;
+
+        @Schema(description = "태그값", example = "서브태그가 없는 경우, 메인태그를 보내주고 서브태그가 있는 경우, 그대로 표시")
+        private String tagValue;
+
+        @Schema(description = "인기태그", example = "인기")
+        private String popularTag;
+
+        @Schema(description = "북마크 여부", example = "false")
+        private Boolean myBookmark;
+
+        public static GamePopularResponse fromEntity(Game game, Member member, boolean isBookmarked, String popularTag) {
+            String tagValue = game.getSubTag() != null ? game.getSubTag() : game.getMainTag().getName();
+            return GamePopularResponse.builder()
+                    .id(game.getId())
+                    .title(game.getTitle())
+                    .description(game.getDescription())
+                    .gameOptions(game.getGameOptions().stream().map(GameOptionDto::fromEntity).toList())
+                    .tagValue(tagValue)
+                    .popularTag(popularTag)
+                    .myBookmark(isBookmarked)
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
     @Schema(description = "밸런스 게임 상세 조회 응답")
     public static class GameDetailResponse {
 

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -11,8 +11,8 @@ import balancetalk.vote.domain.VoteOption;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -133,6 +133,12 @@ public class GameDto {
         @Schema(description = "서브태그", example = "커플지옥")
         private String subTag;
 
+        @Schema(description = "작성자 닉네임", example = "작성자")
+        private String writer;
+
+        @Schema(description = "작성일", example = "2024-09-05")
+        private LocalDate createdAt;
+
         public static GameDetailResponse from(Game game, boolean myBookmark, VoteOption votedOption) {
             return GameDetailResponse.builder()
                     .id(game.getId())
@@ -146,6 +152,8 @@ public class GameDto {
                     .votedOption(votedOption)
                     .mainTag(game.getMainTag().getName())
                     .subTag(game.getSubTag())
+                    .writer(game.getWriter())
+                    .createdAt(game.getCreatedAt().toLocalDate())
                     .build();
         }
     }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -57,7 +57,7 @@ public class GameController {
 
     @GetMapping("/best")
     @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public List<GameResponse> findBestGames(@RequestParam String tagName,
+    public List<GamePopularResponse> findBestGames(@RequestParam String tagName,
                                             @Parameter(hidden = true)  @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         return gameService.findBestGames(tagName, guestOrApiMember);
     }

--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -78,10 +78,10 @@ public class TalkPick extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ViewStatus viewStatus = ViewStatus.NORMAL;
 
-    @OneToMany(mappedBy = "talkPick")
+    @OneToMany(mappedBy = "talkPick", cascade = CascadeType.ALL)
     private List<TalkPickVote> votes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "talkPick")
+    @OneToMany(mappedBy = "talkPick", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
     @Column(columnDefinition = "TEXT")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 작성자, 작성일 필드 추가
- [x] 인기 게시글 조회 시 노출되는 태그 값 변경

## 💡 자세한 설명

게시글 상세 조회 시 작성자 , 작성일 필드 추가했습니다.

![스크린샷 2024-09-05 오후 10 52 46](https://github.com/user-attachments/assets/41c0c2e4-8bf9-4100-9767-cafc2abea249)

---

![스크린샷 2024-09-07 오후 7 09 48](https://github.com/user-attachments/assets/834737b8-1f0d-4485-9918-1e13bc200c94)


> - 인기 태그가 붙은 후 셋팅은
> ㄴi) 서브 태그가 있는 경우, 메인태그 없이 [인기] [서브태그] 제시
> ㄴii) 서브 태그가 없는 경우, [인기] [메인태그] 제시

인기순으로 밸런스 게임을 조회할 때, 서브 태그의 유무에 따라서 표시되는 태그 값이 다릅니다. `인기` 태그 값은 고정이고, 서브 태그가 없는 경우엔 메인 태그를, 서브 태그가 있는 경우엔 그대로 표기하도록 리팩토링 했습니다.

따라서, 서브태그 값이 있는 경우엔 이렇게 응답을 내려주고,
![스크린샷 2024-09-07 오후 7 10 20](https://github.com/user-attachments/assets/87612540-1d35-4514-9c86-aa3960feb874)

없는 경우엔 메인 태그 값으로 응답을 내려줍니다.
![스크린샷 2024-09-07 오후 7 10 25](https://github.com/user-attachments/assets/fb64d7fd-02bf-4df7-b824-9325969d87e8)



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 

현재 `#인기` 라는 상수값을 서비스 코드에서 넣어주고 있는데 dto에서 처리를 해야할지 서비스 로직 안에서 처리를 해야할지 고민입니다.



## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #578 