### PR TITLE
ERD구조 변경에 따라 밸런스 게임 구조 리팩토링

### DIFF
--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -15,6 +15,8 @@ import balancetalk.bookmark.domain.BookmarkGenerator;
 import balancetalk.bookmark.domain.BookmarkRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameReader;
+import balancetalk.game.domain.GameSet;
+import balancetalk.game.domain.repository.GameSetRepository;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.notification.application.NotificationService;
@@ -38,10 +40,13 @@ public class BookmarkGameService {
     private final NotificationService notificationService;
 
     public void createBookmark(final Long gameId, final ApiMember apiMember) {
+
         Game game = gameReader.readById(gameId);
         Member member = apiMember.toMember(memberRepository);
 
-        if (member.isMyGame(game)) {
+        GameSet gameSet = game.getGameSet(gameId);
+
+        if (member.isMyGameSet(gameSet)) {
             throw new BalanceTalkException(ErrorCode.CANNOT_BOOKMARK_MY_RESOURCE);
         }
 
@@ -71,7 +76,7 @@ public class BookmarkGameService {
     }
 
     private void sendBookmarkGameNotification(Game game) {
-        Member member = game.getMember();
+        Member member = null; // TODO: GameSet으로 변경됨에 따라 수정 필요
         long bookmarkedCount = game.getBookmarks();
         String bookmarkCountKey = "BOOKMARK_" + bookmarkedCount;
         Map<String, Boolean> notificationHistory = game.getNotificationHistory();

--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -15,8 +15,6 @@ import balancetalk.bookmark.domain.BookmarkGenerator;
 import balancetalk.bookmark.domain.BookmarkRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameReader;
-import balancetalk.game.domain.GameSet;
-import balancetalk.game.domain.repository.GameSetRepository;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.notification.application.NotificationService;
@@ -44,9 +42,7 @@ public class BookmarkGameService {
         Game game = gameReader.readById(gameId);
         Member member = apiMember.toMember(memberRepository);
 
-        GameSet gameSet = game.getGameSet(gameId);
-
-        if (member.isMyGameSet(gameSet)) {
+        if (member.isMyGame(game)) {
             throw new BalanceTalkException(ErrorCode.CANNOT_BOOKMARK_MY_RESOURCE);
         }
 

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -5,11 +5,14 @@ import static balancetalk.bookmark.domain.BookmarkType.GAME;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameOption;
 import balancetalk.game.domain.GameReader;
+import balancetalk.game.domain.GameSet;
 import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.repository.GameRepository;
+import balancetalk.game.domain.repository.GameSetRepository;
 import balancetalk.game.domain.repository.GameTagRepository;
 import balancetalk.game.dto.GameDto.CreateGameMainTagRequest;
 import balancetalk.game.dto.GameDto.CreateGameRequest;
+import balancetalk.game.dto.GameDto.CreateGameSetRequest;
 import balancetalk.game.dto.GameDto.GameDetailResponse;
 import balancetalk.game.dto.GameDto.GameResponse;
 import balancetalk.global.exception.BalanceTalkException;
@@ -34,31 +37,42 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GameService {
 
-    private static final int START_PAGE = 0;
-    private static final int END_PAGE = 16;
+    private static final int PAGE_INITIAL_INDEX = 0;
+    private static final int PAGE_LIMIT = 16;
+    private static final int GAME_SIZE = 10;
     private final GameReader gameReader;
     private final GameRepository gameRepository;
+    private final GameSetRepository gameSetRepository;
     private final MemberRepository memberRepository;
     private final GameTagRepository gameTagRepository;
 
-    public void createBalanceGame(final CreateGameRequest request, final ApiMember apiMember) {
+    public void createBalanceGameSet(final CreateGameSetRequest request, final ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
+
+        List<CreateGameRequest> games = request.getGames();
+        if (games.size() < GAME_SIZE) {
+            throw new BalanceTalkException(ErrorCode.BALANCE_GAME_SIZE_TEN);
+        }
 
         MainTag mainTag = gameTagRepository.findByName(request.getMainTag())
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_GAME_TOPIC));
 
-        Game game = request.toEntity(mainTag, member);
-        List<GameOption> gameOptions = game.getGameOptions();
-        for (GameOption gameOption : gameOptions) {
-            gameOption.addGame(game);
-        }
+        GameSet gameSet = request.toEntity(mainTag, member);
 
-        gameRepository.save(game);
+        for(CreateGameRequest gameRequest : games) {
+            Game game = gameRequest.toEntity();
+            for(GameOption gameOption : game.getGameOptions()) {
+                gameOption.addGame(game);
+            }
+            game.addGameSet(gameSet);
+            gameRepository.save(game);
+        }
+        gameSetRepository.save(gameSet);
     }
 
     public GameDetailResponse findBalanceGame(final Long gameId, final GuestOrApiMember guestOrApiMember) {
         Game game = gameReader.readById(gameId);
-        game.increaseViews();
+//        game.increaseViews();
 
         if (guestOrApiMember.isGuest()) {
             return GameDetailResponse.from(game, false, null); // 게스트인 경우 북마크, 선택 옵션 없음
@@ -77,8 +91,8 @@ public class GameService {
     }
 
     public List<GameResponse> findLatestGames(final String topicName, GuestOrApiMember guestOrApiMember) {
-        Pageable pageable = PageRequest.of(START_PAGE, END_PAGE);
-        List<Game> games = gameRepository.findGamesByCreated(topicName, pageable);
+        Pageable pageable = PageRequest.of(PAGE_INITIAL_INDEX, PAGE_LIMIT);
+        List<Game> games = gameSetRepository.findGamesByCreated(topicName, pageable);
 
         if (guestOrApiMember.isGuest()) {
             return games.stream()
@@ -94,8 +108,8 @@ public class GameService {
     }
 
     public List<GameResponse> findBestGames(final String topicName, GuestOrApiMember guestOrApiMember) {
-        Pageable pageable = PageRequest.of(START_PAGE, END_PAGE);
-        List<Game> games = gameRepository.findGamesByViews(topicName, pageable);
+        Pageable pageable = PageRequest.of(PAGE_INITIAL_INDEX, PAGE_LIMIT);
+        List<Game> games = gameSetRepository.findGamesByViews(topicName, pageable);
 
         if (guestOrApiMember.isGuest()) {
             return games.stream()

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -58,15 +58,6 @@ public class Game extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String notificationHistory;
 
-    public GameSet getGameSet(Long gameId) {
-        return gameSet.getGames()
-                .stream()
-                .filter(game -> game.getId().equals(gameId))
-                .map(Game::getGameSet)
-                .findFirst()
-                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME_SET));
-    }
-
     public long getVoteCount(VoteOption optionType) {
         GameOption option = gameOptions.stream()
                 .filter(gameOption -> gameOption.isTypeEqual(optionType))

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -6,7 +6,6 @@ import static balancetalk.global.exception.ErrorCode.FAIL_SERIALIZE_NOTIFICATION
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
-import balancetalk.member.domain.Member;
 import balancetalk.vote.domain.VoteOption;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,12 +37,7 @@ public class Game extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "main_tag_id")
-    private MainTag mainTag;
+    private GameSet gameSet;
 
     @OneToMany(mappedBy = "game", cascade = CascadeType.ALL)
     private List<GameOption> gameOptions = new ArrayList<>();
@@ -56,15 +50,7 @@ public class Game extends BaseTimeEntity {
     @Size(max = 100)
     private String description;
 
-    @Size(max = 10)
-    private String subTag;
-
     private LocalDateTime editedAt;
-
-    @PositiveOrZero
-    @ColumnDefault("0")
-    private long views;
-
     @PositiveOrZero
     @ColumnDefault("0")
     private Long bookmarks;
@@ -72,8 +58,13 @@ public class Game extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String notificationHistory;
 
-    public void increaseViews() {
-        this.views++;
+    public GameSet getGameSet(Long gameId) {
+        return gameSet.getGames()
+                .stream()
+                .filter(game -> game.getId().equals(gameId))
+                .map(Game::getGameSet)
+                .findFirst()
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME_SET));
     }
 
     public long getVoteCount(VoteOption optionType) {
@@ -97,6 +88,10 @@ public class Game extends BaseTimeEntity {
 
     public void decreaseBookmarks() {
         this.bookmarks--;
+    }
+
+    public void addGameSet(GameSet gameSet) {
+        this.gameSet = gameSet;
     }
 
     // 알림 이력 조회

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -35,7 +35,7 @@ public class GameSet extends BaseTimeEntity {
     @Column(name = "id")
     private Long id;
 
-    @OneToMany(mappedBy = "gameSet", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "gameSet", cascade = CascadeType.ALL)
     private List<Game> games = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -1,0 +1,59 @@
+package balancetalk.game.domain;
+
+import balancetalk.global.common.BaseTimeEntity;
+import balancetalk.member.domain.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameSet extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @OneToMany(mappedBy = "gameSet", cascade = CascadeType.REMOVE)
+    private List<Game> games = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_tag_id")
+    private MainTag mainTag;
+
+    @PositiveOrZero
+    @ColumnDefault("0")
+    private long views;
+
+    @Size(max = 10)
+    private String subTag;
+
+    public void increaseViews() {
+        this.views++;
+    }
+}

--- a/src/main/java/balancetalk/game/domain/MainTag.java
+++ b/src/main/java/balancetalk/game/domain/MainTag.java
@@ -33,5 +33,5 @@ public class MainTag extends BaseTimeEntity {
     private String name;
 
     @OneToMany(mappedBy = "mainTag")
-    private List<Game> games = new ArrayList<>();
+    private List<GameSet> gameSets = new ArrayList<>();
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -11,22 +11,5 @@ import org.springframework.data.repository.query.Param;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
-    @Query("SELECT g FROM Game g " +
-            "WHERE g.mainTag.id IN (" +
-            "    SELECT mt.id FROM MainTag mt " +
-            "    WHERE mt.name = :name" +
-            ") " +
-            "ORDER BY g.createdAt DESC")
-    List<Game> findGamesByCreated(@Param("name") String mainTag, Pageable pageable);
-
-    @Query("SELECT g FROM Game g " +
-            "WHERE g.mainTag.id IN (" +
-            "    SELECT mt.id FROM MainTag mt " +
-            "    WHERE mt.name = :name" +
-            ") " +
-            "ORDER BY g.views DESC, g.createdAt DESC")
-    List<Game> findGamesByViews(@Param("name") String mainTag, Pageable pageable);
-
-    Page<Game> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
-
+//    Page<Game> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -1,0 +1,29 @@
+package balancetalk.game.domain.repository;
+
+import balancetalk.game.domain.Game;
+import balancetalk.game.domain.GameSet;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GameSetRepository extends JpaRepository<GameSet, Long> {
+
+    @Query("SELECT g FROM GameSet g " +
+            "WHERE g.mainTag.id IN (" +
+            "    SELECT mt.id FROM MainTag mt " +
+            "    WHERE mt.name = :name" +
+            ") " +
+            "ORDER BY g.createdAt DESC")
+    List<Game> findGamesByCreated(@Param("name") String mainTag, Pageable pageable);
+
+    @Query("SELECT g FROM GameSet g " +
+            "WHERE g.mainTag.id IN (" +
+            "    SELECT mt.id FROM MainTag mt " +
+            "    WHERE mt.name = :name" +
+            ") " +
+            "ORDER BY g.views DESC, g.createdAt DESC")
+    List<Game> findGamesByViews(@Param("name") String mainTag, Pageable pageable);
+}

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -3,7 +3,6 @@ package balancetalk.game.domain.repository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameSet;
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +16,7 @@ public interface GameSetRepository extends JpaRepository<GameSet, Long> {
             "    WHERE mt.name = :name" +
             ") " +
             "ORDER BY g.createdAt DESC")
-    List<Game> findGamesByCreated(@Param("name") String mainTag, Pageable pageable);
+    List<Game> findGamesByCreationDate(@Param("name") String mainTag, Pageable pageable);
 
     @Query("SELECT g FROM GameSet g " +
             "WHERE g.mainTag.id IN (" +

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -25,9 +25,9 @@ public class GameController {
 
     @PostMapping
     @Operation(summary = "밸런스 게임 생성", description = "밸런스 게임을 생성합니다.")
-    public void createGame(@RequestBody final CreateGameRequest request,
+    public void createGameSet(@RequestBody final CreateGameSetRequest request,
                            @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
-        gameService.createBalanceGame(request, apiMember);
+        gameService.createBalanceGameSet(request, apiMember);
     }
 
     @GetMapping("/{gameId}")

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -24,7 +24,7 @@ public class GameController {
     private final GameService gameService;
 
     @PostMapping
-    @Operation(summary = "밸런스 게임 생성", description = "밸런스 게임을 생성합니다.")
+    @Operation(summary = "밸런스 게임 세트 생성", description = "10개의 밸런스 게임을 가지고 있는 게임 세트를 생성합니다.")
     public void createGameSet(@RequestBody final CreateGameSetRequest request,
                            @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
         gameService.createBalanceGameSet(request, apiMember);

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     ALREADY_BOOKMARKED(BAD_REQUEST, "이미 북마크한 게시글입니다."),
     ALREADY_DELETED_BOOKMARK(BAD_REQUEST, "이미 북마크가 취소된 상태입니다."),
     SORT_REQUIRED(BAD_REQUEST, "정렬 조건은 필수입니다."),
+    BALANCE_GAME_SIZE_TEN(BAD_REQUEST, "밸런스 게임의 갯수는 10개여야 합니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
@@ -79,6 +80,7 @@ public enum ErrorCode {
     NOT_FOUND_NOTICE(NOT_FOUND, "존재하지 않는 공지사항입니다."),
     NOT_LIKED_COMMENT(NOT_FOUND, "해당 댓글을 좋아요한 기록이 존재하지 않습니다."),
     NOT_FOUND_LIKE(NOT_FOUND, "해당 좋아요가 존재하지 않습니다."),
+    NOT_FOUND_BALANCE_GAME_SET(NOT_FOUND, "존재하지 않는 밸런스 게임 세트 입니다."),
     NOT_FOUND_BALANCE_GAME(NOT_FOUND, "존재하지 않는 밸런스 게임입니다."),
     NOT_FOUND_GAME_TOPIC(NOT_FOUND, "존재하지 않는 밸런스 게임 주제입니다."),
     NOT_FOUND_TALK_PICK_THAT_MEMBER(NOT_FOUND, "해당 회원이 작성하지 않은 톡픽입니다."),

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -7,6 +7,7 @@ import balancetalk.comment.domain.Comment;
 import balancetalk.comment.domain.CommentRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.repository.GameRepository;
+import balancetalk.game.domain.repository.GameSetRepository;
 import balancetalk.game.dto.GameDto.GameMyPageResponse;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
@@ -40,6 +41,7 @@ public class MyPageService {
     private final VoteRepository voteRepository;
     private final CommentRepository commentRepository;
     private final GameRepository gameRepository;
+    private final GameSetRepository gameSetRepository;
 
     public Page<TalkPickMyPageResponse> findAllBookmarkedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
@@ -118,7 +120,8 @@ public class MyPageService {
 
     public Page<GameMyPageResponse> findAllGamesByMember(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        Page<Game> games = gameRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId(), pageable);
+        Page<Game> games = null; // FIXME: 수정 필요
+                // gameSetRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId(), pageable);
 
         List<GameMyPageResponse> responses = games.stream()
                 .map(GameMyPageResponse::from)

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -124,9 +124,9 @@ public class Member extends BaseTimeEntity {
         return talkPicks.contains(talkPick);
     }
 
-    public boolean isMyGameSet(GameSet gameSet) {
+    public boolean isMyGame(Game game) {
         return gameSets.stream()
-                .anyMatch(gs -> gs.equals(gameSet));
+                .anyMatch(gameSet -> gameSet.getGames().contains(game));
     }
 
     public Optional<Bookmark> getBookmarkOf(long resourceId, BookmarkType type) {

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -3,6 +3,7 @@ package balancetalk.member.domain;
 import balancetalk.bookmark.domain.Bookmark;
 import balancetalk.bookmark.domain.BookmarkType;
 import balancetalk.game.domain.Game;
+import balancetalk.game.domain.GameSet;
 import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
@@ -67,7 +68,7 @@ public class Member extends BaseTimeEntity {
     private TempTalkPick tempTalkPick;
 
     @OneToMany(mappedBy = "member")
-    private List<Game> games = new ArrayList<>();
+    private List<GameSet> gameSets = new ArrayList<>();
 
     @OneToMany(mappedBy = "member")
     private List<Like> likes = new ArrayList<>();
@@ -123,8 +124,9 @@ public class Member extends BaseTimeEntity {
         return talkPicks.contains(talkPick);
     }
 
-    public boolean isMyGame(Game game) {
-        return games.contains(game);
+    public boolean isMyGameSet(GameSet gameSet) {
+        return gameSets.stream()
+                .anyMatch(gs -> gs.equals(gameSet));
     }
 
     public Optional<Bookmark> getBookmarkOf(long resourceId, BookmarkType type) {
@@ -149,7 +151,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public int getPostsCount() {
-        return talkPicks.size() + games.size();
+        return talkPicks.size() + gameSets.size();
     }
 
     public int getBookmarkedPostsCount() {

--- a/src/main/java/balancetalk/vote/application/VoteGameService.java
+++ b/src/main/java/balancetalk/vote/application/VoteGameService.java
@@ -94,7 +94,7 @@ public class VoteGameService {
     }
 
     private void sendVoteGameNotification(Game game) {
-        Member member = game.getMember();
+        Member member = null; // TODO: GameSet으로 변경됨에 따라 수정 필요
         long votedCount = game.getVoteCount(A) + game.getVoteCount(B);
         String voteCountKey = "VOTE_" + votedCount;
         Map<String, Boolean> notificationHistory = game.getNotificationHistory();


### PR DESCRIPTION
## 💡 작업 내용
- [x] GameSet 엔티티 생성
- [x] GameSet 엔티티가 생성됨에 따라 연관관계 재설정
- [x] Game_Set 생성 시 10개의 밸런스 게임이 들어가도록 수정
- [x] 밸런스 게임 북마크 로직 리팩토링

## 💡 자세한 설명

밸런스 게임 하나 당 2개의 밸런스 게임 옵션을 가지고 있고 밸런스 게임 세트 하나당 10개의 밸런스 게임이 존재합니다.

![스크린샷 2024-09-12 오후 10 22 15](https://github.com/user-attachments/assets/d18daf7c-2df0-4ae5-9ab9-67c4034e5ed1)

![스크린샷 2024-09-12 오후 10 22 24](https://github.com/user-attachments/assets/803789ab-3c92-4323-955c-019c06d3f605)

![스크린샷 2024-09-12 오후 10 22 31](https://github.com/user-attachments/assets/87f9d8c2-921b-4583-9377-72950e1030da)

밸런스 게임 세트가 생성될 때, 성공적으로 `Game_Set` <-> `Game` <-> `Game_Options` 연관 관계를 맺어주었습니다.

밸런스 게임의 수는 무조건 **10개**여야 하기 때문에, 예외 처리를 해주었습니다.

![스크린샷 2024-09-12 오후 10 27 33](https://github.com/user-attachments/assets/ab374911-4b6d-4d7e-8e65-a1e094364ca6)
![스크린샷 2024-09-12 오후 10 27 40](https://github.com/user-attachments/assets/d17ca5e7-4fdb-4027-b6ef-3cbe213bac96)

---

북마크 처리를 할 때는, `GameSet`을 스트림 돌려서 주어진 `game_id`와 일치하는 게임이 있다면 해당 게임의 `GameSet`을 가져오고 없다면 예외 처리를 해주도록 리팩토링을 진행했습니다.

![스크린샷 2024-09-12 오후 10 32 41](https://github.com/user-attachments/assets/c4622db7-db9a-486a-85bc-9644daf87bdc)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #589 
