### PR TITLE
답글 기능 분리, 댓글 기능 수정 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -112,10 +112,11 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CommentDto.CommentResponse> findAllReplies(Long parentId, Pageable pageable,
+    public Page<CommentDto.CommentResponse> findAllReplies(Long parentId, Long talkPickId, Pageable pageable,
                                                         GuestOrApiMember guestOrApiMember) {
         // 부모 댓글이 존재하는지 확인
         validateCommentId(parentId);
+        validateTalkPickId(talkPickId);
 
         long memberId = guestOrApiMember.getMemberId();
 

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -136,7 +136,7 @@ public class CommentService {
                                                                 GuestOrApiMember guestOrApiMember) {
         validateTalkPickId(talkPickId);
 
-        List<Comment> allComments = commentRepository.findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtDesc(talkPickId,
+        List<Comment> allComments = commentRepository.findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtAsc(talkPickId,
                 LikeType.COMMENT);
         List<CommentDto.CommentResponse> bestComments = new ArrayList<>();
         List<CommentDto.CommentResponse> otherComments = new ArrayList<>();
@@ -174,8 +174,8 @@ public class CommentService {
             }
         }
 
-        bestComments.sort(Comparator.comparing(CommentDto.CommentResponse::getCreatedAt).reversed());
-        otherComments.sort(Comparator.comparing(CommentDto.CommentResponse::getCreatedAt).reversed());
+        bestComments.sort(Comparator.comparing(CommentDto.CommentResponse::getCreatedAt));
+        otherComments.sort(Comparator.comparing(CommentDto.CommentResponse::getCreatedAt));
 
         List<CommentDto.CommentResponse> result = new ArrayList<>();
         result.addAll(bestComments);

--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -102,7 +102,7 @@ public class CommentService {
                                                             GuestOrApiMember guestOrApiMember) {
         validateTalkPickId(talkPickId);
 
-        Page<Comment> comments = commentRepository.findAllByTalkPickId(talkPickId, pageable);
+        Page<Comment> comments = commentRepository.findAllByTalkPickIdAndParentIsNull(talkPickId, pageable);
 
         return comments.map(comment -> {
             int likesCount = likeRepository.countByResourceIdAndLikeType(comment.getId(), LikeType.COMMENT);
@@ -112,11 +112,30 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
+    public Page<CommentDto.CommentResponse> findAllReplies(Long parentId, Pageable pageable,
+                                                        GuestOrApiMember guestOrApiMember) {
+        // 부모 댓글이 존재하는지 확인
+        validateCommentId(parentId);
+
+        long memberId = guestOrApiMember.getMemberId();
+
+        // 해당 부모 댓글의 답글 조회
+        Page<Comment> replies = commentRepository.findAllRepliesByParentIdOrderByMemberAndCreatedAt(parentId, memberId, pageable);
+
+        return replies.map(reply -> {
+            int likesCount = likeRepository.countByResourceIdAndLikeType(reply.getId(), LikeType.COMMENT);
+            boolean myLike = isCommentMyLiked(reply.getId(), guestOrApiMember);
+            return CommentDto.CommentResponse.fromEntity(reply, likesCount, myLike);
+        });
+    }
+
+
+    @Transactional(readOnly = true)
     public Page<CommentDto.CommentResponse> findAllBestComments(Long talkPickId, Pageable pageable,
                                                                 GuestOrApiMember guestOrApiMember) {
         validateTalkPickId(talkPickId);
 
-        List<Comment> allComments = commentRepository.findByTalkPickIdOrderByLikesCountDescCreatedAtDesc(talkPickId,
+        List<Comment> allComments = commentRepository.findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtDesc(talkPickId,
                 LikeType.COMMENT);
         List<CommentDto.CommentResponse> bestComments = new ArrayList<>();
         List<CommentDto.CommentResponse> otherComments = new ArrayList<>();

--- a/src/main/java/balancetalk/comment/domain/Comment.java
+++ b/src/main/java/balancetalk/comment/domain/Comment.java
@@ -81,6 +81,10 @@ public class Comment extends BaseTimeEntity {
 
     private LocalDateTime editedAt;
 
+    public boolean isEdited() {
+        return this.editedAt != null;
+    }
+
     public void updateContent(String content) {
         this.content = content;
         this.editedAt = LocalDateTime.now();

--- a/src/main/java/balancetalk/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/comment/domain/CommentRepository.java
@@ -10,13 +10,18 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Page<Comment> findAllByTalkPickId(Long talkPickId, Pageable pageable);
+    Page<Comment> findAllByTalkPickIdAndParentIsNull(Long talkPickId, Pageable pageable);
 
+    @Query("SELECT c FROM Comment c WHERE c.parent.id = :parentId " +
+            "ORDER BY CASE WHEN c.member.id = :currentMemberId THEN 0 ELSE 1 END, c.createdAt ASC")
+    Page<Comment> findAllRepliesByParentIdOrderByMemberAndCreatedAt(@Param("parentId") Long parentId,
+                                                               @Param("currentMemberId") Long currentMemberId,
+                                                               Pageable pageable);
     @Query("SELECT c FROM Comment c LEFT JOIN Like l ON c.id = l.resourceId AND l.likeType = :likeType " +
             "WHERE c.talkPick.id = :talkPickId " +
             "GROUP BY c " +
             "ORDER BY COUNT(l) DESC, c.createdAt DESC")
-    List<Comment> findByTalkPickIdOrderByLikesCountDescCreatedAtDesc(@Param("talkPickId") Long talkPickId,
+    List<Comment> findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtDesc(@Param("talkPickId") Long talkPickId,
                                                                      @Param("likeType") LikeType likeType);
 
     @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.talkPick IS NOT NULL " +

--- a/src/main/java/balancetalk/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/comment/domain/CommentRepository.java
@@ -18,10 +18,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                                                                @Param("currentMemberId") Long currentMemberId,
                                                                Pageable pageable);
     @Query("SELECT c FROM Comment c LEFT JOIN Like l ON c.id = l.resourceId AND l.likeType = :likeType " +
-            "WHERE c.talkPick.id = :talkPickId " +
+            "WHERE c.talkPick.id = :talkPickId AND c.parent IS NULL " +
             "GROUP BY c " +
-            "ORDER BY COUNT(l) DESC, c.createdAt DESC")
-    List<Comment> findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtDesc(@Param("talkPickId") Long talkPickId,
+            "ORDER BY COUNT(l) DESC, c.createdAt ASC")
+    List<Comment> findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtAsc(@Param("talkPickId") Long talkPickId,
                                                                      @Param("likeType") LikeType likeType);
 
     @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.talkPick IS NOT NULL " +

--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -5,6 +5,8 @@ import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.ViewStatus;
 import balancetalk.vote.domain.VoteOption;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -72,6 +74,7 @@ public class CommentDto {
     @Data
     @AllArgsConstructor
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "댓글 조회 응답")
     public static class CommentResponse {
 
@@ -86,6 +89,9 @@ public class CommentDto {
 
         @Schema(description = "댓글 작성자", example = "운영자1")
         private String nickname;
+
+        @Schema(description = "댓글 작성자 프로필 이미지", example = "https://balancetalk.com/profile/1")
+        private String profileImage;
 
         @Schema(description = "댓글 내용", example = "너는나를존중해야한다나는발롱도르5개와수많은개인트로피를들어올렸으며"
                 + "2016유로에서포르투갈을이끌고우승을차지했고동시에A매치역대최다득점자이다")
@@ -112,13 +118,18 @@ public class CommentDto {
         @Schema(description = "댓글 블라인드 처리 여부", example = "false")
         private boolean isBlind;
 
+        @Schema(description = "댓글 수정 여부", example = "false")
+        private boolean isEdited;
+
         @Schema(description = "댓글이 신고당한 횟수", example = "0")
         private int reportedCount;
 
         @Schema(description = "댓글 생성 날짜")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd hh:mm")
         private LocalDateTime createdAt;
 
         @Schema(description = "댓글 수정 날짜")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd hh:mm")
         private LocalDateTime lastModifiedAt;
 
         public static CommentResponse fromEntity(Comment comment, int likesCount, boolean myLike) {
@@ -126,7 +137,9 @@ public class CommentDto {
                     .id(comment.getId())
                     .content(comment.getContent())
                     .nickname(comment.getMember().getNickname())
+                    .profileImage(comment.getMember().getProfileImgUrl())
                     .talkPickId(comment.getTalkPick().getId())
+                    .talkPickTitle(comment.getTalkPick().getTitle())
                     .option(comment.getVoteOption())
                     .likesCount(likesCount)
                     .myLike(myLike)
@@ -135,6 +148,7 @@ public class CommentDto {
                     .reportedCount(comment.getReportedCount())
                     .isBest(comment.getIsBest())
                     .isBlind(comment.isBlind())
+                    .isEdited(comment.isEdited())
                     .createdAt(comment.getCreatedAt())
                     .lastModifiedAt(comment.getLastModifiedAt())
                     .build();

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -42,7 +42,7 @@ public class CommentController {
     }
 
     @GetMapping
-    @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 최신순으로 정렬해 조회한다.")
+    @Operation(summary = "최신 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글을 최신순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllCommentsByPostIdSortedByCreatedAt(@PathVariable Long talkPickId, Pageable pageable,
                                                                           @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         Pageable sortedByCreatedAtDesc = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
@@ -51,10 +51,18 @@ public class CommentController {
     }
 
     @GetMapping("/best")
-    @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글 및 답글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
+    @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
     public Page<CommentResponse> findAllBestCommentsByPostId(@PathVariable Long talkPickId, Pageable pageable,
                                                              @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
         return commentService.findAllBestComments(talkPickId, pageable, guestOrApiMember);
+    }
+
+    @GetMapping("/{commentId}/replies")
+    @Operation(summary = "답글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 댓글인 comment-id에 존재하는 모든 답글을 조회한다.")
+    public Page<CommentResponse> findAllRepliesByCommentId(@PathVariable Long commentId, @PathVariable Long talkPickId,
+                                                           Pageable pageable,
+                                                           @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
+        return commentService.findAllReplies(commentId, talkPickId, pageable, guestOrApiMember);
     }
 
     @PutMapping("/{commentId}")


### PR DESCRIPTION
## 💡 작업 내용
- [x] Parent 기반 답글 조회 JPA 메서드 작성
- [x] 답글 목록 조회 API 분리
- [x] 댓글 조회 시 추가 정보 반환 및 날짜 형식 변경
- [x] Best 댓글 조회 시 오름차순 정렬

## 💡 자세한 설명
### postman 테스트 완료

### Parent 기반 답글 조회 JPA 메서드 작성, 답글 API 구현
```java
Page<Comment> findAllByTalkPickIdAndParentIsNull(Long talkPickId, Pageable pageable);

    @Query("SELECT c FROM Comment c WHERE c.parent.id = :parentId " +
            "ORDER BY CASE WHEN c.member.id = :currentMemberId THEN 0 ELSE 1 END, c.createdAt ASC")
    Page<Comment> findAllRepliesByParentIdOrderByMemberAndCreatedAt(@Param("parentId") Long parentId,
                                                               @Param("currentMemberId") Long currentMemberId,
                                                               Pageable pageable);
    @Query("SELECT c FROM Comment c LEFT JOIN Like l ON c.id = l.resourceId AND l.likeType = :likeType " +
            "WHERE c.talkPick.id = :talkPickId AND c.parent IS NULL " +
            "GROUP BY c " +
            "ORDER BY COUNT(l) DESC, c.createdAt ASC")
    List<Comment> findByTalkPickIdAndParentIsNullOrderByLikesCountDescCreatedAtAsc(@Param("talkPickId") Long talkPickId,
                                                                     @Param("likeType") LikeType likeType);
```

댓글 기능에서 완전히 답글을 분리하려면 마이페이지, 알림 기능까지 수정해야 했습니다.
현재 답글 기능 분리가 필요한 이유는 '답글 조회' 때문이므로, 답글과 댓글을 구분하는 `parent(부모 댓글)` 존재 여부를 기반으로 답글을 조회하는 메서드를 새로 만들었습니다.

만약 추후 '답글' 이 더 많은 기능들과 연관이 되거나, 기능이 추가가 된다면 댓글 기능에서 아예 분리해야겠지만, 현재로서는 기능명세에 따라 '답글 조회' 만을 기존의 '댓글 조회' 에서 분리하는 것으로 마무리 했습니다.

### 댓글 조회 시 추가 정보 반환 및 날짜 형식 변경
기획 디벨롭에 따라, 클라이언트가 추가로 필요한 정보들을 반환하고, 날짜 형식을 변경했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #599
