### PR TITLE
톡픽 검색 기능 구현

### DIFF
--- a/src/main/java/balancetalk/file/domain/File.java
+++ b/src/main/java/balancetalk/file/domain/File.java
@@ -1,5 +1,6 @@
 package balancetalk.file.domain;
 
+import balancetalk.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,7 +13,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class File {
+public class File extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/balancetalk/global/config/MySQLFunctionContributor.java
+++ b/src/main/java/balancetalk/global/config/MySQLFunctionContributor.java
@@ -1,0 +1,30 @@
+package balancetalk.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MySQLFunctionContributor implements FunctionContributor {
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry()
+                .registerPattern(
+                        "match_talk_pick_in_boolean_mode",
+                        "MATCH(?1, ?2, ?3, ?4, ?5, ?6, ?7) AGAINST(?8 IN BOOLEAN MODE)",
+                        getBooleanBasicType(functionContributions));
+
+        functionContributions.getFunctionRegistry()
+                .registerPattern(
+                        "match_talk_pick_in_natural_mode",
+                        "MATCH(?1, ?2, ?3, ?4, ?5, ?6, ?7) AGAINST(?8)",
+                        getBooleanBasicType(functionContributions));
+    }
+
+    private BasicType<Boolean> getBooleanBasicType(FunctionContributions functionContributions) {
+        return functionContributions.getTypeConfiguration()
+                .getBasicTypeRegistry()
+                .resolve(StandardBasicTypes.BOOLEAN);
+    }
+}

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     CANNOT_BOOKMARK_MY_RESOURCE(BAD_REQUEST, "본인이 생성한 자원에는 북마크가 불가능합니다."),
     ALREADY_BOOKMARKED(BAD_REQUEST, "이미 북마크한 게시글입니다."),
     ALREADY_DELETED_BOOKMARK(BAD_REQUEST, "이미 북마크가 취소된 상태입니다."),
