### PR TITLE
SonarQube 서버를 분리함으로써, 관련 설정 추가 및 CI 워크 플로우 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,34 +25,32 @@ jobs:
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3
-    # - name: Cache SonarQube packages
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.sonar/cache
-    #     key: ${{ runner.os }}-sonar
-    #     restore-keys: ${{ runner.os }}-sonar
+    - name: Cache SonarQube packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
     - name: Cache Gradle packages
       uses: actions/cache@v1
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-    # - name: Build and analyze
-    - name: Build
-      # env:
-      #   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      # run: ./gradlew build sonar --info
-      run: ./gradlew build
-    # - name: SonarQube quality gate check
-    #   uses: phwt/sonarqube-quality-gate-action@v1
-    #   id: quality-gate-check
-    #   with:
-    #     sonar-project-key: ${{ secrets.SONAR_PROJECT_KEY }}
-    #     sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
-    #     sonar-token: ${{ secrets.SONAR_TOKEN }}
-    #     github-token: ${{ secrets.GIT_ACCESS_TOKEN }}
-    # - name: Output sonar result
-    #   run: |
-    #     echo "${{ steps.quality-gate-check.outputs.project-status }}"
-    #     echo "${{ steps.quality-gate-check.outputs.quality-gate-result }}"
+    - name: Build and analyze
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      run: ./gradlew build sonar --info
+    - name: SonarQube quality gate check
+      uses: phwt/sonarqube-quality-gate-action@v1
+      id: quality-gate-check
+      with:
+        sonar-project-key: ${{ secrets.SONAR_PROJECT_KEY }}
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        github-token: ${{ secrets.GIT_ACCESS_TOKEN }}
+    - name: Output sonar result
+      run: |
+        echo "${{ steps.quality-gate-check.outputs.project-status }}"
+        echo "${{ steps.quality-gate-check.outputs.quality-gate-result }}"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.4'
-	id "org.sonarqube" version "5.0.0.4638"
+	id "org.sonarqube" version "5.1.0.4882"
 }
 
 group = 'com.example'
@@ -34,8 +34,8 @@ repositories {
 
 sonar {
 	properties {
-		property "sonar.projectKey", "PICK-O"
-		property "sonar.projectName", "PICK-O"
+		property "sonar.projectKey", "PICKO-BE"
+		property "sonar.projectName", "PICKO-BE"
 	}
 }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] SonarQube 관련 설정 추가
- [x] CI 워크플로우에서 SonarQube 관련 내용 주석 처리 해제

## 💡 자세한 설명
기존 t2.micro 인스턴스에서 실행하던 SonarQube 서버를 다른 인스턴스로 분리했습니다.
이에 따라 관련 설정을 수정하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #618 
