### PR TITLE
톡픽 투표 삭제 요청 시 delete 문이 생성되지 않는 오류 해결

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -78,7 +78,7 @@ public class TalkPick extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ViewStatus viewStatus = ViewStatus.NORMAL;
 
-    @OneToMany(mappedBy = "talkPick", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "talkPick", cascade = CascadeType.REMOVE)
     private List<TalkPickVote> votes = new ArrayList<>();
 
     @OneToMany(mappedBy = "talkPick", cascade = CascadeType.ALL)


### PR DESCRIPTION
## 💡 작업 내용
- [x] TalkPick 엔티티의 votes 필드 영속성 전이 속성을 ALL에서 REMOVE로 변경

## 💡 자세한 설명
TalkPick 엔티티의 votes 필드에서 CascadeType을 ALL에서 REMOVE로 변경함으로써 delete 문이 정상적으로 생성되었습니다.

## 🚩 후속 작업
- 영속성 전이와 delete 문이 생성되지 않는 문제에 대한 인과관계를 분석
- 이와 동일한 문제가 발생할 수 있는 엔티티가 있는지 확인

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #650 
