### PR TITLE
마이페이지 - 내가 저장한 밸런스게임 기능 수정 및 투표 중도 복귀 기능 구현

### DIFF
--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -39,7 +39,6 @@ public class BookmarkGameService {
     private final NotificationService notificationService;
 
     public void createBookmark(final Long gameSetId, final Long gameId, final ApiMember apiMember) {
-
         GameSet gameSet = gameReader.findGameSetById(gameSetId);
         Member member = apiMember.toMember(memberRepository);
 

--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -76,12 +76,12 @@ public class BookmarkGameService {
         }
         bookmark.deactivate();
         gameSet.decreaseBookmarks();
-        sendBookmarkGameNotification(gameSet); // FIXME: 위임 후 대기, 알림 기준이 밸런스게임인지, 밸런스게임 세트인지에 따라 적용
+        // sendBookmarkGameNotification(gameSet); // FIXME: 위임 후 대기, 알림 기준이 밸런스게임인지, 밸런스게임 세트인지에 따라 적용
     }
 
     private void sendBookmarkGameNotification(Game game) {
         Member member = null; // FIXME: 위임 후 대기, 알림 기준이 밸런스게임인지, 밸런스게임 세트인지에 따라 적용
-        long bookmarkedCount = game.getBookmarks();
+        long bookmarkedCount = game.getGameSet().getBookmarks();
         String bookmarkCountKey = "BOOKMARK_" + bookmarkedCount;
         Map<String, Boolean> notificationHistory = game.getNotificationHistory();
         String category = WRITTEN_GAME.getCategory();

--- a/src/main/java/balancetalk/bookmark/domain/Bookmark.java
+++ b/src/main/java/balancetalk/bookmark/domain/Bookmark.java
@@ -68,4 +68,8 @@ public class Bookmark extends BaseTimeEntity {
     public void updateGameId(Long gameId) {
         this.gameId = gameId;
     }
+
+    public boolean isEndGameSet() {
+        return gameId == -1L;
+    }
 }

--- a/src/main/java/balancetalk/bookmark/domain/Bookmark.java
+++ b/src/main/java/balancetalk/bookmark/domain/Bookmark.java
@@ -30,6 +30,9 @@ public class Bookmark extends BaseTimeEntity {
     private Boolean active;
 
     @NotNull
+    private Boolean isEndGameSet;
+
+    @NotNull
     @Enumerated(EnumType.STRING)
     private BookmarkType bookmarkType;
 
@@ -69,7 +72,7 @@ public class Bookmark extends BaseTimeEntity {
         this.gameId = gameId;
     }
 
-    public boolean isEndGameSet() {
-        return gameId == -1L;
+    public void setEndGameSet() {
+        this.isEndGameSet = true;
     }
 }

--- a/src/main/java/balancetalk/bookmark/domain/Bookmark.java
+++ b/src/main/java/balancetalk/bookmark/domain/Bookmark.java
@@ -24,6 +24,8 @@ public class Bookmark extends BaseTimeEntity {
     @NotNull
     private Long resourceId;
 
+    private Long gameId;
+
     @NotNull
     private Boolean active;
 
@@ -31,12 +33,20 @@ public class Bookmark extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private BookmarkType bookmarkType;
 
+    public boolean matches(long resourceId, long gameId, BookmarkType bookmarkType) {
+        return isEqualsResourceId(resourceId) && isEqualsGameId(gameId) && isEqualsType(bookmarkType);
+    }
+
     public boolean matches(long resourceId, BookmarkType bookmarkType) {
         return isEqualsResourceId(resourceId) && isEqualsType(bookmarkType);
     }
 
     private boolean isEqualsResourceId(long resourceId) {
         return this.resourceId.equals(resourceId);
+    }
+
+    private boolean isEqualsGameId(long gameId) {
+        return this.gameId.equals(gameId);
     }
 
     private boolean isEqualsType(BookmarkType bookmarkType) {
@@ -53,5 +63,9 @@ public class Bookmark extends BaseTimeEntity {
 
     public void deactivate() {
         this.active = false;
+    }
+
+    public void updateGameId(Long gameId) {
+        this.gameId = gameId;
     }
 }

--- a/src/main/java/balancetalk/bookmark/domain/BookmarkGenerator.java
+++ b/src/main/java/balancetalk/bookmark/domain/BookmarkGenerator.java
@@ -14,4 +14,14 @@ public class BookmarkGenerator {
                 .active(true)
                 .build();
     }
+
+    public Bookmark generate(final long resourceId, final long gameId, final BookmarkType bookmarkType, final Member member) {
+        return Bookmark.builder()
+                .member(member)
+                .resourceId(resourceId)
+                .gameId(gameId)
+                .bookmarkType(bookmarkType)
+                .active(true)
+                .build();
+    }
 }

--- a/src/main/java/balancetalk/bookmark/domain/BookmarkGenerator.java
+++ b/src/main/java/balancetalk/bookmark/domain/BookmarkGenerator.java
@@ -22,6 +22,7 @@ public class BookmarkGenerator {
                 .gameId(gameId)
                 .bookmarkType(bookmarkType)
                 .active(true)
+                .isEndGameSet(false)
                 .build();
     }
 }

--- a/src/main/java/balancetalk/bookmark/domain/BookmarkRepository.java
+++ b/src/main/java/balancetalk/bookmark/domain/BookmarkRepository.java
@@ -1,18 +1,19 @@
 package balancetalk.bookmark.domain;
 
 import balancetalk.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     @Query("SELECT b FROM Bookmark b WHERE b.member = :member AND b.bookmarkType = :bookmarkType AND b.active = true ORDER BY b.lastModifiedAt DESC")
     Page<Bookmark> findActivatedByMemberOrderByDesc(@Param("member") Member member, @Param("bookmarkType") BookmarkType bookmarkType,
                                                     Pageable pageable);
+
+    Optional<Bookmark> findByMemberAndResourceIdAndBookmarkType(Member member, Long resourceId, BookmarkType bookmarkType);
 
 }

--- a/src/main/java/balancetalk/bookmark/domain/BookmarkType.java
+++ b/src/main/java/balancetalk/bookmark/domain/BookmarkType.java
@@ -1,5 +1,5 @@
 package balancetalk.bookmark.domain;
 
 public enum BookmarkType {
-    TALK_PICK, GAME
+    TALK_PICK, GAME_SET
 }

--- a/src/main/java/balancetalk/bookmark/presentation/BookmarkGameController.java
+++ b/src/main/java/balancetalk/bookmark/presentation/BookmarkGameController.java
@@ -13,23 +13,23 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/bookmarks/games/{gameId}")
+@RequestMapping("/bookmarks/gameSets/{gameSetId}")
 @Tag(name = "bookmark", description = "북마크 API")
 public class BookmarkGameController {
 
     private final BookmarkGameService bookmarkGameService;
 
-    @Operation(summary = "밸런스 게임 북마크", description = "밸런스 게임 북마크를 활성화합니다.")
-    @PostMapping
-    public void bookmarkGame(@PathVariable final Long gameId,
+    @Operation(summary = "밸런스게임 세트 북마크 추가", description = "밸런스게임 세트에 북마크를 추가합니다. (만약 전체 게임 완료 후 북마크를 추가할 경우, gameId를 -1로 보내주세요.)")
+    @PostMapping("/games/{gameId}")
+    public void bookmarkGame(@PathVariable final Long gameSetId, @PathVariable final Long gameId,
                              @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
-        bookmarkGameService.createBookmark(gameId, apiMember);
+        bookmarkGameService.createBookmark(gameSetId, gameId, apiMember);
     }
 
-    @Operation(summary = "밸런스 게임 북마크 취소", description = "밸런스 게임 북마크를 취소합니다.")
+    @Operation(summary = "밸런스게임 세트 북마크 취소", description = "밸런스게임 세트에 북마크를 취소합니다.")
     @DeleteMapping
-    public void deleteBookmarkGame(@PathVariable final Long gameId,
+    public void deleteBookmarkGame(@PathVariable final Long gameSetId,
                                    @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
-        bookmarkGameService.deleteBookmark(gameId, apiMember);
+        bookmarkGameService.deleteBookmark(gameSetId, apiMember);
     }
 }

--- a/src/main/java/balancetalk/bookmark/presentation/BookmarkGameController.java
+++ b/src/main/java/balancetalk/bookmark/presentation/BookmarkGameController.java
@@ -19,11 +19,18 @@ public class BookmarkGameController {
 
     private final BookmarkGameService bookmarkGameService;
 
-    @Operation(summary = "밸런스게임 세트 북마크 추가", description = "밸런스게임 세트에 북마크를 추가합니다. (만약 전체 게임 완료 후 북마크를 추가할 경우, gameId를 -1로 보내주세요.)")
+    @Operation(summary = "밸런스게임 세트 북마크 추가", description = "밸런스게임 세트에 북마크를 추가합니다.")
     @PostMapping("/games/{gameId}")
-    public void bookmarkGame(@PathVariable final Long gameSetId, @PathVariable final Long gameId,
-                             @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+    public void bookmarkGameSet(@PathVariable final Long gameSetId, @PathVariable final Long gameId,
+                                @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         bookmarkGameService.createBookmark(gameSetId, gameId, apiMember);
+    }
+
+    @Operation(summary = "투표 완료한 밸런스게임 세트 북마크 추가", description = "전체 투표를 완료한 밸런스게임 세트에 북마크를 추가합니다. ")
+    @PostMapping()
+    public void bookmarkEndGameSet(@PathVariable final Long gameSetId,
+                                   @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        bookmarkGameService.createEndGameSetBookmark(gameSetId, apiMember);
     }
 
     @Operation(summary = "밸런스게임 세트 북마크 취소", description = "밸런스게임 세트에 북마크를 취소합니다.")

--- a/src/main/java/balancetalk/bookmark/presentation/BookmarkGameController.java
+++ b/src/main/java/balancetalk/bookmark/presentation/BookmarkGameController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/bookmarks/gameSets/{gameSetId}")
+@RequestMapping("/bookmarks/game-sets/{gameSetId}")
 @Tag(name = "bookmark", description = "북마크 API")
 public class BookmarkGameController {
 

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -1,6 +1,6 @@
 package balancetalk.game.application;
 
-import static balancetalk.bookmark.domain.BookmarkType.GAME;
+import static balancetalk.bookmark.domain.BookmarkType.GAME_SET;
 
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameOption;
@@ -85,7 +85,7 @@ public class GameService {
         Map<Long, VoteOption> voteOptionMap = new ConcurrentHashMap<>();
 
         for (Game game : games) {
-            boolean hasBookmarked = member.hasBookmarked(game.getId(), GAME);
+            boolean hasBookmarked = member.hasBookmarked(game.getId(), GAME_SET); //FIXME: 여기도 체크
             bookmarkMap.put(game.getId(), hasBookmarked);
             Optional<GameVote> myVote = member.getVoteOnGameOption(member, game);
             if (myVote.isPresent()) {

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -88,7 +88,7 @@ public class GameService {
         Map<Long, VoteOption> voteOptionMap = new ConcurrentHashMap<>();
 
         boolean isEndGameSet = bookmarkRepository.findByMemberAndResourceIdAndBookmarkType(member, gameSetId, GAME_SET)
-                .map(Bookmark::isEndGameSet)
+                .map(Bookmark::getIsEndGameSet)
                 .orElse(false);
 
         for (Game game : games) {

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -51,9 +51,6 @@ public class Game extends BaseTimeEntity {
     private String description;
 
     private LocalDateTime editedAt;
-    @PositiveOrZero
-    @ColumnDefault("0")
-    private Long bookmarks;
 
     @Column(columnDefinition = "TEXT")
     private String notificationHistory;
@@ -71,14 +68,6 @@ public class Game extends BaseTimeEntity {
         // this.optionA = optionA;
         // this.optionB = optionB;
         this.editedAt = LocalDateTime.now();
-    }
-
-    public void increaseBookmarks() {
-        this.bookmarks++;
-    }
-
-    public void decreaseBookmarks() {
-        this.bookmarks--;
     }
 
     public void addGameSet(GameSet gameSet) {

--- a/src/main/java/balancetalk/game/domain/GameReader.java
+++ b/src/main/java/balancetalk/game/domain/GameReader.java
@@ -1,6 +1,7 @@
 package balancetalk.game.domain;
 
 import balancetalk.game.domain.repository.GameRepository;
+import balancetalk.game.domain.repository.GameSetRepository;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +12,14 @@ import org.springframework.stereotype.Component;
 public class GameReader {
 
     private final GameRepository gameRepository;
+    private final GameSetRepository gameSetRepository;
 
-    public Game readById(Long gameId) {
+    public GameSet findGameSetById(Long gameSetId) {
+        return gameSetRepository.findById(gameSetId)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME_SET));
+    }
+
+    public Game findGameById(Long gameId) {
         return gameRepository.findById(gameId)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME));
     }

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -53,7 +53,20 @@ public class GameSet extends BaseTimeEntity {
     @Size(max = 10)
     private String subTag;
 
+    @PositiveOrZero
+    @ColumnDefault("0")
+    private Long bookmarks;
+
     public void increaseViews() {
         this.views++;
     }
+
+    public void increaseBookmarks() {
+        this.bookmarks++;
+    }
+
+    public void decreaseBookmarks() {
+        this.bookmarks--;
+    }
+
 }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -39,7 +39,6 @@ public class GameDto {
                     .title(title)
                     .description(description)
                     .gameOptions(gameOptions.stream().map(GameOptionDto::toEntity).toList())
-                    .bookmarks(0L)
                     .editedAt(LocalDateTime.now())
                     .build();
         }
@@ -143,8 +142,11 @@ public class GameDto {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class GameMyPageResponse {
 
+        @Schema(description = "밸런스 게임 세트 ID", example = "1")
+        private long gameSetId;
+
         @Schema(description = "밸런스 게임 ID", example = "1")
-        private long id;
+        private long gameId;
 
         @Schema(description = "밸런스 게임 제목", example = "제목")
         private String title;
@@ -165,46 +167,47 @@ public class GameDto {
         @Schema(description = "북마크 여부")
         private boolean isBookmarked;
 
-//        @Schema(description = "밸런스 게임 서브 태그", example = "화제의 중심")
-//        private String subTag;
-//
-//        @Schema(description = "밸런스 게임 메인 태그", example = "인기")
-//        private String mainTag;
+        @Schema(description = "밸런스 게임 서브 태그", example = "화제의 중심")
+        private String subTag;
+
+        @Schema(description = "밸런스 게임 메인 태그", example = "인기")
+        private MainTag mainTag;
 
         public static GameMyPageResponse from(Game game) {
             return GameMyPageResponse.builder()
-                    .id(game.getId())
+                    .gameId(game.getId())
                     .title(game.getTitle())
                     .optionAImg(game.getGameOptions().get(0).getImgUrl())
                     .optionBImg(game.getGameOptions().get(1).getImgUrl())
-//                    .subTag(game.getSubTag())
-//                    .mainTag(game.getMainTag().getName())
+                    .subTag(game.getGameSet().getSubTag())
+                    .mainTag(game.getGameSet().getMainTag())
                     .editedAt(game.getEditedAt())
                     .build();
         }
 
         public static GameMyPageResponse from(Game game, Bookmark bookmark) {
             return GameMyPageResponse.builder()
-                    .id(game.getId())
+                    .gameSetId(game.getGameSet().getId())
+                    .gameId(game.getId())
                     .title(game.getTitle())
                     .optionAImg(game.getGameOptions().get(0).getImgUrl())
                     .optionBImg(game.getGameOptions().get(1).getImgUrl())
                     .isBookmarked(bookmark.isActive())
-//                    .subTag(game.getSubTag())
-//                    .mainTag(game.getMainTag().getName())
+                    .subTag(game.getGameSet().getSubTag())
+                    .mainTag(game.getGameSet().getMainTag())
                     .editedAt(game.getEditedAt())
                     .build();
         }
 
         public static GameMyPageResponse from(Game game, GameVote vote) {
             return GameMyPageResponse.builder()
-                    .id(game.getId())
+                    .gameId(game.getId())
                     .title(game.getTitle())
                     .optionAImg(game.getGameOptions().get(0).getImgUrl())
                     .optionBImg(game.getGameOptions().get(1).getImgUrl())
                     .voteOption(vote.getVoteOption())
-//                    .subTag(game.getSubTag())
-//                    .mainTag(game.getMainTag().getName())
+                    .subTag(game.getGameSet().getSubTag())
+                    .mainTag(game.getGameSet().getMainTag())
                     .editedAt(game.getEditedAt())
                     .build();
         }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -170,8 +170,8 @@ public class GameDto {
         @Schema(description = "밸런스 게임 서브 태그", example = "화제의 중심")
         private String subTag;
 
-        @Schema(description = "밸런스 게임 메인 태그", example = "인기")
-        private MainTag mainTag;
+        @Schema(description = "밸런스 게임 메인 태그 이름", example = "인기")
+        private String mainTagName;
 
         public static GameMyPageResponse from(Game game) {
             return GameMyPageResponse.builder()
@@ -180,7 +180,7 @@ public class GameDto {
                     .optionAImg(game.getGameOptions().get(0).getImgUrl())
                     .optionBImg(game.getGameOptions().get(1).getImgUrl())
                     .subTag(game.getGameSet().getSubTag())
-                    .mainTag(game.getGameSet().getMainTag())
+                    .mainTagName(game.getGameSet().getMainTag().getName())
                     .editedAt(game.getEditedAt())
                     .build();
         }
@@ -194,7 +194,7 @@ public class GameDto {
                     .optionBImg(game.getGameOptions().get(1).getImgUrl())
                     .isBookmarked(bookmark.isActive())
                     .subTag(game.getGameSet().getSubTag())
-                    .mainTag(game.getGameSet().getMainTag())
+                    .mainTagName(game.getGameSet().getMainTag().getName())
                     .editedAt(game.getEditedAt())
                     .build();
         }
@@ -207,7 +207,7 @@ public class GameDto {
                     .optionBImg(game.getGameOptions().get(1).getImgUrl())
                     .voteOption(vote.getVoteOption())
                     .subTag(game.getGameSet().getSubTag())
-                    .mainTag(game.getGameSet().getMainTag())
+                    .mainTagName(game.getGameSet().getMainTag().getName())
                     .editedAt(game.getEditedAt())
                     .build();
         }

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -85,8 +85,26 @@ public class GameSetDto {
 
         private List<GameDetailResponse> gameDetailResponses;
 
-        public static GameSetDetailResponse fromEntity(GameSet gameSet, Map<Long, Boolean> bookmarkMap, Map<Long, VoteOption> voteOptionMap) {
+        @Schema(description = "밸런스게임 세트 전체 투표 완료 여부", example = "false")
+        private boolean isEndGameSet;
+
+        public static GameSetDetailResponse fromEntity(GameSet gameSet, Map<Long, Boolean> bookmarkMap,
+                                                       Map<Long, VoteOption> voteOptionMap, boolean isEndGameSet) {
+
+            if (!isEndGameSet) {
+                // voteOption을 null로 반환
+                return GameSetDetailResponse.builder()
+                        .isEndGameSet(false)
+                        .gameDetailResponses(gameSet.getGames().stream()
+                                .map(game -> GameDetailResponse.fromEntity(game,
+                                        bookmarkMap.getOrDefault(game.getId(), false),
+                                        null)) // TODO : 끝까지 투표했을 경우, 투표옵션이 NULL로 되는지 체크.
+                                .toList())
+                        .build();
+            }
+
             return GameSetDetailResponse.builder()
+                    .isEndGameSet(true)
                     .gameDetailResponses(gameSet.getGames().stream()
                             .map(game -> GameDetailResponse.fromEntity(game,
                                     bookmarkMap.getOrDefault(game.getId(), false),

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -35,6 +35,7 @@ public class GameSetDto {
                     .subTag(subTag)
                     .member(member)
                     .games(games.stream().map(CreateGameRequest::toEntity).toList())
+                    .bookmarks(0L)
                     .build();
         }
     }

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -91,10 +91,10 @@ public class GameSetDto {
         public static GameSetDetailResponse fromEntity(GameSet gameSet, Map<Long, Boolean> bookmarkMap,
                                                        Map<Long, VoteOption> voteOptionMap, boolean isEndGameSet) {
 
-            if (!isEndGameSet) {
+            if (isEndGameSet) {
                 // voteOption을 null로 반환
                 return GameSetDetailResponse.builder()
-                        .isEndGameSet(false)
+                        .isEndGameSet(true)
                         .gameDetailResponses(gameSet.getGames().stream()
                                 .map(game -> GameDetailResponse.fromEntity(game,
                                         bookmarkMap.getOrDefault(game.getId(), false),
@@ -104,7 +104,7 @@ public class GameSetDto {
             }
 
             return GameSetDetailResponse.builder()
-                    .isEndGameSet(true)
+                    .isEndGameSet(false)
                     .gameDetailResponses(gameSet.getGames().stream()
                             .map(game -> GameDetailResponse.fromEntity(game,
                                     bookmarkMap.getOrDefault(game.getId(), false),

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -7,6 +7,7 @@ import balancetalk.game.dto.GameDto.CreateGameRequest;
 import balancetalk.game.dto.GameDto.GameDetailResponse;
 import balancetalk.member.domain.Member;
 import balancetalk.vote.domain.VoteOption;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,6 +87,7 @@ public class GameSetDto {
         private List<GameDetailResponse> gameDetailResponses;
 
         @Schema(description = "밸런스게임 세트 전체 투표 완료 여부", example = "false")
+        @JsonProperty("isEndGameSet")
         private boolean isEndGameSet;
 
         public static GameSetDetailResponse fromEntity(GameSet gameSet, Map<Long, Boolean> bookmarkMap,

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -93,11 +93,11 @@ public class MyPageService {
 
     public Page<GameMyPageResponse> findAllBookmarkedGames(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
-        Page<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.GAME, pageable);
+        Page<Bookmark> bookmarks = bookmarkRepository.findActivatedByMemberOrderByDesc(member, BookmarkType.GAME_SET, pageable);
 
         List<GameMyPageResponse> responses = bookmarks.stream()
                 .map(bookmark -> {
-                    Game game = gameRepository.findById(bookmark.getResourceId())
+                    Game game = gameRepository.findById(bookmark.getGameId())
                             .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME));
                     return GameMyPageResponse.from(game, bookmark);
                 })

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -97,7 +97,7 @@ public class MyPageService {
 
         List<GameMyPageResponse> responses = bookmarks.stream()
                 .map(bookmark -> {
-                    Game game = gameRepository.findById(bookmark.getGameId())
+                    Game game = gameRepository.findById(bookmark.getGameId()) // 사용자가 북마크한 위치의 밸런스게임을 찾음
                             .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME));
                     return GameMyPageResponse.from(game, bookmark);
                 })

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -124,9 +124,8 @@ public class Member extends BaseTimeEntity {
         return talkPicks.contains(talkPick);
     }
 
-    public boolean isMyGame(Game game) {
-        return gameSets.stream()
-                .anyMatch(gameSet -> gameSet.getGames().contains(game));
+    public boolean isMyGameSet(GameSet gameSet) {
+        return gameSets.contains(gameSet);
     }
 
     public Optional<Bookmark> getBookmarkOf(long resourceId, BookmarkType type) {

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -85,6 +85,11 @@ public class Member extends BaseTimeEntity {
         this.profileImgUrl = profileImgUrl;
     }
 
+    public boolean hasBookmarked(Long resourceId, Long gameId, BookmarkType bookmarkType) {
+        return this.bookmarks.stream()
+                .anyMatch(bookmark -> bookmark.matches(resourceId, gameId, bookmarkType) && bookmark.isActive());
+    }
+
     public boolean hasBookmarked(Long resourceId, BookmarkType bookmarkType) {
         return this.bookmarks.stream()
                 .anyMatch(bookmark -> bookmark.matches(resourceId, bookmarkType) && bookmark.isActive());

--- a/src/main/java/balancetalk/vote/application/VoteGameService.java
+++ b/src/main/java/balancetalk/vote/application/VoteGameService.java
@@ -41,7 +41,7 @@ public class VoteGameService {
     private final NotificationService notificationService;
 
     public void createVote(Long gameId, VoteRequest request, GuestOrApiMember guestOrApiMember) {
-        Game game = gameReader.readById(gameId);
+        Game game = gameReader.findGameById(gameId);
         GameOption gameOption = getGameOption(game, request);
 
         if (guestOrApiMember.isGuest()) {
@@ -58,7 +58,7 @@ public class VoteGameService {
     }
 
     public void updateVote(Long gameId, VoteRequest request, ApiMember apiMember) {
-        Game game = gameReader.readById(gameId);
+        Game game = gameReader.findGameById(gameId);
 
         Member member = apiMember.toMember(memberRepository);
 
@@ -82,7 +82,7 @@ public class VoteGameService {
     }
 
     public void deleteVote(Long gameId, ApiMember apiMember) {
-        Game game = gameReader.readById(gameId);
+        Game game = gameReader.findGameById(gameId);
 
         Member member = apiMember.toMember(memberRepository);
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 북마크 Game -> GameSet 수정
- [x] 마이페이지에 저장한 밸런스게임 조회 시 밸런스게임 id 기준으로 찾도록 수정
- [x] 밸런스게임 세트 전체 투표 완료 여부 기능 구현
- [x] 밸런스게임 투표 중도 복귀 기능 구현
- [x] 밸런스게임 전체 완료 시 북마크 API 구현

## 💡 자세한 설명
### postman 테스트 완료

너무 많은 곳을 수정해서, 밸런스게임 북마크 로직 실행 순서를 따라 설명하겠습니다.

먼저, `createBookmark()` 메서드 입니다.
예외처리 후, 해당 멤버가 해당 GameSet에 대해 북마크가 이미 존재한다면, 해당 `Bookmark` 엔티티가 가지는 `gameId` 필드를 업데이트 합니다. 

만약 북마크가 존재하지 않는다면, 새로 북마크를 생성하고, 이 경우에만 해당 `GameSet` 의 `bookmarks` 수를 증가시킵니다. 

```java
public void createBookmark(final Long gameSetId, Long gameId, final ApiMember apiMember) {
        GameSet gameSet = gameReader.findGameSetById(gameSetId);
        Member member = apiMember.toMember(memberRepository);

        if (member.isMyGameSet(gameSet)) {
            throw new BalanceTalkException(ErrorCode.CANNOT_BOOKMARK_MY_RESOURCE);
        }

        // 밸런스게임 세트, 게임 아이디가 모두 일치한다면 예외 처리
        if (member.hasBookmarked(gameSetId, gameId, GAME_SET)) {
            throw new BalanceTalkException(ErrorCode.ALREADY_BOOKMARKED);
        }

        // 해당 멤버가 가진 GameSet 북마크 중, resourceId가 gameSetId와 일치하는 북마크가 있다면
        member.getBookmarkOf(gameSetId, GAME_SET)
                .ifPresentOrElse(
                        bookmark -> {
                            bookmark.activate();
                            bookmark.updateGameId(gameId); //gameId도 업데이트
                        },
                        () -> { // resourceId가 gameSetId와 일치하는 북마크가 없다면 새로 생성
                            bookmarkRepository.save(bookmarkGenerator.generate(gameSetId, gameId, GAME_SET, member));
                            gameSet.increaseBookmarks();
                        });
    }
```
`gameId` 필드는 `Bookmark` 엔티티 내에 새로 추가된 필드로, 북마크 버튼을 누른 `단건 밸런스게임` 의 id 값을 저장합니다.
이 값은 톡픽 북마크일 경우에는 존재하지 않으므로, Nullable 입니다.

이 `gameId` 값은, 투표 도중 저장 버튼을 눌렀을 때, 추후 해당 밸런스게임 세트로 재접속시 저장했던 `단건 밸런스게임` 으로 사용자를 이동시키는데 쓰입니다.

```java
public class Bookmark extends BaseTimeEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "id")
    private Long id;

...

    private Long gameId;
```
---

그 다음, `createEndGameSetBookmark()` 메서드 입니다.
이 메서드는 밸런스게임 세트의 모든 투표를 완료한 뒤 저장할 때 사용되는 메서드입니다.

위의 `createBookmark()` 메서드와는 다르게, 해당 북마크의 `isEndGameSet` 필드를 true로 바꿔주고, `gameId`를 **해당 밸런스게임 세트의 첫 번째 밸런스게임 id** 로 바꿔줍니다.

이로 인해서, 모든 투표가 완료된 후 저장할 경우 해당 밸런스게임 세트에 들어가면 첫 번째 밸런스게임이 보이도록 유도할 수 있습니다. 

```java
public void createEndGameSetBookmark(final Long gameSetId, final ApiMember apiMember) {
        GameSet gameSet = gameReader.findGameSetById(gameSetId);
        Member member = apiMember.toMember(memberRepository);

        if (member.isMyGameSet(gameSet)) {
            throw new BalanceTalkException(ErrorCode.CANNOT_BOOKMARK_MY_RESOURCE);
        }

        // gameId를 해당 밸런스게임 세트의 첫 번째 밸런스게임 id로 설정
        long gameId = getFirstGameIdOrThrow(gameSet);

        // 해당 멤버가 가진 GameSet 북마크 중, resourceId가 gameSetId와 일치하는 북마크가 있다면
        member.getBookmarkOf(gameSetId, GAME_SET)
                .ifPresentOrElse(
                        bookmark -> {
                            bookmark.activate();
                            bookmark.setEndGameSet(); // 밸런스게임 세트 종료 표시
                            bookmark.updateGameId(gameId); //gameId도 업데이트
                        },
                        () -> { // resourceId가 gameSetId와 일치하는 북마크가 없다면 새로 생성
                            bookmarkRepository.save(bookmarkGenerator.generate(gameSetId, gameId, GAME_SET, member));
                            gameSet.increaseBookmarks();
                        });
    }

    private Long getFirstGameIdOrThrow(GameSet gameSet) {
        return gameSet.getGames().stream()
                .findFirst()
                .map(Game::getId)
                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME));
    }
```

또한, 밸런스게임 세트의 모든 투표를 완료했다면, 사용자가 다시 그 밸런스게임 세트에 접속 시 투표 기록이 보이지 않아야 합니다. 그러나, 투표기록 자체가 DB에서 사라지지는 않아야 합니다. 이를 `isEndGameSet` 이 `true` 라면, DTO에서 `votedOption` 값을 전부 `null` 로 반환해줍니다.

다만, 이 경우에 밸런스게임 투표 생성 API를 실행하면 중복 투표 불가 예외처리가 발생하므로, 밸런스게임 투표 수정 API가 동작하도록 추가 구현해야 합니다.

```java
@Data
    @Builder
    @AllArgsConstructor
    @Schema(description = "밸런스 게임 세트 상세 조회 응답")
    public static class GameSetDetailResponse {

        private List<GameDetailResponse> gameDetailResponses;

        @Schema(description = "밸런스게임 세트 전체 투표 완료 여부", example = "false")
        @JsonProperty("isEndGameSet")
        private boolean isEndGameSet;

        public static GameSetDetailResponse fromEntity(GameSet gameSet, Map<Long, Boolean> bookmarkMap,
                                                       Map<Long, VoteOption> voteOptionMap, boolean isEndGameSet) {

            if (isEndGameSet) {
                // voteOption을 null로 반환
                return GameSetDetailResponse.builder()
                        .isEndGameSet(true)
                        .gameDetailResponses(gameSet.getGames().stream()
                                .map(game -> GameDetailResponse.fromEntity(game,
                                        bookmarkMap.getOrDefault(game.getId(), false),
                                        null)) // TODO : 끝까지 투표했을 경우, 투표옵션이 NULL로 되는지 체크.
                                .toList())
                        .build();
            }

            return GameSetDetailResponse.builder()
                    .isEndGameSet(false)
                    .gameDetailResponses(gameSet.getGames().stream()
                            .map(game -> GameDetailResponse.fromEntity(game,
                                    bookmarkMap.getOrDefault(game.getId(), false),
                                    voteOptionMap.get(game.getId())))
                            .toList())
                    .build();
        }
    }
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
1. 밸런스게임 세트 전체 투표 완료 시, 재투표 가능 처리 및 투표수 중복 카운트 기능 구현
2. 마이페이지 - 투표한 밸런스게임, 작성한 밸런스게임은 무조건 '첫 번째 밸런스게임' 보이도록 구현
3. 밸런스게임 세트 '투표 수' 가 '첫 번째 밸런스게임' 의 투표수와 같도록 구현
4. 알림 기능 수정

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #600 #601
