### PR TITLE
톡픽 본문 요약 요청 시 회원 구분 없이 가능하도록 개선

### DIFF
--- a/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
+++ b/src/main/java/balancetalk/talkpick/application/SummaryContentService.java
@@ -1,11 +1,9 @@
 package balancetalk.talkpick.application;
 
 import balancetalk.global.exception.BalanceTalkException;
-import balancetalk.member.domain.Member;
-import balancetalk.member.domain.MemberRepository;
-import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.domain.Summary;
 import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.talkpick.domain.TalkPickReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.retry.annotation.Backoff;
@@ -19,14 +17,13 @@ import static balancetalk.global.exception.ErrorCode.SUMMARY_SIZE_IS_OVER;
 @RequiredArgsConstructor
 public class SummaryContentService {
 
-    private final MemberRepository memberRepository;
+    private final TalkPickReader talkPickReader;
     private final ChatClient chatClient;
 
     @Retryable(backoff = @Backoff(delay = 1000))
     @Transactional
-    public void summaryContent(long talkPickId, ApiMember apiMember) {
-        Member member = apiMember.toMember(memberRepository);
-        TalkPick talkPick = member.getTalkPickById(talkPickId);
+    public void summaryContent(long talkPickId) {
+        TalkPick talkPick = talkPickReader.readById(talkPickId);
 
         Summary summary = chatClient.prompt()
                 .system("- 당신의 역할은 사용자가 입력한 문장을 3줄로 요약하는 것입니다.\n" +

--- a/src/main/java/balancetalk/talkpick/presentation/SummaryContentController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/SummaryContentController.java
@@ -1,10 +1,7 @@
 package balancetalk.talkpick.presentation;
 
-import balancetalk.global.utils.AuthPrincipal;
-import balancetalk.member.dto.ApiMember;
 import balancetalk.talkpick.application.SummaryContentService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,8 +19,7 @@ public class SummaryContentController {
 
     @Operation(summary = "톡픽 본문 요약", description = "톡픽 본문 내용을 요약합니다.")
     @PostMapping
-    public void summaryContent(@PathVariable final Long talkPickId,
-                               @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
-        summaryContentService.summaryContent(talkPickId, apiMember);
+    public void summaryContent(@PathVariable final Long talkPickId) {
+        summaryContentService.summaryContent(talkPickId);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] openai api-key 수정
- [x] 톡픽 요약 요청 기능에서 회원 관련 로직 제거

## 💡 자세한 설명
톡픽 본문 요약 요청 시 회원 구분 없이 가능하도록 개선했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #616 