### PR TITLE
중복된 이메일 오류 해결

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -61,6 +61,9 @@ public class GameSetDto {
         @Schema(description = "밸런스 게임 세트 id", example = "1")
         private Long id;
 
+        @Schema(description = "밸런스 게임 제목", example = "제목")
+        private String title;
+
         @Schema(description = "메인 태그", example = "사랑")
         private String mainTag;
 
@@ -78,6 +81,7 @@ public class GameSetDto {
             ));
             return GameSetResponse.builder()
                     .id(gameSet.getId())
+                    .title(gameSet.getTitle())
                     .mainTag(gameSet.getMainTag().getName())
                     .subTag(gameSet.getSubTag())
                     .images(images)

--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -1,5 +1,7 @@
 package balancetalk.global.oauth2;
 
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.global.jwt.JwtTokenProvider;
 import balancetalk.global.oauth2.dto.CustomOAuth2User;
 import balancetalk.member.domain.Member;
@@ -10,12 +12,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 
 import static balancetalk.global.jwt.JwtTokenProvider.createAccessCookie;
 import static balancetalk.global.jwt.JwtTokenProvider.createCookie;
@@ -35,14 +34,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // Oauth2User
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
 
-        String username = customUserDetails.getUsername();
+        String email = customUserDetails.getEmail();
 
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority auth = iterator.next();
-        String role = auth.getAuthority();
-
-        Member member = memberRepository.findByUsername(username);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MEMBER));
         String accessToken = jwtTokenProvider.createAccessToken(authentication, member.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication, member.getId());
 

--- a/src/main/java/balancetalk/global/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/balancetalk/global/oauth2/dto/CustomOAuth2User.java
@@ -35,7 +35,7 @@ public class CustomOAuth2User implements OAuth2User {
         return oauth2Dto.getName();
     }
 
-    public String getUsername() {
-        return oauth2Dto.getUsername();
+    public String getEmail() {
+        return oauth2Dto.getEmail();
     }
 }

--- a/src/main/java/balancetalk/global/oauth2/dto/Oauth2Dto.java
+++ b/src/main/java/balancetalk/global/oauth2/dto/Oauth2Dto.java
@@ -12,7 +12,6 @@ import lombok.Data;
 public class Oauth2Dto {
 
     private String name;
-    private String username;
     private String email;
     private Role role;
     private String password;
@@ -20,7 +19,6 @@ public class Oauth2Dto {
     public Member toEntity() {
         return Member.builder()
                 .nickname(name)
-                .username(username)
                 .email(email)
                 .role(Role.USER)
                 .password(password)

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -30,8 +30,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        log.info("Loading user: {}", oAuth2User);
-
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
         Oauth2Response oauth2Response = switch (registrationId) {
@@ -48,7 +46,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             String encodedPassword = passwordEncoder().encode(OAUTH2_PASSWORD);
             Oauth2Dto oauth2Dto = Oauth2Dto.builder()
                     .name(hideNickname(oauth2Response.getEmail()))
-                    .email(oauth2Response.getEmail())
+                    .email(oauth2Response.getProvider() + "_" + oauth2Response.getEmail())
                     .username(username)
                     .role(Role.USER)
                     .password(encodedPassword)

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -24,9 +24,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-//    private static final String OAUTH2_PASSWORD = "OAUTH2_PASSWORD";
-    @Value("${spring.security.user.password}")
+    @Value("${spring.security.security.oauth2-password}")
     private String oauth2Password;
+
     private final MemberRepository memberRepository;
 
     @Override

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -46,8 +46,6 @@ public class Member extends BaseTimeEntity {
     @NotBlank
     private String password;
 
-    private String username; // 소셜 로그인으로 가입했을 때 식별하기 위해 설정
-
     @Enumerated(value = EnumType.STRING)
     private Role role;
 

--- a/src/main/java/balancetalk/member/domain/MemberRepository.java
+++ b/src/main/java/balancetalk/member/domain/MemberRepository.java
@@ -10,8 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     void deleteByEmail(String email);
 
-    Member findByUsername(String username);
-
 //    @Query("select m.id from Member m JOIN m.votes v WHERE v.balanceOption.id = :balanceOptionId")
 //    List<Long> findMemberIdsBySelectedOptionId(Long balanceOptionId);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 소셜 로그인 시 해당 도메인 + "_" 이메일 주소로 등록되도록 구현
- [x] 불필요한 username 필드 삭제
- [x] 밸런스 세트 조회 시 제목 필드 추가

## 💡 자세한 설명
![스크린샷 2024-10-17 오전 12 16 17](https://github.com/user-attachments/assets/c42d1731-645b-438e-b8fd-8b6d2b6cc15c)

소셜 로그인으로 가입할 때, provider + "_" + email 형태로 DB에 저장되게끔 구현하여 동일한 값이 DB에 저장되지 않도록 구현했습니다.

기존에 식별자로 쓰이던 username 필드는 email이 unique해짐에 따라서 삭제했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #646 
