### PR TITLE
밸런스게임 세트 투표수 구현 완료

### DIFF
--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -4,6 +4,7 @@ import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
+import balancetalk.vote.domain.VoteOption;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -92,5 +93,9 @@ public class GameSet extends BaseTimeEntity {
             game.addGameSet(this);
             game.getGameOptions().forEach(option -> option.addGame(game));
         });
+    }
+
+    public long getVoteCount() {
+        return games.get(0).getVoteCount(VoteOption.A) + games.get(0).getVoteCount(VoteOption.B);
     }
 }

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -95,7 +95,7 @@ public class GameSet extends BaseTimeEntity {
         });
     }
 
-    public long getVoteCount() {
+    public long getVotesCount() {
         return games.get(0).getVoteCount(VoteOption.A) + games.get(0).getVoteCount(VoteOption.B);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 밸런스게임 세트 투표수 구현

## 💡 자세한 설명
```java
public long getVotesCount() {
        return games.get(0).getVoteCount(VoteOption.A) + games.get(0).getVoteCount(VoteOption.B);
    }
```

`GameSet` 엔티티 내에 `getVotesCount()` 메서드를 만들었습니다.

플로우 및 기능상, 밸런스게임 세트에서 투표를 하지 않으면 다음 밸런스게임으로 넘어갈 수 없으므로, 해당 밸런스게임 세트의 **첫 번째 밸런스게임 투표 수 = 밸런스게임 세트 투표 수**와 같습니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #612
