### PR TITLE
d-n 룰 도입에 따른 워크플로우 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,7 @@ jobs:
         GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: ./gradlew build sonar --info
+    - name: Update D-n Labels
+      uses: naver/d-day-labeler@latest
+      with:
+        token: ${{ secrets.GIT_ACCESS_TOKEN }}


### PR DESCRIPTION
## 💡 작업 내용
- [x] ci 워크플로우에 d-n 룰 자동화 로직 추가

## 💡 자세한 설명
PR 리뷰 우선 순위 판단을 위해 d-n 룰을 도입합니다.

### d-n 룰 설명
작업 담당자는 PR을 생성할 때 d-n 라벨을 추가합니다.
d-n 기준은 다음과 같습니다.
- `D-0`: 긴급한 이슈에 대한 작업으로 최대한 빠른 병합을 원하는 경우
- `D-2`: 긴급 이슈가 아니면서 여유로운 작업도 아닌 일반적인 경우
- `D-3` or `D-5`: 우선 순위가 낮은 작업이거나 여유롭게 병합해도 되는 경우

리뷰어는 d-n 라벨을 통해 우선 순위를 판단하고, d-n이 짧은 PR부터 리뷰를 진행합니다.

## 📗 참고 자료
https://blog.banksalad.com/tech/banksalad-code-review-culture/
https://github.com/naver/d-day-labeler

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #667 