+    SORT_REQUIRED(BAD_REQUEST, "정렬 조건은 필수입니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
@@ -104,6 +105,7 @@ public enum ErrorCode {
     SEND_NOTIFICATION_FAIL(INTERNAL_SERVER_ERROR, "알림 전송에 실패했습니다."),
     FAIL_PARSE_NOTIFICATION_HISTORY(INTERNAL_SERVER_ERROR, "알림 내역 파싱에 실패했습니다."),
     FAIL_SERIALIZE_NOTIFICATION_HISTORY(INTERNAL_SERVER_ERROR, "알림 내역 직렬화에 실패했습니다."),
+    FAIL_SORT(INTERNAL_SERVER_ERROR, "정렬에 실패했습니다."),
     SUMMARY_SIZE_IS_OVER(INTERNAL_SERVER_ERROR, "요약 내용의 길이가 적정 기준을 초과했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/balancetalk/global/utils/QuerydslUtils.java
+++ b/src/main/java/balancetalk/global/utils/QuerydslUtils.java
@@ -1,0 +1,54 @@
+package balancetalk.global.utils;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static balancetalk.talkpick.domain.QTalkPick.talkPick;
+
+public class QuerydslUtils {
+
+    public static OrderSpecifier<?>[] getOrderSpecifiers(Path<?> path, Sort sort) {
+        if (sort == null || sort.isEmpty()) {
+            throw new BalanceTalkException(ErrorCode.SORT_REQUIRED);
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        for (Sort.Order order : sort) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+            String property = order.getProperty();
+            if (path.equals(talkPick)) {
+                return orderSpecifiersForTalkPick(orderSpecifiers, direction, property);
+            }
+        }
+
+        throw new BalanceTalkException(ErrorCode.FAIL_SORT);
+    }
+
+    private static OrderSpecifier<?>[] orderSpecifiersForTalkPick(List<OrderSpecifier<?>> orderSpecifiers, Order direction, String property) {
+        switch (property) {
+            case "views" -> {
+                orderSpecifiers.add(getOrderSpecifier(direction, talkPick, property));
+                orderSpecifiers.add(getOrderSpecifier(Order.DESC, talkPick, "createdAt"));
+            }
+            case "createdAt" -> {
+                orderSpecifiers.add(getOrderSpecifier(direction, talkPick, property));
+                orderSpecifiers.add(getOrderSpecifier(Order.DESC, talkPick, "views"));
+            }
+        }
+
+        return orderSpecifiers.toArray(OrderSpecifier[]::new);
+    }
+
+    private static OrderSpecifier<?> getOrderSpecifier(Order direction, Path<?> path, String fieldName) {
+        Path<Boolean> fieldPath = Expressions.path(Boolean.class, path, fieldName);
+        return new OrderSpecifier<>(direction, fieldPath);
+    }
+}

--- a/src/main/java/balancetalk/global/utils/QuerydslUtils.java
+++ b/src/main/java/balancetalk/global/utils/QuerydslUtils.java
@@ -6,6 +6,8 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Sort;
 
 import java.util.ArrayList;
@@ -13,6 +15,7 @@ import java.util.List;
 
 import static balancetalk.talkpick.domain.QTalkPick.talkPick;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuerydslUtils {
 
     public static OrderSpecifier<?>[] getOrderSpecifiers(Path<?> path, Sort sort) {

--- a/src/main/java/balancetalk/talkpick/application/SearchTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/SearchTalkPickService.java
@@ -13,7 +13,7 @@ public class SearchTalkPickService {
 
     private final SearchTalkPickRepository searchTalkPickRepository;
 
-    public List<SearchTalkPickResponse> searchTalkPicks(final String query) {
-        return searchTalkPickRepository.searchTalkPicks(query);
+    public List<SearchTalkPickResponse> searchLimitedTalkPicks(final String query) {
+        return searchTalkPickRepository.searchLimitedTalkPicks(query);
     }
 }

--- a/src/main/java/balancetalk/talkpick/application/SearchTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/SearchTalkPickService.java
@@ -1,0 +1,19 @@
+package balancetalk.talkpick.application;
+
+import balancetalk.talkpick.domain.repository.SearchTalkPickRepository;
+import balancetalk.talkpick.dto.SearchTalkPickResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchTalkPickService {
+
+    private final SearchTalkPickRepository searchTalkPickRepository;
+
+    public List<SearchTalkPickResponse> searchTalkPicks(final String query) {
+        return searchTalkPickRepository.searchTalkPicks(query);
+    }
+}

--- a/src/main/java/balancetalk/talkpick/application/SearchTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/SearchTalkPickService.java
@@ -3,9 +3,9 @@ package balancetalk.talkpick.application;
 import balancetalk.talkpick.domain.repository.SearchTalkPickRepository;
 import balancetalk.talkpick.dto.SearchTalkPickResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,7 +13,7 @@ public class SearchTalkPickService {
 
     private final SearchTalkPickRepository searchTalkPickRepository;
 
-    public List<SearchTalkPickResponse> searchLimitedTalkPicks(final String query) {
-        return searchTalkPickRepository.searchLimitedTalkPicks(query);
+    public Page<SearchTalkPickResponse> searchTalkPicks(final String query, Pageable pageable) {
+        return searchTalkPickRepository.searchTalkPicks(query, pageable);
     }
 }

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepository.java
@@ -1,0 +1,7 @@
+package balancetalk.talkpick.domain.repository;
+
+import balancetalk.talkpick.domain.TalkPick;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SearchTalkPickRepository extends JpaRepository<TalkPick, Long>, SearchTalkPickRepositoryCustom {
+}

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryCustom.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryCustom.java
@@ -1,0 +1,10 @@
+package balancetalk.talkpick.domain.repository;
+
+import balancetalk.talkpick.dto.SearchTalkPickResponse;
+
+import java.util.List;
+
+public interface SearchTalkPickRepositoryCustom {
+
+    List<SearchTalkPickResponse> searchTalkPicks(String query);
+}

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryCustom.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryCustom.java
@@ -1,10 +1,10 @@
 package balancetalk.talkpick.domain.repository;
 
 import balancetalk.talkpick.dto.SearchTalkPickResponse;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface SearchTalkPickRepositoryCustom {
 
-    List<SearchTalkPickResponse> searchLimitedTalkPicks(String query);
+    Page<SearchTalkPickResponse> searchTalkPicks(String query, Pageable pageable);
 }

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryCustom.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface SearchTalkPickRepositoryCustom {
 
-    List<SearchTalkPickResponse> searchTalkPicks(String query);
+    List<SearchTalkPickResponse> searchLimitedTalkPicks(String query);
 }

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryImpl.java
@@ -1,0 +1,108 @@
+package balancetalk.talkpick.domain.repository;
+
+import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.talkpick.dto.SearchTalkPickResponse;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.StringTokenizer;
+
+import static balancetalk.talkpick.domain.QTalkPick.talkPick;
+
+@RequiredArgsConstructor
+public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCustom {
+
+    private static final int SEARCH_LIMIT_SIZE = 4;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SearchTalkPickResponse> searchTalkPicks(String keyword) {
+        List<TalkPick> result = getTalkPicksByExactMatch(keyword);
+
+        if (isLessThanLimitSize(result) && containsSpacing(keyword)) {
+            List<TalkPick> talkPicks = getTalkPicksByBlankIgnoredExactMatch(keyword);
+            addUniqueTalkPicksToResult(result, talkPicks);
+        }
+
+        if (isLessThanLimitSize(result)) {
+            List<TalkPick> talkPicks = getTalkPicksByNaturalMode(keyword);
+            addUniqueTalkPicksToResult(result, talkPicks);
+        }
+
+        return result.stream()
+                .map(SearchTalkPickResponse::new)
+                .distinct()
+                .toList();
+    }
+
+    private boolean isLessThanLimitSize(List<TalkPick> result) {
+        return result.size() < SEARCH_LIMIT_SIZE;
+    }
+
+    private boolean containsSpacing(String keyword) {
+        return keyword.contains(" ");
+    }
+
+    private List<TalkPick> getTalkPicksByExactMatch(String keyword) {
+        return queryFactory
+                .selectFrom(talkPick)
+                .where(matchInBooleanMode(addQuotes(keyword)))
+                .limit(SEARCH_LIMIT_SIZE)
+                .fetch();
+    }
+
+    private BooleanExpression matchInBooleanMode(String keyword) {
+        return Expressions.booleanTemplate(
+                "function('match_talk_pick_in_boolean_mode', {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
+                talkPick.title, talkPick.summary.firstLine, talkPick.summary.secondLine, talkPick.summary.thirdLine,
+                talkPick.content, talkPick.optionA, talkPick.optionB, keyword);
+    }
+
+    private String addQuotes(String keyword) {
+        return "'\"%s\"'".formatted(keyword);
+    }
+
+    private List<TalkPick> getTalkPicksByBlankIgnoredExactMatch(String keyword) {
+        return queryFactory
+                .selectFrom(talkPick)
+                .where(matchInBooleanMode(addQuotes(ignoreSpacing(keyword))))
+                .limit(SEARCH_LIMIT_SIZE)
+                .fetch();
+    }
+
+    private String ignoreSpacing(String keyword) {
+        StringTokenizer st = new StringTokenizer(keyword);
+        StringBuilder sb = new StringBuilder();
+        while (st.hasMoreTokens()) {
+            sb.append(st.nextToken());
+        }
+        return sb.toString();
+    }
+
+    private void addUniqueTalkPicksToResult(List<TalkPick> result, List<TalkPick> talkPicks) {
+        for (TalkPick talkPick : talkPicks) {
+            if (!result.contains(talkPick)) {
+                result.add(talkPick);
+            }
+        }
+    }
+
+    private List<TalkPick> getTalkPicksByNaturalMode(String keyword) {
+        return queryFactory
+                .selectFrom(talkPick)
+                .where(matchInNaturalMode(keyword))
+                .limit(SEARCH_LIMIT_SIZE)
+                .fetch();
+    }
+
+    private BooleanExpression matchInNaturalMode(String keyword) {
+        return Expressions.booleanTemplate(
+                "function('match_talk_pick_in_natural_mode', {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
+                talkPick.title, talkPick.summary.firstLine, talkPick.summary.secondLine, talkPick.summary.thirdLine,
+                talkPick.content, talkPick.optionA, talkPick.optionB, keyword);
+    }
+}

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryImpl.java
@@ -20,7 +20,7 @@ public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCus
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<SearchTalkPickResponse> searchTalkPicks(String keyword) {
+    public List<SearchTalkPickResponse> searchLimitedTalkPicks(String keyword) {
         List<TalkPick> result = getTalkPicksByExactMatch(keyword);
 
         if (isLessThanLimitSize(result) && containsSpacing(keyword)) {

--- a/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/SearchTalkPickRepositoryImpl.java
@@ -1,9 +1,11 @@
 package balancetalk.talkpick.domain.repository;
 
-import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.talkpick.dto.QSearchTalkPickResponse;
 import balancetalk.talkpick.dto.SearchTalkPickResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,8 @@ import org.springframework.data.support.PageableExecutionUtils;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import static balancetalk.file.domain.FileType.TALK_PICK;
+import static balancetalk.file.domain.QFile.file;
 import static balancetalk.global.utils.QuerydslUtils.getOrderSpecifiers;
 import static balancetalk.talkpick.domain.QTalkPick.talkPick;
 
@@ -27,30 +31,32 @@ public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCus
         int totalSize = pageable.getPageSize();
 
         // 1. 키워드와 완전 일치하는 단어가 포함된 톡픽 조회
-        List<TalkPick> result = findByExactMatch(keyword, pageable, totalSize);
+        List<SearchTalkPickResponse> result = findByExactMatch(keyword, pageable, totalSize);
 
         // 2. 공백 제거한 키워드와 완전 일치하는 단어가 포함된 톡픽 조회
         if (hasMoreTalkPicks(totalSize, result) && containsSpacing(keyword)) {
-            List<TalkPick> talkPicks = findByExactMatch(ignoreSpacing(keyword), pageable, totalSize - result.size());
+            List<SearchTalkPickResponse> talkPicks = findByExactMatch(ignoreSpacing(keyword), pageable, totalSize - result.size());
             addUniqueTalkPicksToResult(result, talkPicks);
         }
 
         // 3. 자연어 모드에 매칭되는 톡픽 조회
         if (hasMoreTalkPicks(totalSize, result)) {
-            List<TalkPick> talkPicks = findByNaturalMode(keyword, pageable, totalSize - result.size());
+            List<SearchTalkPickResponse> talkPicks = findByNaturalMode(keyword, pageable, totalSize - result.size());
             addUniqueTalkPicksToResult(result, talkPicks);
         }
 
-        // 페이징 응답으로 변환
-        List<SearchTalkPickResponse> content = toResponses(result);
+        // 페이징 처리
         JPAQuery<Long> countQuery = countQueryForTalkPicks();
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 
-    private List<TalkPick> findByExactMatch(String keyword, Pageable pageable, int limit) {
+    private List<SearchTalkPickResponse> findByExactMatch(String keyword, Pageable pageable, int limit) {
         return queryFactory
-                .selectFrom(talkPick)
+                .select(new QSearchTalkPickResponse(talkPick, file.path.concat(file.storedName)))
+                .from(talkPick)
+                .leftJoin(file)
+                .on(talkPick.id.eq(file.resourceId), file.id.eq(getMinFileIdByResourceIdAndType()))
                 .where(matchInBooleanMode(addQuotes(keyword)))
                 .orderBy(getOrderSpecifiers(talkPick, pageable.getSort()))
                 .offset(pageable.getOffset())
@@ -58,7 +64,15 @@ public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCus
                 .fetch();
     }
 
-    private boolean hasMoreTalkPicks(int totalSize, List<TalkPick> result) {
+    private JPQLQuery<Long> getMinFileIdByResourceIdAndType() {
+        return JPAExpressions
+                .select(file.id.min())
+                .from(file)
+                .where(file.resourceId.eq(talkPick.id), file.fileType.eq(TALK_PICK))
+                .groupBy(file.resourceId);
+    }
+
+    private boolean hasMoreTalkPicks(int totalSize, List<SearchTalkPickResponse> result) {
         return result.size() < totalSize;
     }
 
@@ -86,17 +100,20 @@ public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCus
         return sb.toString();
     }
 
-    private void addUniqueTalkPicksToResult(List<TalkPick> result, List<TalkPick> talkPicks) {
-        for (TalkPick talkPick : talkPicks) {
+    private void addUniqueTalkPicksToResult(List<SearchTalkPickResponse> result, List<SearchTalkPickResponse> talkPicks) {
+        for (SearchTalkPickResponse talkPick : talkPicks) {
             if (!result.contains(talkPick)) {
                 result.add(talkPick);
             }
         }
     }
 
-    private List<TalkPick> findByNaturalMode(String keyword, Pageable pageable, int limit) {
+    private List<SearchTalkPickResponse> findByNaturalMode(String keyword, Pageable pageable, int limit) {
         return queryFactory
-                .selectFrom(talkPick)
+                .select(new QSearchTalkPickResponse(talkPick, file.path.concat(file.storedName)))
+                .from(talkPick)
+                .leftJoin(file)
+                .on(talkPick.id.eq(file.resourceId), file.id.eq(getMinFileIdByResourceIdAndType()))
                 .where(matchInNaturalMode(keyword))
                 .orderBy(getOrderSpecifiers(talkPick, pageable.getSort()))
                 .offset(pageable.getOffset())
@@ -109,13 +126,6 @@ public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCus
                 "function('match_talk_pick_in_natural_mode', {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
                 talkPick.title, talkPick.summary.firstLine, talkPick.summary.secondLine, talkPick.summary.thirdLine,
                 talkPick.content, talkPick.optionA, talkPick.optionB, keyword);
-    }
-
-    private List<SearchTalkPickResponse> toResponses(List<TalkPick> result) {
-        return result.stream()
-                .map(SearchTalkPickResponse::new)
-                .distinct()
-                .toList();
     }
 
     private JPAQuery<Long> countQueryForTalkPicks() {

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -2,21 +2,16 @@ package balancetalk.talkpick.domain.repository;
 
 import balancetalk.talkpick.dto.QTalkPickDto_TalkPickResponse;
 import balancetalk.talkpick.dto.QTodayTalkPickDto_TodayTalkPickResponse;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Path;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import static balancetalk.global.utils.QuerydslUtils.getOrderSpecifiers;
 import static balancetalk.talkpick.domain.QTalkPick.talkPick;
 import static balancetalk.talkpick.dto.TalkPickDto.TalkPickResponse;
 import static balancetalk.talkpick.dto.TodayTalkPickDto.TodayTalkPickResponse;
@@ -43,15 +38,13 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
 
     @Override
     public Page<TalkPickResponse> findPagedTalkPicks(Pageable pageable) {
-        List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(pageable.getSort());
-
         List<TalkPickResponse> content = queryFactory
                 .select(new QTalkPickDto_TalkPickResponse(
                         talkPick.id, talkPick.title, talkPick.member.nickname,
                         talkPick.createdAt, talkPick.views, talkPick.bookmarks
                 ))
                 .from(talkPick)
-                .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
+                .orderBy(getOrderSpecifiers(talkPick, pageable.getSort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -61,32 +54,6 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
                 .from(talkPick);
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
-    }
-
-    private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort) {
-        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
-        if (!sort.isEmpty()) {
-            for (Sort.Order order : sort) {
-                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-                String property = order.getProperty();
-                switch (property) {
-                    case "views" -> {
-                        orderSpecifiers.add(getOrderSpecifier(direction, talkPick, property));
-                        orderSpecifiers.add(getOrderSpecifier(Order.DESC, talkPick, "createdAt"));
-                    }
-                    case "createdAt" -> {
-                        orderSpecifiers.add(getOrderSpecifier(direction, talkPick, property));
-                        orderSpecifiers.add(getOrderSpecifier(Order.DESC, talkPick, "views"));
-                    }
-                }
-            }
-        }
-        return orderSpecifiers;
-    }
-
-    private OrderSpecifier<?> getOrderSpecifier(Order direction, Path<?> parent, String fieldName) {
-        Path<Boolean> fieldPath = Expressions.path(Boolean.class, parent, fieldName);
-        return new OrderSpecifier<>(direction, fieldPath);
     }
 
     @Override

--- a/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
@@ -1,0 +1,35 @@
+package balancetalk.talkpick.dto;
+
+import balancetalk.talkpick.domain.TalkPick;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Schema(description = "톡픽 검색 응답")
+@Data
+public class SearchTalkPickResponse {
+
+    @Schema(description = "제목", example = "톡픽 제목")
+    private String title;
+
+    private SummaryResponse summary;
+
+    @Schema(description = "본문 내용", example = "톡픽 본문 내용")
+    private String content;
+
+    @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
+    private String optionA;
+
+    @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
+    private String optionB;
+
+    @Schema(description = "첫 번째 이미지 URL", example = "https://picko-image.s3.ap-northeast-2.amazonaws.com/temp-talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png")
+    private String firstImgUrl;
+
+    public SearchTalkPickResponse(TalkPick talkPick) {
+        this.title = talkPick.getTitle();
+        this.summary = new SummaryResponse(talkPick.getSummary());
+        this.content = talkPick.getContent();
+        this.optionA = talkPick.getOptionA();
+        this.optionB = talkPick.getOptionB();
+    }
+}

--- a/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
@@ -4,6 +4,8 @@ import balancetalk.talkpick.domain.TalkPick;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Schema(description = "톡픽 검색 응답")
 @Data
 public class SearchTalkPickResponse {
@@ -28,6 +30,9 @@ public class SearchTalkPickResponse {
     @Schema(description = "첫 번째 이미지 URL", example = "https://picko-image.s3.ap-northeast-2.amazonaws.com/temp-talk-pick/9b4856fe-b624-4e54-ad80-a94e083301d2_czz.png")
     private String firstImgUrl;
 
+    @Schema(description = "작성일", example = "2024-08-04")
+    private LocalDateTime createdAt;
+
     public SearchTalkPickResponse(TalkPick talkPick) {
         this.id = talkPick.getId();
         this.title = talkPick.getTitle();
@@ -35,5 +40,6 @@ public class SearchTalkPickResponse {
         this.content = talkPick.getContent();
         this.optionA = talkPick.getOptionA();
         this.optionB = talkPick.getOptionB();
+        this.createdAt = talkPick.getCreatedAt();
     }
 }

--- a/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
@@ -1,6 +1,7 @@
 package balancetalk.talkpick.dto;
 
 import balancetalk.talkpick.domain.TalkPick;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -33,7 +34,8 @@ public class SearchTalkPickResponse {
     @Schema(description = "작성일", example = "2024-08-04")
     private LocalDateTime createdAt;
 
-    public SearchTalkPickResponse(TalkPick talkPick) {
+    @QueryProjection
+    public SearchTalkPickResponse(TalkPick talkPick, String firstImgUrl) {
         this.id = talkPick.getId();
         this.title = talkPick.getTitle();
         this.summary = new SummaryResponse(talkPick.getSummary());
@@ -41,5 +43,6 @@ public class SearchTalkPickResponse {
         this.optionA = talkPick.getOptionA();
         this.optionB = talkPick.getOptionB();
         this.createdAt = talkPick.getCreatedAt();
+        this.firstImgUrl = firstImgUrl;
     }
 }

--- a/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SearchTalkPickResponse.java
@@ -8,6 +8,9 @@ import lombok.Data;
 @Data
 public class SearchTalkPickResponse {
 
+    @Schema(description = "톡픽 ID", example = "2")
+    private Long id;
+
     @Schema(description = "제목", example = "톡픽 제목")
     private String title;
 
@@ -26,6 +29,7 @@ public class SearchTalkPickResponse {
     private String firstImgUrl;
 
     public SearchTalkPickResponse(TalkPick talkPick) {
+        this.id = talkPick.getId();
         this.title = talkPick.getTitle();
         this.summary = new SummaryResponse(talkPick.getSummary());
         this.content = talkPick.getContent();

--- a/src/main/java/balancetalk/talkpick/dto/SummaryResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SummaryResponse.java
@@ -1,7 +1,6 @@
 package balancetalk.talkpick.dto;
 
 import balancetalk.talkpick.domain.Summary;
-import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -18,8 +17,10 @@ public class SummaryResponse {
     @Schema(description = "요약 3번째 줄", example = "요약 3번째 줄 내용")
     private String summaryThirdLine;
 
-    @QueryProjection
     public SummaryResponse(Summary summary) {
+        if (summary == null) {
+            return;
+        }
         this.summaryFirstLine = summary.getFirstLine();
         this.summarySecondLine = summary.getSecondLine();
         this.summaryThirdLine = summary.getThirdLine();

--- a/src/main/java/balancetalk/talkpick/dto/SummaryResponse.java
+++ b/src/main/java/balancetalk/talkpick/dto/SummaryResponse.java
@@ -1,6 +1,7 @@
 package balancetalk.talkpick.dto;
 
 import balancetalk.talkpick.domain.Summary;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -17,6 +18,7 @@ public class SummaryResponse {
     @Schema(description = "요약 3번째 줄", example = "요약 3번째 줄 내용")
     private String summaryThirdLine;
 
+    @QueryProjection
     public SummaryResponse(Summary summary) {
         this.summaryFirstLine = summary.getFirstLine();
         this.summarySecondLine = summary.getSecondLine();

--- a/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
@@ -7,10 +7,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @Tag(name = "talk_pick", description = "톡픽 API")
 @RestController
@@ -22,8 +25,9 @@ public class SearchTalkPickController {
 
     @Operation(summary = "톡픽 검색", description = "키워드를 통해 톡픽을 검색합니다.")
     @GetMapping
-    public Page<SearchTalkPickResponse> searchTalkPicks(@RequestParam final String query,
-                                                        Pageable pageable) {
+    public Page<SearchTalkPickResponse> searchTalkPicks(
+            @RequestParam final String query,
+            @PageableDefault(size = 4, sort = "views", direction = DESC) Pageable pageable) {
         return searchTalkPickService.searchTalkPicks(query, pageable);
     }
 }

--- a/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
@@ -5,12 +5,12 @@ import balancetalk.talkpick.dto.SearchTalkPickResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "talk_pick", description = "톡픽 API")
 @RestController
@@ -22,7 +22,8 @@ public class SearchTalkPickController {
 
     @Operation(summary = "톡픽 검색", description = "키워드를 통해 톡픽을 검색합니다.")
     @GetMapping
-    public List<SearchTalkPickResponse> searchTalkPicks(@RequestParam final String query) {
-        return searchTalkPickService.searchLimitedTalkPicks(query);
+    public Page<SearchTalkPickResponse> searchTalkPicks(@RequestParam final String query,
+                                                        Pageable pageable) {
+        return searchTalkPickService.searchTalkPicks(query, pageable);
     }
 }

--- a/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
@@ -23,6 +23,6 @@ public class SearchTalkPickController {
     @Operation(summary = "톡픽 검색", description = "키워드를 통해 톡픽을 검색합니다.")
     @GetMapping
     public List<SearchTalkPickResponse> searchTalkPicks(@RequestParam final String query) {
-        return searchTalkPickService.searchTalkPicks(query);
+        return searchTalkPickService.searchLimitedTalkPicks(query);
     }
 }

--- a/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SearchTalkPickController.java
@@ -1,0 +1,28 @@
+package balancetalk.talkpick.presentation;
+
+import balancetalk.talkpick.application.SearchTalkPickService;
+import balancetalk.talkpick.dto.SearchTalkPickResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "talk_pick", description = "톡픽 API")
+@RestController
+@RequestMapping("/talks/search")
+@RequiredArgsConstructor
+public class SearchTalkPickController {
+
+    private final SearchTalkPickService searchTalkPickService;
+
+    @Operation(summary = "톡픽 검색", description = "키워드를 통해 톡픽을 검색합니다.")
+    @GetMapping
+    public List<SearchTalkPickResponse> searchTalkPicks(@RequestParam final String query) {
+        return searchTalkPickService.searchTalkPicks(query);
+    }
+}

--- a/src/main/java/balancetalk/talkpick/presentation/SummaryContentController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SummaryContentController.java
@@ -3,13 +3,16 @@ package balancetalk.talkpick.presentation;
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.application.SummaryContentService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "talk_pick", description = "톡픽 API")
 @RestController
 @RequestMapping("/talks/{talkPickId}/summary")
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class SummaryContentController {
 
     private final SummaryContentService summaryContentService;
 
+    @Operation(summary = "톡픽 본문 요약", description = "톡픽 본문 내용을 요약합니다.")
     @PostMapping
     public void summaryContent(@PathVariable final Long talkPickId,
                                @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+balancetalk.global.config.MySQLFunctionContributor


### PR DESCRIPTION
## 💡 작업 내용
- [x] mysql 사용자 정의 함수 관련 설정 추가
- [x] 로컬 환경에 SQL 파라미터 관련 로그가 출력되도록 설정
- [x] Swagger에 톡픽 본문 요약 API 명세 추가
- [x] 톡픽 검색 기능 구현
- [x] querydsl 정렬 로직 유틸 클래스화

## 💡 자세한 설명
### 톡픽 검색 기능 시퀀스 다이어그램
<img width="412" alt="image" src="https://github.com/user-attachments/assets/0b83d0fd-8af3-4cd7-a5ce-6336ce782383">

### MySQL 사용자 정의 함수 관련 설정
Querydsl에서 MySQL의 사용자 정의 함수를 사용하려면 다음과 같이 FunctionContributor의 구현 클래스를 작성해야 합니다.
```java
public class MySQLFunctionContributor implements FunctionContributor {

    @Override
    public void contributeFunctions(FunctionContributions functionContributions) {
        functionContributions.getFunctionRegistry()
                .registerPattern(
                        "match_talk_pick_in_boolean_mode",
                        "MATCH(?1, ?2, ?3, ?4, ?5, ?6, ?7) AGAINST(?8 IN BOOLEAN MODE)",
                        getBooleanBasicType(functionContributions));

        functionContributions.getFunctionRegistry()
                .registerPattern(
                        "match_talk_pick_in_natural_mode",
                        "MATCH(?1, ?2, ?3, ?4, ?5, ?6, ?7) AGAINST(?8)",
                        getBooleanBasicType(functionContributions));
    }

    private BasicType<Boolean> getBooleanBasicType(FunctionContributions functionContributions) {
        return functionContributions.getTypeConfiguration()
                .getBasicTypeRegistry()
                .resolve(StandardBasicTypes.BOOLEAN);
    }
}
```
MySQL에서 제공하는 `MATCH ... AGAINST`를 사용자 정의 함수로 등록했습니다.

등록한 함수는 다음과 같이 사용할 수 있습니다.
```java
public class SearchTalkPickRepositoryImpl implements SearchTalkPickRepositoryCustom {
    ...

    private BooleanExpression matchInNaturalMode(String keyword) {
        return Expressions.booleanTemplate(
                "function('match_talk_pick_in_natural_mode', {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
                talkPick.title, talkPick.summary.firstLine, talkPick.summary.secondLine, talkPick.summary.thirdLine,
                talkPick.content, talkPick.optionA, talkPick.optionB, keyword);
    }

    ...
```

### Querydsl 정렬 로직 유틸 클래스화
QueryDSL에서 동적 정렬 로직을 사용하려면 OrderSpecifiers를 사용해야 합니다.
기존에는 특정 클래스에 위치시켰지만, 더 넓은 범위에서 사용할 수 있도록 다음과 같이 유틸 클래스로 리팩토링했습니다.
```java
@AllArgsConstructor(access = AccessLevel.PRIVATE)
public class QuerydslUtils {

    public static OrderSpecifier<?>[] getOrderSpecifiers(Path<?> path, Sort sort) {
        if (sort == null || sort.isEmpty()) {
            throw new BalanceTalkException(ErrorCode.SORT_REQUIRED);
        }

        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
        for (Sort.Order order : sort) {
            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
            String property = order.getProperty();
            if (path.equals(talkPick)) {
                return orderSpecifiersForTalkPick(orderSpecifiers, direction, property);
            }
        }

        throw new BalanceTalkException(ErrorCode.FAIL_SORT);
    }

    private static OrderSpecifier<?>[] orderSpecifiersForTalkPick(List<OrderSpecifier<?>> orderSpecifiers, Order direction, String property) {
        switch (property) {
            case "views" -> {
                orderSpecifiers.add(getOrderSpecifier(direction, talkPick, property));
                orderSpecifiers.add(getOrderSpecifier(Order.DESC, talkPick, "createdAt"));
            }
            case "createdAt" -> {
                orderSpecifiers.add(getOrderSpecifier(direction, talkPick, property));
                orderSpecifiers.add(getOrderSpecifier(Order.DESC, talkPick, "views"));
            }
        }

        return orderSpecifiers.toArray(OrderSpecifier[]::new);
    }

    private static OrderSpecifier<?> getOrderSpecifier(Order direction, Path<?> path, String fieldName) {
        Path<Boolean> fieldPath = Expressions.path(Boolean.class, path, fieldName);
        return new OrderSpecifier<>(direction, fieldPath);
    }
}
```

## 📗 참고 자료
[MySQL 공식 문서](https://dev.mysql.com/doc/refman/8.4/en/fulltext-search.html)
[관련 블로그](https://inpa.tistory.com/entry/MYSQL-%F0%9F%93%9A-%ED%92%80%ED%85%8D%EC%8A%A4%ED%8A%B8-%EC%9D%B8%EB%8D%B1%EC%8A%A4Full-Text-Index-%EC%82%AC%EC%9A%A9%EB%B2%95#%ED%92%80%ED%85%8D%EC%8A%A4%ED%8A%B8_%EC%9D%B8%EB%8D%B1%EC%8A%A4_%EC%A0%84%EC%B2%B4%ED%85%8D%EC%8A%A4%ED%8A%B8_%EC%9D%B8%EB%8D%B1%EC%8A%A4)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #560 
