### PR TITLE
밸런스게임 북마크 취소 후 카운트 수 적용하도록 수정, 밸런스게임 세트 조회 시 북마크 관련 로직 수정

### DIFF
--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -61,6 +61,7 @@ public class BookmarkGameService {
         member.getGameBookmarkOf(gameSet)
                 .ifPresentOrElse(
                         bookmark -> {
+                            increaseBookmarkCountForActivation(bookmark, gameSet);
                             bookmark.activate();
                             bookmark.setIsEndGameSet(false); // 밸런스게임 세트 종료 표시 해제
                             bookmark.updateGameId(gameId); //gameId도 업데이트
@@ -70,6 +71,12 @@ public class BookmarkGameService {
                             gameSet.increaseBookmarks();
                             sendBookmarkGameNotification(gameSet);
                         });
+    }
+
+    private void increaseBookmarkCountForActivation(GameBookmark bookmark, GameSet gameSet) {
+        if (!bookmark.isActive()) {
+            gameSet.increaseBookmarks();
+        }
     }
 
     public void createEndGameSetBookmark(final Long gameSetId, final ApiMember apiMember) {
@@ -87,6 +94,7 @@ public class BookmarkGameService {
         member.getGameBookmarkOf(gameSet)
                 .ifPresentOrElse(
                         bookmark -> {
+                            increaseBookmarkCountForActivation(bookmark, gameSet);
                             bookmark.activate();
                             bookmark.setIsEndGameSet(true); // 밸런스게임 세트 종료 표시
                             voteRepository.deleteAllByMemberIdAndGameOption_Game_GameSet(member.getId(), gameSet);

--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -125,6 +125,7 @@ public class BookmarkGameService {
             throw new BalanceTalkException(ErrorCode.ALREADY_DELETED_BOOKMARK);
         }
         bookmark.deactivate();
+        bookmark.setIsEndGameSet(false);
         gameSet.decreaseBookmarks();
         sendBookmarkGameNotification(gameSet);
     }

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -3,7 +3,6 @@ package balancetalk.game.application;
 import balancetalk.bookmark.domain.GameBookmark;
 import balancetalk.file.domain.FileType;
 import balancetalk.file.domain.repository.FileRepository;
-import balancetalk.bookmark.domain.GameBookmarkRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameSet;
 import balancetalk.game.domain.MainTag;

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -1,7 +1,5 @@
 package balancetalk.game.application;
 
-import static balancetalk.global.exception.ErrorCode.NOT_FOUND_BOOKMARK;
-
 import balancetalk.bookmark.domain.GameBookmark;
 import balancetalk.file.domain.FileType;
 import balancetalk.file.domain.repository.FileRepository;
@@ -48,7 +46,6 @@ public class GameService {
     private final MemberRepository memberRepository;
     private final GameTagRepository gameTagRepository;
     private final FileRepository fileRepository;
-    private final GameBookmarkRepository gameBookmarkRepository;
 
     public void createBalanceGameSet(final CreateGameSetRequest request, final ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
@@ -75,7 +72,8 @@ public class GameService {
         gameSet.increaseViews();
 
         if (guestOrApiMember.isGuest()) { // 비회원인 경우
-            return GameSetDetailResponse.fromEntity(gameSet, null, new ConcurrentHashMap<>(), false); // 게스트인 경우 북마크, 선택 옵션 없음
+            // 게스트인 경우 북마크, 선택 옵션 없음
+            return GameSetDetailResponse.fromEntity(gameSet, null, new ConcurrentHashMap<>(), false);
         }
 
         Member member = guestOrApiMember.toMember(memberRepository);

--- a/src/main/java/balancetalk/game/domain/repository/GameTagRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameTagRepository.java
@@ -8,5 +8,5 @@ public interface GameTagRepository extends JpaRepository<MainTag, Long> {
 
     Optional<MainTag> findByName(String name);
 
-    Boolean existsByName(String mainTag);
+    boolean existsByName(String mainTag);
 }

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -1,5 +1,6 @@
 package balancetalk.game.dto;
 
+import balancetalk.bookmark.domain.GameBookmark;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameSet;
 import balancetalk.game.domain.MainTag;
@@ -116,7 +117,11 @@ public class GameSetDto {
         @JsonProperty("isEndGameSet")
         private boolean isEndGameSet;
 
-        public static GameSetDetailResponse fromEntity(GameSet gameSet, Map<Long, Boolean> bookmarkMap,
+        @Schema(description = "밸런스게임 세트 엔딩 페이지에 사용되는 북마크 filled 여부", example = "false")
+        @JsonProperty("isEndBookmarked")
+        private boolean isEndBookmarked;
+
+        public static GameSetDetailResponse fromEntity(GameSet gameSet, GameBookmark gameBookmark,
                                                        Map<Long, VoteOption> voteOptionMap, boolean isEndGameSet) {
 
             return GameSetDetailResponse.builder()
@@ -126,9 +131,10 @@ public class GameSetDto {
                     .mainTag(gameSet.getMainTag().getName())
                     .subTag(gameSet.getSubTag())
                     .isEndGameSet(isEndGameSet)
+                    .isEndBookmarked(gameBookmark != null && gameBookmark.isActive())
                     .gameDetailResponses(gameSet.getGames().stream()
                             .map(game -> GameDetailResponse.fromEntity(game,
-                                    bookmarkMap.getOrDefault(game.getId(), false),
+                                    gameBookmark != null && gameBookmark.getGameId().equals(game.getId()),
                                     voteOptionMap.get(game.getId())))
                             .toList())
                     .build();

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -134,7 +134,8 @@ public class GameSetDto {
                     .isEndBookmarked(gameBookmark != null && gameBookmark.isActive())
                     .gameDetailResponses(gameSet.getGames().stream()
                             .map(game -> GameDetailResponse.fromEntity(game,
-                                    gameBookmark != null && gameBookmark.getGameId().equals(game.getId()),
+                                    gameBookmark != null && gameBookmark.getGameId().equals(game.getId())
+                                    && gameBookmark.isActive(),
                                     voteOptionMap.get(game.getId())))
                             .toList())
                     .build();

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -121,8 +121,8 @@ public class GameSetDto {
         @JsonProperty("isEndBookmarked")
         private boolean isEndBookmarked;
 
-        public static GameSetDetailResponse fromEntity(GameSet gameSet, GameBookmark gameBookmark,
-                                                       Map<Long, VoteOption> voteOptionMap, boolean isEndGameSet) {
+        public static GameSetDetailResponse fromEntity(GameSet gameSet, GameBookmark gameBookmark, boolean isEndGameSet,
+                                                       List<GameDetailResponse> gameDetailResponses) {
 
             return GameSetDetailResponse.builder()
                     .member(gameSet.getMember().getNickname())
@@ -132,12 +132,7 @@ public class GameSetDto {
                     .subTag(gameSet.getSubTag())
                     .isEndGameSet(isEndGameSet)
                     .isEndBookmarked(gameBookmark != null && gameBookmark.isActive())
-                    .gameDetailResponses(gameSet.getGames().stream()
-                            .map(game -> GameDetailResponse.fromEntity(game,
-                                    gameBookmark != null && gameBookmark.getGameId().equals(game.getId())
-                                    && gameBookmark.isActive(),
-                                    voteOptionMap.get(game.getId())))
-                            .toList())
+                    .gameDetailResponses(gameDetailResponses)
                     .build();
         }
     }

--- a/src/main/java/balancetalk/global/notification/domain/NotificationHistory.java
+++ b/src/main/java/balancetalk/global/notification/domain/NotificationHistory.java
@@ -18,14 +18,14 @@ public class NotificationHistory {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Column(columnDefinition = "TEXT")
-    private String notificationHistory;
+    private String notificationHistoryJson;
 
     public Map<String, Boolean> mappingNotification() {
-        if (notificationHistory == null) {
+        if (notificationHistoryJson == null) {
             return new HashMap<>();
         }
         try {
-            return OBJECT_MAPPER.readValue(notificationHistory, new TypeReference<Map<String, Boolean>>() {});
+            return OBJECT_MAPPER.readValue(notificationHistoryJson, new TypeReference<Map<String, Boolean>>() {});
         } catch (IOException e) {
             throw new BalanceTalkException(FAIL_PARSE_NOTIFICATION_HISTORY);
         }
@@ -33,7 +33,7 @@ public class NotificationHistory {
 
     public void setNotificationHistory(Map<String, Boolean> history) {
         try {
-            this.notificationHistory = OBJECT_MAPPER.writeValueAsString(history);
+            this.notificationHistoryJson = OBJECT_MAPPER.writeValueAsString(history);
         } catch (IOException e) {
             throw new BalanceTalkException(FAIL_SERIALIZE_NOTIFICATION_HISTORY);
         }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 밸런스게임 북마크 취소 후 카운트 수 적용하도록 수정
- [x] 밸런스게임 세트 조회 시 BookmarkMap 사용 대신 GameBookmark 타입 사용하도록 수정
- [x] 밸런스게임 세트 조회 시 DTO 조건 추가

## 💡 자세한 설명
### postman 테스트 완료

### 밸런스게임 북마크 취소 후 카운트 수 적용하도록 수정

밸런스게임 북마크는 삭제 시, 엔티티를 삭제하지 않고 `GameBookmark`의 active 필드를 false로 바꿔줍니다.
따라서, 북마크 삭제 API 실행 시 북마크 카운트는 감소하지만, 해당 엔티티는 그대로 남아 있습니다.

북마크를 생성하는 아래 로직에서도, 해당 밸런스게임 세트에 대해서 밸런스게임 북마크가 하나라도 존재한다면, 새로운 북마크 엔티티를 생성하지 않고 active 필드를 true로 바꿔줍니다.

```java
 member.getGameBookmarkOf(gameSet)
                .ifPresentOrElse(
                        bookmark -> {
                            bookmark.activate();
                            bookmark.setIsEndGameSet(false); // 밸런스게임 세트 종료 표시 해제
                            bookmark.updateGameId(gameId); //gameId도 업데이트
                        },
                        () -> { // resourceId가 gameSetId와 일치하는 북마크가 없다면 새로 생성
                            gameBookmarkRepository.save(bookmarkGenerator.generate(gameSet, gameId, member));
                            gameSet.increaseBookmarks();
                            sendBookmarkGameNotification(gameSet);
                        });
```

그런데 이 경우, 다시 북마크 카운트를 증가시키는 로직이 부재하기에, 동일 밸런스게임 세트에 대해 새로 북마크를 추가해도 북마크 카운트가 증가하지 않았습니다.

이로 인해, [북마크 추가 -> 북마크 삭제 -> 북마크 추가 -> 북마크 삭제] 시 해당 북마크의 카운트가 -1이 되버리는 에러가 발생했었습니다.

따라서, 이 문제를 해결하기 위해 해당 북마크가 deactive일 경우에는 북마크 카운트 수가 증가하는 아래 메서드를 만들어, 북마크 생성 로직에 포함시켰습니다.

```java
private void increaseBookmarkCountForActivation(GameBookmark bookmark, GameSet gameSet) {
        if (!bookmark.isActive()) {
            gameSet.increaseBookmarks();
        }
    }
```

```java
 member.getGameBookmarkOf(gameSet)
                .ifPresentOrElse(
                        bookmark -> {
                            **_increaseBookmarkCountForActivation(bookmark, gameSet);_**
                            bookmark.activate();
                            bookmark.setIsEndGameSet(false); // 밸런스게임 세트 종료 표시 해제
                            bookmark.updateGameId(gameId); //gameId도 업데이트
                        },
                        () -> { // resourceId가 gameSetId와 일치하는 북마크가 없다면 새로 생성
                            gameBookmarkRepository.save(bookmarkGenerator.generate(gameSet, gameId, member));
                            gameSet.increaseBookmarks();
                            sendBookmarkGameNotification(gameSet);
                        });
```

### 밸런스게임 세트 조회 시 BookmarkMap 사용 대신 GameBookmark 타입 사용하도록 수정
플로우상 하나의 밸런스게임 세트에 존재하는 밸런스게임 단건들은, 이들 중 단 하나의 밸런스게임만 북마크를 가질 수 있습니다. (예 : `GameSet` 안에 1~10번 `Game` 이 존재할 때, 1번 `Game` 과 2번 `Game` 이 동시에 북마크를 가질 수 없음)

따라서 불필요한 Map 사용을 제거하는 방식으로 리팩토링 하였습니다.

### 밸런스게임 세트 조회 시 DTO 조건 추가

기존에 매개변수로 Map을 받아오던 것을 `GameBookmark` 를 받아오도록 수정했으며, 밸런스게임 세트 엔딩 페이지에 표시되는 북마크 버튼에  filled 여부를 알려주는 `isEndBookmarked` 필드를 반환하도록 추가했습니다. 해당 필드는 해당 밸런스게임 세트의 `Game` 중 `bookmark` 를 가지면서 동시에 해당 `bookmark` 가 `active` 상태라면(즉, 북마크가 삭제처리되지 않았다면) `true` 를 반환함으로서 해당 밸런스게임 세트 중 어디선가 북마크가 존재함을 알려줍니다.

또한 `gameDetailResponses` 응답 시에도 해당 밸런스게임이 북마크를 가지는지 여부를 
1. 매개변수로 받는 북마크 값이 `null` 이 아니며
2. 해당 북마크가 가지는 `gameId` 와 동일하며
3. `active` 상태인지 (즉, 북마크가 삭제되지 않았는지)
를 모두 만족시키는 경우로 설정했습니다.

```java
public static GameSetDetailResponse fromEntity(GameSet gameSet, GameBookmark gameBookmark,
                                                       Map<Long, VoteOption> voteOptionMap, boolean isEndGameSet) {

            return GameSetDetailResponse.builder()
                    .member(gameSet.getMember().getNickname())
                    .title(gameSet.getTitle())
                    .createdAt(gameSet.getCreatedAt())
                    .mainTag(gameSet.getMainTag().getName())
                    .subTag(gameSet.getSubTag())
                    .isEndGameSet(isEndGameSet)
                    .isEndBookmarked(gameBookmark != null && gameBookmark.isActive())
                    .gameDetailResponses(gameSet.getGames().stream()
                            .map(game -> GameDetailResponse.fromEntity(game,
                                    gameBookmark != null && gameBookmark.getGameId().equals(game.getId())
                                    && gameBookmark.isActive(),
                                    voteOptionMap.get(game.getId())))
                            .toList())
                    .build();
        }
```
이로 인해 북마크 삭제 이후에 연관되는 모든 응답을 정상적으로 반환할 수 있게 되었습니다.

---

### 리뷰 사항 반영
DTO 계층은,
- 비즈니스 로직을 포함하지 않아야 합니다.
- 단순히 데이터를 담고 전달하는 역할에 충실해야 합니다.
- 불변성을 유지하는 것이 좋습니다.

따라서 DTO에 존재하던 비즈니스 로직을 서비스 레이어로 옮김으로서, 책임 분리 원칙을 지키고, DTO는 데이터 전달에만 집중할 수 있게 되었습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #621 #654 
