### PR TITLE
톡픽 생성 API 응답을 톡픽 ID로 변경

### DIFF
--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -32,10 +32,12 @@ public class TalkPickService {
     private final FileRepository fileRepository;
 
     @Transactional
-    public void createTalkPick(CreateOrUpdateTalkPickRequest request, ApiMember apiMember) {
+    public Long createTalkPick(CreateOrUpdateTalkPickRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         TalkPick savedTalkPick = talkPickRepository.save(request.toEntity(member));
         fileRepository.updateResourceIdAndTypeByStoredNames(savedTalkPick.getId(), FileType.TALK_PICK, request.getStoredNames());
+
+        return savedTalkPick.getId();
     }
 
     @Transactional

--- a/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
@@ -31,8 +31,8 @@ public class TempTalkPickService {
         Member member = apiMember.toMember(memberRepository);
 
         if (member.hasTempTalkPick()) {
-            Long prevTempTalkPickId = member.updateTempTalkPick(request.toEntity(member));
-            updateFileResourceIdByStoredNames(prevTempTalkPickId, request.getStoredNames());
+            Long tempTalkPickId = member.updateTempTalkPick(request.toEntity(member));
+            updateFileResourceIdByStoredNames(tempTalkPickId, request.getStoredNames());
             return;
         }
 

--- a/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
@@ -28,9 +28,9 @@ public class TalkPickController {
 
     @Operation(summary = "톡픽 생성", description = "톡픽을 생성합니다.")
     @PostMapping
-    public void createTalkPick(@RequestBody final CreateOrUpdateTalkPickRequest request,
+    public Long createTalkPick(@RequestBody final CreateOrUpdateTalkPickRequest request,
                                @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
-        talkPickService.createTalkPick(request, apiMember);
+        return talkPickService.createTalkPick(request, apiMember);
     }
 
     @Operation(summary = "톡픽 상세 조회", description = "톡픽 상세 페이지를 조회합니다.")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 생성 API 응답을 톡픽 ID로 변경
- [x] 변수명 개선

## 💡 자세한 설명
클라이언트에서 톡픽 요약 API 요청을 하려면, 앞서 생성된 톡픽의 ID를 전달해야 합니다.
따라서 톡픽 생성 API가 생성한 톡픽 ID를 반환하도록 응답을 수정했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #606 
