### PR TITLE
답글 작성 시 해당 톡픽 작성자가 예외처리되는 버그 해결 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -97,15 +97,6 @@ public class CommentService {
             throw new BalanceTalkException(NOT_FOUND_VOTE);
         }
 
-        // option이 VoteOption에 존재하는 값인지 확인 및 예외 처리
-        VoteOption option = member.getVoteOnTalkPick(talkPick)
-                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_VOTE))
-                .getVoteOption();
-
-        if (option == null || !EnumSet.allOf(VoteOption.class).contains(option)) {
-            throw new BalanceTalkException(NOT_FOUND_VOTE_OPTION);
-        }
-
         Comment commentReply = createCommentRequest.toEntity(member, talkPick, parentComment);
         commentRepository.save(commentReply);
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] deprecated 된 예외처리 코드 삭제

## 💡 자세한 설명
```java
// option이 VoteOption에 존재하는 값인지 확인 및 예외 처리
        VoteOption option = member.getVoteOnTalkPick(talkPick)
                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_VOTE))
                .getVoteOption();

        if (option == null || !EnumSet.allOf(VoteOption.class).contains(option)) {
            throw new BalanceTalkException(NOT_FOUND_VOTE_OPTION);
        }
```

더 이상 사용되지 않는 deprecated된 예외처리 코드를 삭제했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #652 
