### PR TITLE
밸런스 게임 목록 최신순, 인기순 기능 리팩토링

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -13,6 +13,7 @@ import balancetalk.game.dto.GameDto.CreateGameRequest;
 import balancetalk.game.dto.GameDto.GameResponse;
 import balancetalk.game.dto.GameSetDto.CreateGameSetRequest;
 import balancetalk.game.dto.GameSetDto.GameSetDetailResponse;
+import balancetalk.game.dto.GameSetDto.GameSetResponse;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
@@ -112,21 +113,12 @@ public class GameService {
                 }).toList();
     }
 
-    public List<GameResponse> findBestGames(final String topicName, GuestOrApiMember guestOrApiMember) {
+    public List<GameSetResponse> findBestGames(final String topicName) {
         Pageable pageable = PageRequest.of(PAGE_INITIAL_INDEX, PAGE_LIMIT);
-        List<Game> games = gameSetRepository.findGamesByViews(topicName, pageable);
+        List<GameSet> gameSets = gameSetRepository.findGamesByViews(topicName, pageable);
 
-        if (guestOrApiMember.isGuest()) {
-            return games.stream()
-                    .map(game -> GameResponse.fromEntity(game, null, false)).toList();
-        }
-
-        Member member = guestOrApiMember.toMember(memberRepository);
-        return games.stream()
-                .map(game -> {
-                    boolean bookmarked = member.hasBookmarked(game.getId(), GAME);
-                    return GameResponse.fromEntity(game, member, bookmarked);
-                }).toList();
+        return gameSets.stream()
+                .map(gameSet -> GameSetResponse.fromEntity(gameSet)).toList();
     }
 
     public void createGameMainTag(final CreateGameMainTagRequest request, final ApiMember apiMember) {

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -10,7 +10,6 @@ import balancetalk.game.domain.repository.GameSetRepository;
 import balancetalk.game.domain.repository.GameTagRepository;
 import balancetalk.game.dto.GameDto.CreateGameMainTagRequest;
 import balancetalk.game.dto.GameDto.CreateGameRequest;
-import balancetalk.game.dto.GameDto.GameResponse;
 import balancetalk.game.dto.GameSetDto.CreateGameSetRequest;
 import balancetalk.game.dto.GameSetDto.GameSetDetailResponse;
 import balancetalk.game.dto.GameSetDto.GameSetResponse;
@@ -96,27 +95,16 @@ public class GameService {
         return GameSetDetailResponse.fromEntity(gameSet, bookmarkMap, voteOptionMap);
     }
 
-    public List<GameResponse> findLatestGames(final String topicName, GuestOrApiMember guestOrApiMember) {
+    public List<GameSetResponse> findLatestGames(final String topicName) {
         Pageable pageable = PageRequest.of(PAGE_INITIAL_INDEX, PAGE_LIMIT);
-        List<Game> games = gameSetRepository.findGamesByCreationDate(topicName, pageable);
-
-        if (guestOrApiMember.isGuest()) {
-            return games.stream()
-                    .map(game -> GameResponse.fromEntity(game, null, false)).toList();
-        }
-
-        Member member = guestOrApiMember.toMember(memberRepository);
-        return games.stream()
-                .map(game -> {
-                    boolean bookmarked = member.hasBookmarked(game.getId(), GAME);
-                    return GameResponse.fromEntity(game, member, bookmarked);
-                }).toList();
+        List<GameSet> gameSets = gameSetRepository.findGamesByCreationDate(topicName, pageable);
+        return gameSets.stream()
+                .map(gameSet -> GameSetResponse.fromEntity(gameSet)).toList();
     }
 
     public List<GameSetResponse> findBestGames(final String topicName) {
         Pageable pageable = PageRequest.of(PAGE_INITIAL_INDEX, PAGE_LIMIT);
         List<GameSet> gameSets = gameSetRepository.findGamesByViews(topicName, pageable);
-
         return gameSets.stream()
                 .map(gameSet -> GameSetResponse.fromEntity(gameSet)).toList();
     }

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -1,6 +1,5 @@
 package balancetalk.game.domain.repository;
 
-import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameSet;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -11,12 +10,9 @@ import org.springframework.data.repository.query.Param;
 public interface GameSetRepository extends JpaRepository<GameSet, Long> {
 
     @Query("SELECT g FROM GameSet g " +
-            "WHERE g.mainTag.id IN (" +
-            "    SELECT mt.id FROM MainTag mt " +
-            "    WHERE mt.name = :name" +
-            ") " +
-            "ORDER BY g.createdAt DESC")
-    List<Game> findGamesByCreationDate(@Param("name") String mainTag, Pageable pageable);
+            "WHERE g.mainTag.name = :name " +
+            "ORDER BY g.views DESC")
+    List<GameSet> findGamesByCreationDate(@Param("name") String mainTag, Pageable pageable);
 
     @Query("SELECT g FROM GameSet g " +
             "WHERE g.mainTag.name = :name " +

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -20,6 +20,6 @@ public interface GameSetRepository extends JpaRepository<GameSet, Long> {
 
     @Query("SELECT g FROM GameSet g " +
             "WHERE g.mainTag.name = :name " +
-            "ORDER BY g.views DESC")
+            "ORDER BY g.views DESC, g.createdAt DESC")
     List<GameSet> findGamesByViews(@Param("name") String mainTag, Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -11,7 +11,7 @@ public interface GameSetRepository extends JpaRepository<GameSet, Long> {
 
     @Query("SELECT g FROM GameSet g " +
             "WHERE g.mainTag.name = :name " +
-            "ORDER BY g.views DESC")
+            "ORDER BY g.createdAt DESC")
     List<GameSet> findGamesByCreationDate(@Param("name") String mainTag, Pageable pageable);
 
     @Query("SELECT g FROM GameSet g " +

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -19,10 +19,7 @@ public interface GameSetRepository extends JpaRepository<GameSet, Long> {
     List<Game> findGamesByCreationDate(@Param("name") String mainTag, Pageable pageable);
 
     @Query("SELECT g FROM GameSet g " +
-            "WHERE g.mainTag.id IN (" +
-            "    SELECT mt.id FROM MainTag mt " +
-            "    WHERE mt.name = :name" +
-            ") " +
-            "ORDER BY g.views DESC, g.createdAt DESC")
-    List<Game> findGamesByViews(@Param("name") String mainTag, Pageable pageable);
+            "WHERE g.mainTag.name = :name " +
+            "ORDER BY g.views DESC")
+    List<GameSet> findGamesByViews(@Param("name") String mainTag, Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -1,5 +1,6 @@
 package balancetalk.game.dto;
 
+import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameSet;
 import balancetalk.game.domain.MainTag;
 import balancetalk.game.dto.GameDto.CreateGameRequest;
@@ -7,6 +8,8 @@ import balancetalk.game.dto.GameDto.GameDetailResponse;
 import balancetalk.member.domain.Member;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -32,6 +35,43 @@ public class GameSetDto {
                     .subTag(subTag)
                     .member(member)
                     .games(games.stream().map(CreateGameRequest::toEntity).toList())
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "밸런스 게임 세트 목록 조회 응답")
+    public static class GameSetResponse {
+
+        @Schema(description = "밸런스 게임 세트 id", example = "1")
+        private Long id;
+
+        @Schema(description = "메인 태그", example = "사랑")
+        private String mainTag;
+
+        @Schema(description = "서브 태그", example = "서브 태그")
+        private String subTag;
+
+        @Schema(description = "게시글 제목", example = "제목")
+        private String title;
+
+        private List<String> images;
+
+        public static GameSetResponse fromEntity(GameSet gameSet) {
+            Game game = gameSet.getGames().get(0);
+            List<String> images = new ArrayList<>();
+            images.addAll(Arrays.asList(
+                    game.getGameOptions().get(0).getImgUrl(),
+                    game.getGameOptions().get(1).getImgUrl()
+            ));
+            return GameSetResponse.builder()
+                    .id(gameSet.getId())
+                    .mainTag(gameSet.getMainTag().getName())
+                    .subTag(gameSet.getSubTag())
+                    .title(game.getTitle())
+                    .images(images)
                     .build();
         }
     }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -52,13 +52,12 @@ public class GameController {
 
     @GetMapping("/latest")
     @Operation(summary = "최신순으로 밸런스 게임 조회", description = "최신순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public List<GameResponse> findLatestGames(@RequestParam String tagName,
-                                              @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
-        return gameService.findLatestGames(tagName, guestOrApiMember);
+    public List<GameSetResponse> findLatestGames(@RequestParam String tagName) {
+        return gameService.findLatestGames(tagName);
     }
 
     @GetMapping("/best")
-    @Operation(summary = "조회순으로 밸런스 게임 조회", description = "조회순으로 정렬된 16개의 게임 목록을 리턴합니다.")
+    @Operation(summary = "조회수 순으로 밸런스 게임 조회", description = "조회수 순으로 정렬된 16개의 게임 목록을 리턴합니다.")
     public List<GameSetResponse> findBestGames(@RequestParam String tagName) {
         return gameService.findBestGames(tagName);
     }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -3,6 +3,7 @@ package balancetalk.game.presentation;
 import balancetalk.game.application.GameService;
 import balancetalk.game.dto.GameSetDto.CreateGameSetRequest;
 import balancetalk.game.dto.GameSetDto.GameSetDetailResponse;
+import balancetalk.game.dto.GameSetDto.GameSetResponse;
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
@@ -47,7 +48,6 @@ public class GameController {
     @DeleteMapping("/{gameId}")
     @Operation(summary = "밸런스 게임 삭제", description = "밸런스 게임을 삭제합니다.")
     public void deleteGame(@PathVariable final Long gameId) {
-
     }
 
     @GetMapping("/latest")
@@ -58,9 +58,8 @@ public class GameController {
     }
 
     @GetMapping("/best")
-    @Operation(summary = "인기순으로 밸런스 게임 조회", description = "인기순으로 정렬된 16개의 게임 목록을 리턴합니다.")
-    public List<GameResponse> findBestGames(@RequestParam String tagName,
-                                            @Parameter(hidden = true)  @AuthPrincipal GuestOrApiMember guestOrApiMember) {
-        return gameService.findBestGames(tagName, guestOrApiMember);
+    @Operation(summary = "조회순으로 밸런스 게임 조회", description = "조회순으로 정렬된 16개의 게임 목록을 리턴합니다.")
+    public List<GameSetResponse> findBestGames(@RequestParam String tagName) {
+        return gameService.findBestGames(tagName);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 회원 비회원 여부를 판별하는 로직 제거
- [x] GameSet의 목록을 보여주는 dto 생성

## 💡 자세한 설명

![스크린샷 2024-09-17 오전 12 47 35](https://github.com/user-attachments/assets/161f4141-3a00-45f2-b0a6-40546f23e510)

목록 페이지에 id값, 메인 태그, 서브 태그, 제목, 그리고 이미지 파일 두개를 보여주도록 설정했습니다. 목록에 표시되는 값들은 GameSet의 첫번째 Game을 기준으로 조회되도록 구현했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #597 
